### PR TITLE
Tor连接卡死

### DIFF
--- a/v2rayN/v2rayN/Sample/SampleClientConfig.txt
+++ b/v2rayN/v2rayN/Sample/SampleClientConfig.txt
@@ -14,7 +14,7 @@
       "ip": "127.0.0.1"
     },
 	"sniffing": {
-      "enabled": true,
+      "enabled": false,
       "destOverride": [
         "http",
         "tls"


### PR DESCRIPTION
tor前置还是需要的，默认还是禁用吧，或者作者可以增加设置项。看好像是读取模板，所以猜测改这里就可以了……