### PR TITLE
更新订阅时，支持当前的代理连接。

### DIFF
--- a/v2rayN/v2rayN/Forms/MainForm.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.cs
@@ -9,6 +9,7 @@ using v2rayN.Handler;
 using v2rayN.HttpProxyHandler;
 using v2rayN.Mode;
 using v2rayN.Base;
+using System.Net;
 
 namespace v2rayN.Forms
 {
@@ -1366,7 +1367,14 @@ namespace v2rayN.Forms
                     AppendText(true, args.GetException().Message);
                 };
 
-                downloadHandle3.WebDownloadString(url);
+                IWebProxy proxy = null;
+
+                if (config.index >= 0 && config.vmess.Count > 0)
+                {
+                    proxy = new WebProxy(Global.Loopback, config.GetLocalPort(Global.InboundHttp));
+                }
+
+                downloadHandle3.WebDownloadString(url, proxy);
                 AppendText(false, $"{hashCode}{UIRes.I18N("MsgStartGettingSubscriptions")}");
             }
 

--- a/v2rayN/v2rayN/Handler/DownloadHandle.cs
+++ b/v2rayN/v2rayN/Handler/DownloadHandle.cs
@@ -188,7 +188,7 @@ namespace v2rayN.Handler
         /// DownloadString
         /// </summary> 
         /// <param name="url"></param>
-        public void WebDownloadString(string url)
+        public void WebDownloadString(string url, IWebProxy proxy = null)
         {
             string source = string.Empty;
             try
@@ -196,6 +196,12 @@ namespace v2rayN.Handler
                 SetSecurityProtocol();
 
                 WebClientEx ws = new WebClientEx();
+
+                if (proxy != null)
+                {
+                    ws.Proxy = proxy;
+                }
+
                 ws.DownloadStringCompleted += Ws_DownloadStringCompleted;
                 ws.DownloadStringAsync(new Uri(url));
             }


### PR DESCRIPTION
更新订阅时，经常耗时很久，调试发现在更新订阅时用的是直连，当订阅源在境外时就会耗时很久。