### PR TITLE
Improved compatibility for base64 decoding.

### DIFF
--- a/v2rayN/v2rayN/Tool/Utils.cs
+++ b/v2rayN/v2rayN/Tool/Utils.cs
@@ -211,7 +211,11 @@ namespace v2rayN
         {
             try
             {
-                plainText = plainText.Trim();
+                plainText = plainText.Trim()
+                    .Replace("\n", "")
+                    .Replace("r\n", "")
+                    .Replace("\r", "")
+                    .Replace(" ", "");
                 if (plainText.Length % 4 > 0)
                 {
                     plainText = plainText.PadRight(plainText.Length + 4 - plainText.Length % 4, '=');


### PR DESCRIPTION
Fixed the problem about updateing subscription, while the subscription is created by *nix command __base64__:

```sh
base64 my.sub.src > my.sub
```

Its output will break every 76 characters, e.g.

> Reference: https://superuser.com/questions/1225134/why-does-the-base64-of-a-string-contain-n
