### PR TITLE
Fixes #390 允许来自局域网的连接需要人工重启

### DIFF
--- a/v2rayN/v2rayN/Forms/MainForm.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.cs
@@ -352,6 +352,13 @@ namespace v2rayN.Forms
 
         #endregion
 
+        #region http proxy 操作
+        private void RestartHttpProxy()
+        {
+            HttpProxyHandle.RestartHttpAgent(config, true);
+        }
+        #endregion
+
         #region v2ray 操作
 
         /// <summary>
@@ -703,6 +710,7 @@ namespace v2rayN.Forms
                 //刷新
                 RefreshServers();
                 LoadV2ray();
+                RestartHttpProxy();
             }
         }
 

--- a/v2rayN/v2rayN/HttpProxyHandler/HttpProxyHandle.cs
+++ b/v2rayN/v2rayN/HttpProxyHandler/HttpProxyHandle.cs
@@ -121,6 +121,11 @@ namespace v2rayN.HttpProxyHandler
         public static void RestartHttpAgent(Config config, bool forced)
         {
             bool isRestart = false;
+            if (config.listenerType == 0)
+            {
+                // 关闭http proxy时，直接返回
+                return;
+            }
             //强制重启或者socks端口变化
             if (forced)
             {


### PR DESCRIPTION
当修改参数设置时，除重新加载v2ray外也重新启动HTTP代理，
否则，需要用户人工退出再启动。
如果没有开启HTTP代理，因为修改参数设置触发的重启HTTP代理不做任何操作。