### PR TITLE
修复v2rayN有几率无法退出问题

### DIFF
--- a/v2rayN/v2rayN/Handler/StatisticsHandler.cs
+++ b/v2rayN/v2rayN/Handler/StatisticsHandler.cs
@@ -96,7 +96,10 @@ namespace v2rayN.Handler
         public void Close()
         {
             exitFlag_ = true;
-            connector_.Kill();
+            if (!connector_.HasExited)
+            {
+                connector_.Kill();
+            }
         }
 
         public void run()


### PR DESCRIPTION
如果调用kill的时候进程已经退出，就会导致v2rayN程序无法退出，先判断该进程是否已经退出再kill，修复该问题