### PR TITLE
功能和代码优化

### DIFF
--- a/v2rayN/v2rayN/Base/HttpWebServerB.cs
+++ b/v2rayN/v2rayN/Base/HttpWebServerB.cs
@@ -35,25 +35,32 @@ namespace v2rayN.Base
 
         private void StartListen()
         {
-            listener = new TcpListener(IPAddress.Any, port);
-            listener.Start();
-            Utils.SaveLog("WebserverB running...");
-
-            while (true)
+            try
             {
-                if (!listener.Pending())
-                {
-                    Thread.Sleep(100);
-                    continue;
-                }
+                listener = new TcpListener(IPAddress.Any, port);
+                listener.Start();
+                Utils.SaveLog("WebserverB running...");
 
-                TcpClient socket = listener.AcceptTcpClient();
-                Thread thread = new Thread(new ParameterizedThreadStart(ProcessThread))
+                while (true)
                 {
-                    IsBackground = true
-                };
-                thread.Start(socket);
-                Thread.Sleep(1);
+                    if (!listener.Pending())
+                    {
+                        Thread.Sleep(100);
+                        continue;
+                    }
+
+                    TcpClient socket = listener.AcceptTcpClient();
+                    Thread thread = new Thread(new ParameterizedThreadStart(ProcessThread))
+                    {
+                        IsBackground = true
+                    };
+                    thread.Start(socket);
+                    Thread.Sleep(1);
+                }
+            }
+            catch
+            {
+                Utils.SaveLog("WebserverB start fail.");
             }
         }
         private void ProcessThread(object obj)

--- a/v2rayN/v2rayN/Base/WebClientEx.cs
+++ b/v2rayN/v2rayN/Base/WebClientEx.cs
@@ -17,17 +17,7 @@ namespace v2rayN.Base
         protected override WebRequest GetWebRequest(Uri address)
         {
             HttpWebRequest request;
-            if (address.Scheme == "https")
-            {
-                ServicePointManager.ServerCertificateValidationCallback = (a, b, c, d) => { return true; };
-                request = (HttpWebRequest)base.GetWebRequest(address);
-                //request.ProtocolVersion = HttpVersion.Version10;
-            }
-            else
-            {
-                request = (HttpWebRequest)base.GetWebRequest(address);
-            }
-
+            request = (HttpWebRequest)base.GetWebRequest(address);
             request.Timeout = Timeout;
             request.ReadWriteTimeout = Timeout;
             //request.AllowAutoRedirect = false;

--- a/v2rayN/v2rayN/Forms/AddServer3Form.zh-Hans.resx
+++ b/v2rayN/v2rayN/Forms/AddServer3Form.zh-Hans.resx
@@ -153,7 +153,4 @@
   <data name="menuItemImportClipboard.Text" xml:space="preserve">
     <value>从剪贴板导入URL</value>
   </data>
-  <data name="menuItemScanScreen.Text" xml:space="preserve">
-    <value>扫描屏幕上的二维码</value>
-  </data>
 </root>

--- a/v2rayN/v2rayN/Forms/MainForm.Designer.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.Designer.cs
@@ -76,7 +76,7 @@
             this.menuAddServers2 = new System.Windows.Forms.ToolStripMenuItem();
             this.menuScanScreen2 = new System.Windows.Forms.ToolStripMenuItem();
             this.menuCopyPACUrl = new System.Windows.Forms.ToolStripMenuItem();
-            this.update_subscription = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuUpdateSubscriptions = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.menuExit = new System.Windows.Forms.ToolStripMenuItem();
             this.bgwScan = new System.ComponentModel.BackgroundWorker();
@@ -390,7 +390,7 @@
             this.menuAddServers2,
             this.menuScanScreen2,
             this.menuCopyPACUrl,
-            this.update_subscription,
+            this.menuUpdateSubscriptions,
             this.toolStripSeparator2,
             this.menuExit});
             this.cmsMain.Name = "contextMenuStrip1";
@@ -476,11 +476,11 @@
             resources.ApplyResources(this.menuCopyPACUrl, "menuCopyPACUrl");
             this.menuCopyPACUrl.Click += new System.EventHandler(this.menuCopyPACUrl_Click);
             // 
-            // update_subscription
+            // menuUpdateSubscriptions
             // 
-            this.update_subscription.Name = "update_subscription";
-            resources.ApplyResources(this.update_subscription, "update_subscription");
-            this.update_subscription.Click += new System.EventHandler(this.update_subscription_Click);
+            this.menuUpdateSubscriptions.Name = "menuUpdateSubscriptions";
+            resources.ApplyResources(this.menuUpdateSubscriptions, "menuUpdateSubscriptions");
+            this.menuUpdateSubscriptions.Click += new System.EventHandler(this.menuUpdateSubscriptions_Click);
             // 
             // toolStripSeparator2
             // 
@@ -918,7 +918,7 @@
         private System.Windows.Forms.ToolStripMenuItem menuRealPingServer;
         private System.Windows.Forms.ToolStripMenuItem menuNotEnabledHttp;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator13;
-        private System.Windows.Forms.ToolStripMenuItem update_subscription;
+        private System.Windows.Forms.ToolStripMenuItem menuUpdateSubscriptions;
         private System.Windows.Forms.ToolStripMenuItem tsbV2rayWebsite;
         private System.Windows.Forms.ToolStripButton tsbTestMe;
         private System.Windows.Forms.ToolStripMenuItem menuKeepNothing;

--- a/v2rayN/v2rayN/Forms/MainForm.Designer.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.Designer.cs
@@ -103,6 +103,7 @@
             this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
             this.tsbOptionSetting = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
+            this.tsbTestMe = new System.Windows.Forms.ToolStripButton();
             this.tsbReload = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
             this.tsbCheckUpdate = new System.Windows.Forms.ToolStripDropDownButton();
@@ -606,6 +607,7 @@
             this.toolStripSeparator8,
             this.tsbOptionSetting,
             this.toolStripSeparator5,
+            this.tsbTestMe,
             this.tsbReload,
             this.toolStripSeparator7,
             this.tsbCheckUpdate,
@@ -659,6 +661,13 @@
             // 
             this.toolStripSeparator5.Name = "toolStripSeparator5";
             resources.ApplyResources(this.toolStripSeparator5, "toolStripSeparator5");
+            // 
+            // tsbTestMe
+            // 
+            this.tsbTestMe.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.tsbTestMe.Name = "tsbTestMe";
+            resources.ApplyResources(this.tsbTestMe, "tsbTestMe");
+            this.tsbTestMe.Click += new System.EventHandler(this.tsbTestMe_Click);
             // 
             // tsbReload
             // 
@@ -811,7 +820,7 @@
 
         }
 
-        #endregion
+#endregion
 
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.GroupBox groupBox2;
@@ -902,6 +911,7 @@
         private System.Windows.Forms.ToolStripMenuItem menuNotEnabledHttp;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator13;
         private System.Windows.Forms.ToolStripMenuItem tsbV2rayWebsite;
+        private System.Windows.Forms.ToolStripButton tsbTestMe;
         private System.Windows.Forms.ToolStripMenuItem menuKeepNothing;
         private System.Windows.Forms.ToolStripMenuItem menuKeepPACNothing;
     }

--- a/v2rayN/v2rayN/Forms/MainForm.Designer.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.Designer.cs
@@ -74,6 +74,7 @@
             this.menuAddServers2 = new System.Windows.Forms.ToolStripMenuItem();
             this.menuScanScreen2 = new System.Windows.Forms.ToolStripMenuItem();
             this.menuCopyPACUrl = new System.Windows.Forms.ToolStripMenuItem();
+            this.update_subscription = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.menuExit = new System.Windows.Forms.ToolStripMenuItem();
             this.bgwScan = new System.ComponentModel.BackgroundWorker();
@@ -107,6 +108,7 @@
             this.tsbCheckUpdateN = new System.Windows.Forms.ToolStripMenuItem();
             this.tsbCheckUpdateCore = new System.Windows.Forms.ToolStripMenuItem();
             this.tsbCheckUpdatePACList = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
             this.tsbCheckClearPACList = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
             this.tsbHelp = new System.Windows.Forms.ToolStripDropDownButton();
@@ -117,7 +119,6 @@
             this.tsbPromotion = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
             this.tsbClose = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator13 = new System.Windows.Forms.ToolStripSeparator();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -385,6 +386,7 @@
             this.menuAddServers2,
             this.menuScanScreen2,
             this.menuCopyPACUrl,
+            this.update_subscription,
             this.toolStripSeparator2,
             this.menuExit});
             this.cmsMain.Name = "contextMenuStrip1";
@@ -455,6 +457,12 @@
             this.menuCopyPACUrl.Name = "menuCopyPACUrl";
             resources.ApplyResources(this.menuCopyPACUrl, "menuCopyPACUrl");
             this.menuCopyPACUrl.Click += new System.EventHandler(this.menuCopyPACUrl_Click);
+            // 
+            // update_subscription
+            // 
+            this.update_subscription.Name = "update_subscription";
+            resources.ApplyResources(this.update_subscription, "update_subscription");
+            this.update_subscription.Click += new System.EventHandler(this.update_subscription_Click);
             // 
             // toolStripSeparator2
             // 
@@ -684,6 +692,11 @@
             resources.ApplyResources(this.tsbCheckUpdatePACList, "tsbCheckUpdatePACList");
             this.tsbCheckUpdatePACList.Click += new System.EventHandler(this.tsbCheckUpdatePACList_Click);
             // 
+            // toolStripSeparator13
+            // 
+            this.toolStripSeparator13.Name = "toolStripSeparator13";
+            resources.ApplyResources(this.toolStripSeparator13, "toolStripSeparator13");
+            // 
             // tsbCheckClearPACList
             // 
             this.tsbCheckClearPACList.Name = "tsbCheckClearPACList";
@@ -747,11 +760,6 @@
             resources.ApplyResources(this.tsbClose, "tsbClose");
             this.tsbClose.Name = "tsbClose";
             this.tsbClose.Click += new System.EventHandler(this.tsbClose_Click);
-            // 
-            // toolStripSeparator13
-            // 
-            this.toolStripSeparator13.Name = "toolStripSeparator13";
-            resources.ApplyResources(this.toolStripSeparator13, "toolStripSeparator13");
             // 
             // MainForm
             // 
@@ -877,6 +885,7 @@
         private System.Windows.Forms.ToolStripMenuItem menuRealPingServer;
         private System.Windows.Forms.ToolStripMenuItem menuNotEnabledHttp;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator13;
+        private System.Windows.Forms.ToolStripMenuItem update_subscription;
     }
 }
 

--- a/v2rayN/v2rayN/Forms/MainForm.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.cs
@@ -1516,5 +1516,12 @@ namespace v2rayN.Forms
         {
             Process.Start(Global.v2rayWebsiteUrl);
         }
+
+        private void tsbTestMe_Click(object sender, EventArgs e)
+        {
+            SpeedtestHandler statistics = new SpeedtestHandler(ref config, ref v2rayHandler, lvSelecteds, "", UpdateSpeedtestHandler);
+            string result = statistics.RunAvailabilityCheck() + "ms";
+            AppendText(false, string.Format(UIRes.I18N("TestMeOutput"), result));
+        }
     }
 }

--- a/v2rayN/v2rayN/Forms/MainForm.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.cs
@@ -883,7 +883,7 @@ namespace v2rayN.Forms
             return counter;
         }
 
-        private void update_subscription_Click(object sender, EventArgs e)
+        private void menuUpdateSubscriptions_Click(object sender, EventArgs e)
         {
             UpdateSubscriptionProcess();
         }

--- a/v2rayN/v2rayN/Forms/MainForm.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.cs
@@ -334,10 +334,12 @@ namespace v2rayN.Forms
 
             toolSslSocksPort.Text = $"{Global.Loopback}:{config.inbound[0].localPort}";
 
-            if (config.listenerType != 0)
+            if (config.listenerType != (int)ListenerType.noHttpProxy)
             {
                 toolSslHttpPort.Text = $"{Global.Loopback}:{Global.httpPort}";
-                if (config.listenerType % 2 == 0)
+                if (config.listenerType == ListenerType.GlobalPac ||
+                    config.listenerType == ListenerType.PacOpenAndClear ||
+                    config.listenerType == ListenerType.PacOpenOnly)
                 {
                     if (PACServerHandle.IsRunning)
                     {
@@ -1133,41 +1135,41 @@ namespace v2rayN.Forms
 
         private void menuNotEnabledHttp_Click(object sender, EventArgs e)
         {
-            SetListenerType(0);
+            SetListenerType(ListenerType.noHttpProxy);
         }
         private void menuGlobal_Click(object sender, EventArgs e)
         {
-            SetListenerType(1);
+            SetListenerType(ListenerType.GlobalHttp);
         }
         private void menuGlobalPAC_Click(object sender, EventArgs e)
         {
-            SetListenerType(2);
+            SetListenerType(ListenerType.GlobalPac);
         }
         private void menuKeep_Click(object sender, EventArgs e)
         {
-            SetListenerType(3);
+            SetListenerType(ListenerType.HttpOpenAndClear);
         }
         private void menuKeepPAC_Click(object sender, EventArgs e)
         {
-            SetListenerType(4);
+            SetListenerType(ListenerType.PacOpenAndClear);
         }
         private void menuKeepNothing_Click(object sender, EventArgs e)
         {
-            SetListenerType(5);
+            SetListenerType(ListenerType.HttpOpenOnly);
         }
         private void menuKeepPACNothing_Click(object sender, EventArgs e)
         {
-            SetListenerType(6);
+            SetListenerType(ListenerType.PacOpenOnly);
         }
-        private void SetListenerType(int type)
+        private void SetListenerType(ListenerType type)
         {
             config.listenerType = type;
             ChangePACButtonStatus(type);
         }
 
-        private void ChangePACButtonStatus(int type)
+        private void ChangePACButtonStatus(ListenerType type)
         {
-            if (type != 0)
+            if (type != ListenerType.noHttpProxy)
             {
                 HttpProxyHandle.RestartHttpAgent(config, false);
             }
@@ -1179,7 +1181,7 @@ namespace v2rayN.Forms
             for (int k = 0; k < menuSysAgentMode.DropDownItems.Count; k++)
             {
                 ToolStripMenuItem item = ((ToolStripMenuItem)menuSysAgentMode.DropDownItems[k]);
-                item.Checked = (type == k);
+                item.Checked = ((int)type == k);
             }
 
             ConfigHandler.SaveConfig(ref config, false);

--- a/v2rayN/v2rayN/Forms/MainForm.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.cs
@@ -10,6 +10,7 @@ using v2rayN.Base;
 using v2rayN.Tool;
 using System.Diagnostics;
 using System.Drawing;
+using System.Net;
 
 namespace v2rayN.Forms
 {
@@ -1185,6 +1186,22 @@ namespace v2rayN.Forms
 
         #region CheckUpdate
 
+        private void askToDownload(DownloadHandle downloadHandle, string url)
+        {
+            if (UI.ShowYesNo(string.Format(UIRes.I18N("DownloadYesNo"), url)) == DialogResult.Yes)
+            {
+                if (httpProxyTest() > 0)
+                {
+                    int httpPort = config.GetLocalPort(Global.InboundHttp);
+                    WebProxy webProxy = new WebProxy(Global.Loopback, httpPort);
+                    downloadHandle.DownloadFileAsync(url, webProxy, 60);
+                }
+                else
+                {
+                    downloadHandle.DownloadFileAsync(url, null, 60);
+                }
+            }
+        }
         private void tsbCheckUpdateN_Click(object sender, EventArgs e)
         {
             //System.Diagnostics.Process.Start(Global.UpdateUrl);
@@ -1201,15 +1218,7 @@ namespace v2rayN.Forms
                         string url = args.Msg;
                         this.Invoke((MethodInvoker)(delegate
                         {
-
-                            if (UI.ShowYesNo(string.Format(UIRes.I18N("DownloadYesNo"), url)) == DialogResult.No)
-                            {
-                                return;
-                            }
-                            else
-                            {
-                                downloadHandle.DownloadFileAsync(url, null, -1);
-                            }
+                            askToDownload(downloadHandle, url);
                         }));
                     }
                     else
@@ -1267,15 +1276,7 @@ namespace v2rayN.Forms
                         string url = args.Msg;
                         this.Invoke((MethodInvoker)(delegate
                         {
-
-                            if (UI.ShowYesNo(string.Format(UIRes.I18N("DownloadYesNo"), url)) == DialogResult.No)
-                            {
-                                return;
-                            }
-                            else
-                            {
-                                downloadHandle.DownloadFileAsync(url, null, -1);
-                            }
+                            askToDownload(downloadHandle, url);
                         }));
                     }
                     else
@@ -1519,9 +1520,13 @@ namespace v2rayN.Forms
 
         private void tsbTestMe_Click(object sender, EventArgs e)
         {
-            SpeedtestHandler statistics = new SpeedtestHandler(ref config, ref v2rayHandler, lvSelecteds, "", UpdateSpeedtestHandler);
-            string result = statistics.RunAvailabilityCheck() + "ms";
+            string result = httpProxyTest() + "ms";
             AppendText(false, string.Format(UIRes.I18N("TestMeOutput"), result));
+        }
+        private int httpProxyTest()
+        {
+            SpeedtestHandler statistics = new SpeedtestHandler(ref config, ref v2rayHandler, lvSelecteds, "", UpdateSpeedtestHandler);
+            return statistics.RunAvailabilityCheck();
         }
     }
 }

--- a/v2rayN/v2rayN/Forms/MainForm.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.cs
@@ -1226,7 +1226,7 @@ namespace v2rayN.Forms
                         try
                         {
                             string fileName = Utils.GetPath(downloadHandle.DownloadFileName);
-                            Process process = Process.Start("v2rayUpgrade.exe", fileName);
+                            Process process = Process.Start("v2rayUpgrade.exe", "\"" + fileName + "\"");
                             if (process.Id > 0)
                             {
                                 menuExit_Click(null, null);

--- a/v2rayN/v2rayN/Forms/MainForm.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.cs
@@ -240,6 +240,10 @@ namespace v2rayN.Forms
                     item.testResult
                    });
                 }
+                if (k % 2 == 1) // 隔行着色
+                {
+                    lvItem.BackColor = Color.WhiteSmoke;
+                }
                 if (config.index.Equals(k))
                 {
                     //lvItem.Checked = true;

--- a/v2rayN/v2rayN/Forms/MainForm.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.cs
@@ -652,7 +652,7 @@ namespace v2rayN.Forms
         }
         private void Speedtest(string actionType)
         {
-            GetLvSelectedIndex();
+            if (GetLvSelectedIndex() < 0) return;
             ClearTestResult();
             SpeedtestHandler statistics = new SpeedtestHandler(ref config, ref v2rayHandler, lvSelecteds, actionType, UpdateSpeedtestHandler);
         }

--- a/v2rayN/v2rayN/Forms/MainForm.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.cs
@@ -835,6 +835,11 @@ namespace v2rayN.Forms
             return 0;
         }
 
+        private void update_subscription_Click(object sender, EventArgs e)
+        {
+            UpdateSubscriptionProcess();
+        }
+
         #endregion
 
 
@@ -1377,6 +1382,14 @@ namespace v2rayN.Forms
 
         private void tsbSubUpdate_Click(object sender, EventArgs e)
         {
+            UpdateSubscriptionProcess();
+        }
+
+        /// <summary>
+        /// the subscription update process
+        /// </summary>
+        private void UpdateSubscriptionProcess()
+        {
             AppendText(false, UIRes.I18N("MsgUpdateSubscriptionStart"));
 
             if (config.subItem == null || config.subItem.Count <= 0)
@@ -1439,7 +1452,6 @@ namespace v2rayN.Forms
                 AppendText(false, $"{hashCode}{UIRes.I18N("MsgStartGettingSubscriptions")}");
             }
         }
-
         #endregion
 
         #region Language
@@ -1458,8 +1470,9 @@ namespace v2rayN.Forms
             Utils.RegWriteValue(Global.MyRegPath, Global.MyRegKeyLanguage, value);
         }
 
+
         #endregion
 
-
+        
     }
 }

--- a/v2rayN/v2rayN/Forms/MainForm.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.cs
@@ -9,6 +9,7 @@ using v2rayN.Mode;
 using v2rayN.Base;
 using v2rayN.Tool;
 using System.Diagnostics;
+using System.Drawing;
 
 namespace v2rayN.Forms
 {
@@ -238,6 +239,12 @@ namespace v2rayN.Forms
                     item.getSubRemarks(config),
                     item.testResult
                    });
+                }
+                if (config.index.Equals(k))
+                {
+                    //lvItem.Checked = true;
+                    lvItem.ForeColor = Color.Blue;
+                    lvItem.Font = new Font(lvItem.Font, FontStyle.Bold);
                 }
 
                 if (lvItem != null) lvServers.Items.Add(lvItem);

--- a/v2rayN/v2rayN/Forms/MainForm.resx
+++ b/v2rayN/v2rayN/Forms/MainForm.resx
@@ -422,27 +422,6 @@
   <data name="cmsMain.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="cmsMain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>265, 142</value>
-  </data>
-  <data name="&gt;&gt;cmsMain.Name" xml:space="preserve">
-    <value>cmsMain</value>
-  </data>
-  <data name="&gt;&gt;cmsMain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="notifyMain.Text" xml:space="preserve">
-    <value>v2rayN</value>
-  </data>
-  <data name="notifyMain.Visible" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="menuSysAgentMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>264, 22</value>
-  </data>
-  <data name="menuSysAgentMode.Text" xml:space="preserve">
-    <value>Http proxy</value>
-  </data>
   <data name="menuNotEnabledHttp.Size" type="System.Drawing.Size, System.Drawing">
     <value>547, 22</value>
   </data>
@@ -473,6 +452,12 @@
   <data name="menuKeepPAC.Text" xml:space="preserve">
     <value>Only open PAC, do not automatically configure PAC</value>
   </data>
+  <data name="menuSysAgentMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>264, 22</value>
+  </data>
+  <data name="menuSysAgentMode.Text" xml:space="preserve">
+    <value>Http proxy</value>
+  </data>
   <data name="menuServers.Size" type="System.Drawing.Size, System.Drawing">
     <value>264, 22</value>
   </data>
@@ -497,6 +482,12 @@
   <data name="menuCopyPACUrl.Text" xml:space="preserve">
     <value>Copy local PAC URL</value>
   </data>
+  <data name="update_subscription.Size" type="System.Drawing.Size, System.Drawing">
+    <value>264, 22</value>
+  </data>
+  <data name="update_subscription.Text" xml:space="preserve">
+    <value>update subscription</value>
+  </data>
   <data name="toolStripSeparator2.Size" type="System.Drawing.Size, System.Drawing">
     <value>261, 6</value>
   </data>
@@ -505,6 +496,21 @@
   </data>
   <data name="menuExit.Text" xml:space="preserve">
     <value>Exit</value>
+  </data>
+  <data name="cmsMain.Size" type="System.Drawing.Size, System.Drawing">
+    <value>265, 186</value>
+  </data>
+  <data name="&gt;&gt;cmsMain.Name" xml:space="preserve">
+    <value>cmsMain</value>
+  </data>
+  <data name="&gt;&gt;cmsMain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="notifyMain.Text" xml:space="preserve">
+    <value>v2rayN</value>
+  </data>
+  <data name="notifyMain.Visible" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <metadata name="bgwScan.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>498, 17</value>
@@ -535,60 +541,6 @@
   </data>
   <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
     <value>2</value>
-  </data>
-  <metadata name="ssMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>228, 18</value>
-  </metadata>
-  <data name="&gt;&gt;txtMsgBox.Name" xml:space="preserve">
-    <value>txtMsgBox</value>
-  </data>
-  <data name="&gt;&gt;txtMsgBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtMsgBox.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;txtMsgBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ssMain.Name" xml:space="preserve">
-    <value>ssMain</value>
-  </data>
-  <data name="&gt;&gt;ssMain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.StatusStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ssMain.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;ssMain.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="groupBox2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Bottom</value>
-  </data>
-  <data name="groupBox2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 417</value>
-  </data>
-  <data name="groupBox2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>952, 176</value>
-  </data>
-  <data name="groupBox2.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="groupBox2.Text" xml:space="preserve">
-    <value>Information</value>
-  </data>
-  <data name="&gt;&gt;groupBox2.Name" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;groupBox2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBox2.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;groupBox2.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="txtMsgBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -626,30 +578,6 @@
   <metadata name="ssMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>228, 18</value>
   </metadata>
-  <data name="ssMain.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 151</value>
-  </data>
-  <data name="ssMain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>946, 22</value>
-  </data>
-  <data name="ssMain.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="ssMain.Text" xml:space="preserve">
-    <value>statusStrip1</value>
-  </data>
-  <data name="&gt;&gt;ssMain.Name" xml:space="preserve">
-    <value>ssMain</value>
-  </data>
-  <data name="&gt;&gt;ssMain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.StatusStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ssMain.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;ssMain.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="toolSslSocksPortLab.Font" type="System.Drawing.Font, System.Drawing">
     <value>微软雅黑, 8pt</value>
   </data>
@@ -725,6 +653,57 @@
   <data name="toolSslBlank4.Size" type="System.Drawing.Size, System.Drawing">
     <value>0, 17</value>
   </data>
+  <data name="ssMain.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 151</value>
+  </data>
+  <data name="ssMain.Size" type="System.Drawing.Size, System.Drawing">
+    <value>946, 22</value>
+  </data>
+  <data name="ssMain.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="ssMain.Text" xml:space="preserve">
+    <value>statusStrip1</value>
+  </data>
+  <data name="&gt;&gt;ssMain.Name" xml:space="preserve">
+    <value>ssMain</value>
+  </data>
+  <data name="&gt;&gt;ssMain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.StatusStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ssMain.Parent" xml:space="preserve">
+    <value>groupBox2</value>
+  </data>
+  <data name="&gt;&gt;ssMain.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="groupBox2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Bottom</value>
+  </data>
+  <data name="groupBox2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 417</value>
+  </data>
+  <data name="groupBox2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>952, 176</value>
+  </data>
+  <data name="groupBox2.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="groupBox2.Text" xml:space="preserve">
+    <value>Information</value>
+  </data>
+  <data name="&gt;&gt;groupBox2.Name" xml:space="preserve">
+    <value>groupBox2</value>
+  </data>
+  <data name="&gt;&gt;groupBox2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox2.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;groupBox2.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <data name="panel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
@@ -754,6 +733,18 @@
   </metadata>
   <data name="toolStripSeparator4.Size" type="System.Drawing.Size, System.Drawing">
     <value>6, 56</value>
+  </data>
+  <data name="tsbSubSetting.Size" type="System.Drawing.Size, System.Drawing">
+    <value>197, 22</value>
+  </data>
+  <data name="tsbSubSetting.Text" xml:space="preserve">
+    <value>Subscription settings</value>
+  </data>
+  <data name="tsbSubUpdate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>197, 22</value>
+  </data>
+  <data name="tsbSubUpdate.Text" xml:space="preserve">
+    <value>Update subscription</value>
   </data>
   <data name="tsbSub.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
@@ -856,6 +847,27 @@
   <data name="toolStripSeparator10.Size" type="System.Drawing.Size, System.Drawing">
     <value>6, 56</value>
   </data>
+  <data name="tsbAbout.Size" type="System.Drawing.Size, System.Drawing">
+    <value>187, 22</value>
+  </data>
+  <data name="tsbAbout.Text" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="toolStripSeparator12.Size" type="System.Drawing.Size, System.Drawing">
+    <value>184, 6</value>
+  </data>
+  <data name="tsbLanguageDef.Size" type="System.Drawing.Size, System.Drawing">
+    <value>187, 22</value>
+  </data>
+  <data name="tsbLanguageDef.Text" xml:space="preserve">
+    <value>Language-[English]</value>
+  </data>
+  <data name="tsbLanguageZhHans.Size" type="System.Drawing.Size, System.Drawing">
+    <value>187, 22</value>
+  </data>
+  <data name="tsbLanguageZhHans.Text" xml:space="preserve">
+    <value>语言-[中文简体]</value>
+  </data>
   <data name="tsbHelp.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
   </data>
@@ -922,39 +934,6 @@
   </data>
   <data name="&gt;&gt;tsMain.ZOrder" xml:space="preserve">
     <value>5</value>
-  </data>
-  <data name="tsbSubSetting.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
-  </data>
-  <data name="tsbSubSetting.Text" xml:space="preserve">
-    <value>Subscription settings</value>
-  </data>
-  <data name="tsbSubUpdate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>197, 22</value>
-  </data>
-  <data name="tsbSubUpdate.Text" xml:space="preserve">
-    <value>Update subscription</value>
-  </data>
-  <data name="tsbAbout.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
-  </data>
-  <data name="tsbAbout.Text" xml:space="preserve">
-    <value>About</value>
-  </data>
-  <data name="toolStripSeparator12.Size" type="System.Drawing.Size, System.Drawing">
-    <value>184, 6</value>
-  </data>
-  <data name="tsbLanguageDef.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
-  </data>
-  <data name="tsbLanguageDef.Text" xml:space="preserve">
-    <value>Language-[English]</value>
-  </data>
-  <data name="tsbLanguageZhHans.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 22</value>
-  </data>
-  <data name="tsbLanguageZhHans.Text" xml:space="preserve">
-    <value>语言-[中文简体]</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -1208,6 +1187,12 @@
   <data name="&gt;&gt;menuCopyPACUrl.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;update_subscription.Name" xml:space="preserve">
+    <value>update_subscription</value>
+  </data>
+  <data name="&gt;&gt;update_subscription.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;toolStripSeparator2.Name" xml:space="preserve">
     <value>toolStripSeparator2</value>
   </data>
@@ -1370,6 +1355,12 @@
   <data name="&gt;&gt;tsbCheckUpdatePACList.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="&gt;&gt;toolStripSeparator13.Name" xml:space="preserve">
+    <value>toolStripSeparator13</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator13.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;tsbCheckClearPACList.Name" xml:space="preserve">
     <value>tsbCheckClearPACList</value>
   </data>
@@ -1429,12 +1420,6 @@
   </data>
   <data name="&gt;&gt;tsbClose.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator13.Name" xml:space="preserve">
-    <value>toolStripSeparator13</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator13.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>MainForm</value>

--- a/v2rayN/v2rayN/Forms/MainForm.resx
+++ b/v2rayN/v2rayN/Forms/MainForm.resx
@@ -184,7 +184,7 @@
     <value>cmsMain</value>
   </data>
   <data name="cmsMain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>265, 186</value>
+    <value>265, 164</value>
   </data>
   <data name="&gt;&gt;cmsMain.Type" xml:space="preserve">
     <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
@@ -714,6 +714,18 @@
     <value>Test servers with tcping (Ctrl+O)</value>
   </data>
   <data name="&gt;&gt;menuTcpingServer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuUpdateSubscriptions.Name" xml:space="preserve">
+    <value>menuUpdateSubscriptions</value>
+  </data>
+  <data name="menuUpdateSubscriptions.Size" type="System.Drawing.Size, System.Drawing">
+    <value>264, 22</value>
+  </data>
+  <data name="menuUpdateSubscriptions.Text" xml:space="preserve">
+    <value>Update subscriptions</value>
+  </data>
+  <data name="&gt;&gt;menuUpdateSubscriptions.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;notifyMain.Name" xml:space="preserve">
@@ -1465,17 +1477,5 @@
   </data>
   <data name="&gt;&gt;txtMsgBox.ZOrder" xml:space="preserve">
     <value>0</value>
-  </data>
-  <data name="&gt;&gt;update_subscription.Name" xml:space="preserve">
-    <value>update_subscription</value>
-  </data>
-  <data name="update_subscription.Size" type="System.Drawing.Size, System.Drawing">
-    <value>264, 22</value>
-  </data>
-  <data name="update_subscription.Text" xml:space="preserve">
-    <value>update subscription</value>
-  </data>
-  <data name="&gt;&gt;update_subscription.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/v2rayN/v2rayN/Forms/MainForm.resx
+++ b/v2rayN/v2rayN/Forms/MainForm.resx
@@ -119,48 +119,87 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <metadata name="cmsLv.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>327, 17</value>
+  </metadata>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <metadata name="notifyMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="cmsMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>137, 17</value>
+  </metadata>
+  <metadata name="bgwScan.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>498, 17</value>
+  </metadata>
+  <metadata name="ssMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>228, 18</value>
+  </metadata>
+  <metadata name="tsMain.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>409, 17</value>
+  </metadata>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>65</value>
+  </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 12</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>952, 593</value>
   </data>
-  <data name="$this.Localizable" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
   <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 4, 4, 4</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>MainForm</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>v2rayN</value>
   </data>
-  <data name="$this.TrayHeight" type="System.Int32, mscorlib">
-    <value>65</value>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>v2rayN.Forms.BaseForm, v2rayN, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="bgwScan.TrayLocation" type="System.Drawing.Point, System.Drawing">
-    <value>498, 17</value>
+  <data name="&gt;&gt;bgwScan.Name" xml:space="preserve">
+    <value>bgwScan</value>
+  </data>
+  <data name="&gt;&gt;bgwScan.Type" xml:space="preserve">
+    <value>System.ComponentModel.BackgroundWorker, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmsLv.Name" xml:space="preserve">
+    <value>cmsLv</value>
   </data>
   <data name="cmsLv.Size" type="System.Drawing.Size, System.Drawing">
     <value>356, 534</value>
   </data>
-  <data name="cmsLv.TrayLocation" type="System.Drawing.Point, System.Drawing">
-    <value>327, 17</value>
+  <data name="&gt;&gt;cmsLv.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="cmsMain.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="cmsMain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>265, 164</value>
+  <data name="&gt;&gt;cmsMain.Name" xml:space="preserve">
+    <value>cmsMain</value>
   </data>
-  <data name="cmsMain.TrayLocation" type="System.Drawing.Point, System.Drawing">
-    <value>137, 17</value>
+  <data name="cmsMain.Size" type="System.Drawing.Size, System.Drawing">
+    <value>265, 142</value>
+  </data>
+  <data name="&gt;&gt;cmsMain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="groupBox1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
   <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 66</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
   <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
     <value>952, 351</value>
@@ -171,11 +210,23 @@
   <data name="groupBox1.Text" xml:space="preserve">
     <value>Servers list</value>
   </data>
+  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
   <data name="groupBox2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Bottom</value>
   </data>
   <data name="groupBox2.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 417</value>
+  </data>
+  <data name="&gt;&gt;groupBox2.Name" xml:space="preserve">
+    <value>groupBox2</value>
+  </data>
+  <data name="&gt;&gt;groupBox2.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
   <data name="groupBox2.Size" type="System.Drawing.Size, System.Drawing">
     <value>952, 176</value>
@@ -185,6 +236,12 @@
   </data>
   <data name="groupBox2.Text" xml:space="preserve">
     <value>Informations</value>
+  </data>
+  <data name="&gt;&gt;groupBox2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox2.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="lvServers.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -209,11 +266,26 @@
   <data name="lvServers.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="&gt;&gt;lvServers.Name" xml:space="preserve">
+    <value>lvServers</value>
+  </data>
+  <data name="&gt;&gt;lvServers.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
   <data name="lvServers.Size" type="System.Drawing.Size, System.Drawing">
     <value>686, 331</value>
   </data>
   <data name="lvServers.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
+  </data>
+  <data name="&gt;&gt;lvServers.Type" xml:space="preserve">
+    <value>v2rayN.Base.ListViewFlickerFree, v2rayN, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;lvServers.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;menuAddCustomServer.Name" xml:space="preserve">
+    <value>menuAddCustomServer</value>
   </data>
   <data name="menuAddCustomServer.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
@@ -221,11 +293,23 @@
   <data name="menuAddCustomServer.Text" xml:space="preserve">
     <value>Add a custom configuration server</value>
   </data>
+  <data name="&gt;&gt;menuAddCustomServer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuAddServers.Name" xml:space="preserve">
+    <value>menuAddServers</value>
+  </data>
   <data name="menuAddServers.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
   </data>
   <data name="menuAddServers.Text" xml:space="preserve">
     <value>Import bulk URL from clipboard (Ctrl+V)</value>
+  </data>
+  <data name="&gt;&gt;menuAddServers.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuAddServers2.Name" xml:space="preserve">
+    <value>menuAddServers2</value>
   </data>
   <data name="menuAddServers2.Size" type="System.Drawing.Size, System.Drawing">
     <value>264, 22</value>
@@ -233,11 +317,23 @@
   <data name="menuAddServers2.Text" xml:space="preserve">
     <value>Import bulk URL from clipboard</value>
   </data>
+  <data name="&gt;&gt;menuAddServers2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuAddShadowsocksServer.Name" xml:space="preserve">
+    <value>menuAddShadowsocksServer</value>
+  </data>
   <data name="menuAddShadowsocksServer.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
   </data>
   <data name="menuAddShadowsocksServer.Text" xml:space="preserve">
     <value>Add [Shadowsocks] server</value>
+  </data>
+  <data name="&gt;&gt;menuAddShadowsocksServer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuAddSocksServer.Name" xml:space="preserve">
+    <value>menuAddSocksServer</value>
   </data>
   <data name="menuAddSocksServer.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
@@ -245,11 +341,23 @@
   <data name="menuAddSocksServer.Text" xml:space="preserve">
     <value>Add [Socks] server</value>
   </data>
+  <data name="&gt;&gt;menuAddSocksServer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuAddVmessServer.Name" xml:space="preserve">
+    <value>menuAddVmessServer</value>
+  </data>
   <data name="menuAddVmessServer.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
   </data>
   <data name="menuAddVmessServer.Text" xml:space="preserve">
     <value>Add [VMess] server</value>
+  </data>
+  <data name="&gt;&gt;menuAddVmessServer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuCopyPACUrl.Name" xml:space="preserve">
+    <value>menuCopyPACUrl</value>
   </data>
   <data name="menuCopyPACUrl.Size" type="System.Drawing.Size, System.Drawing">
     <value>264, 22</value>
@@ -257,11 +365,23 @@
   <data name="menuCopyPACUrl.Text" xml:space="preserve">
     <value>Copy local PAC URL</value>
   </data>
+  <data name="&gt;&gt;menuCopyPACUrl.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuCopyServer.Name" xml:space="preserve">
+    <value>menuCopyServer</value>
+  </data>
   <data name="menuCopyServer.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
   </data>
   <data name="menuCopyServer.Text" xml:space="preserve">
     <value>Clone selected server</value>
+  </data>
+  <data name="&gt;&gt;menuCopyServer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuExit.Name" xml:space="preserve">
+    <value>menuExit</value>
   </data>
   <data name="menuExit.Size" type="System.Drawing.Size, System.Drawing">
     <value>264, 22</value>
@@ -269,11 +389,23 @@
   <data name="menuExit.Text" xml:space="preserve">
     <value>Exit</value>
   </data>
+  <data name="&gt;&gt;menuExit.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuExport2ClientConfig.Name" xml:space="preserve">
+    <value>menuExport2ClientConfig</value>
+  </data>
   <data name="menuExport2ClientConfig.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
   </data>
   <data name="menuExport2ClientConfig.Text" xml:space="preserve">
     <value>Export selected server for client configuration</value>
+  </data>
+  <data name="&gt;&gt;menuExport2ClientConfig.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuExport2ServerConfig.Name" xml:space="preserve">
+    <value>menuExport2ServerConfig</value>
   </data>
   <data name="menuExport2ServerConfig.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
@@ -281,11 +413,23 @@
   <data name="menuExport2ServerConfig.Text" xml:space="preserve">
     <value>Export selected server for server configuration</value>
   </data>
+  <data name="&gt;&gt;menuExport2ServerConfig.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuExport2ShareUrl.Name" xml:space="preserve">
+    <value>menuExport2ShareUrl</value>
+  </data>
   <data name="menuExport2ShareUrl.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
   </data>
   <data name="menuExport2ShareUrl.Text" xml:space="preserve">
     <value>Export share URLs to clipboard (Ctrl+C)</value>
+  </data>
+  <data name="&gt;&gt;menuExport2ShareUrl.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuExport2SubContent.Name" xml:space="preserve">
+    <value>menuExport2SubContent</value>
   </data>
   <data name="menuExport2SubContent.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
@@ -293,11 +437,23 @@
   <data name="menuExport2SubContent.Text" xml:space="preserve">
     <value>Export subscription (base64) share to clipboard</value>
   </data>
+  <data name="&gt;&gt;menuExport2SubContent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuGlobal.Name" xml:space="preserve">
+    <value>menuGlobal</value>
+  </data>
   <data name="menuGlobal.Size" type="System.Drawing.Size, System.Drawing">
     <value>411, 22</value>
   </data>
   <data name="menuGlobal.Text" xml:space="preserve">
     <value>Open Http proxy and set the system proxy (global mode)</value>
+  </data>
+  <data name="&gt;&gt;menuGlobal.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuGlobalPAC.Name" xml:space="preserve">
+    <value>menuGlobalPAC</value>
   </data>
   <data name="menuGlobalPAC.Size" type="System.Drawing.Size, System.Drawing">
     <value>411, 22</value>
@@ -305,11 +461,23 @@
   <data name="menuGlobalPAC.Text" xml:space="preserve">
     <value>Open PAC and set the system proxy (PAC mode)</value>
   </data>
+  <data name="&gt;&gt;menuGlobalPAC.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuKeep.Name" xml:space="preserve">
+    <value>menuKeep</value>
+  </data>
   <data name="menuKeep.Size" type="System.Drawing.Size, System.Drawing">
     <value>411, 22</value>
   </data>
   <data name="menuKeep.Text" xml:space="preserve">
     <value>Only open Http proxy and clear the proxy settings</value>
+  </data>
+  <data name="&gt;&gt;menuKeep.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuKeepNothing.Name" xml:space="preserve">
+    <value>menuKeepNothing</value>
   </data>
   <data name="menuKeepNothing.Size" type="System.Drawing.Size, System.Drawing">
     <value>411, 22</value>
@@ -317,11 +485,23 @@
   <data name="menuKeepNothing.Text" xml:space="preserve">
     <value>Only open Http proxy and do nothing</value>
   </data>
+  <data name="&gt;&gt;menuKeepNothing.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuKeepPAC.Name" xml:space="preserve">
+    <value>menuKeepPAC</value>
+  </data>
   <data name="menuKeepPAC.Size" type="System.Drawing.Size, System.Drawing">
     <value>411, 22</value>
   </data>
   <data name="menuKeepPAC.Text" xml:space="preserve">
     <value>Only open PAC and clear the proxy settings</value>
+  </data>
+  <data name="&gt;&gt;menuKeepPAC.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuKeepPACNothing.Name" xml:space="preserve">
+    <value>menuKeepPACNothing</value>
   </data>
   <data name="menuKeepPACNothing.Size" type="System.Drawing.Size, System.Drawing">
     <value>411, 22</value>
@@ -329,11 +509,23 @@
   <data name="menuKeepPACNothing.Text" xml:space="preserve">
     <value>Only open PAC and do nothing</value>
   </data>
+  <data name="&gt;&gt;menuKeepPACNothing.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuMoveBottom.Name" xml:space="preserve">
+    <value>menuMoveBottom</value>
+  </data>
   <data name="menuMoveBottom.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
   </data>
   <data name="menuMoveBottom.Text" xml:space="preserve">
     <value>Move to bottom (B)</value>
+  </data>
+  <data name="&gt;&gt;menuMoveBottom.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuMoveDown.Name" xml:space="preserve">
+    <value>menuMoveDown</value>
   </data>
   <data name="menuMoveDown.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
@@ -341,11 +533,23 @@
   <data name="menuMoveDown.Text" xml:space="preserve">
     <value>Down (D)</value>
   </data>
+  <data name="&gt;&gt;menuMoveDown.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuMoveTop.Name" xml:space="preserve">
+    <value>menuMoveTop</value>
+  </data>
   <data name="menuMoveTop.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
   </data>
   <data name="menuMoveTop.Text" xml:space="preserve">
     <value>Move to top (T)</value>
+  </data>
+  <data name="&gt;&gt;menuMoveTop.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuMoveUp.Name" xml:space="preserve">
+    <value>menuMoveUp</value>
   </data>
   <data name="menuMoveUp.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
@@ -353,11 +557,23 @@
   <data name="menuMoveUp.Text" xml:space="preserve">
     <value>Up (U)</value>
   </data>
+  <data name="&gt;&gt;menuMoveUp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuNotEnabledHttp.Name" xml:space="preserve">
+    <value>menuNotEnabledHttp</value>
+  </data>
   <data name="menuNotEnabledHttp.Size" type="System.Drawing.Size, System.Drawing">
     <value>411, 22</value>
   </data>
   <data name="menuNotEnabledHttp.Text" xml:space="preserve">
     <value>Not Enabled Http Proxy</value>
+  </data>
+  <data name="&gt;&gt;menuNotEnabledHttp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuPingServer.Name" xml:space="preserve">
+    <value>menuPingServer</value>
   </data>
   <data name="menuPingServer.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
@@ -365,11 +581,23 @@
   <data name="menuPingServer.Text" xml:space="preserve">
     <value>Test servers ping (Ctrl+P)</value>
   </data>
+  <data name="&gt;&gt;menuPingServer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuRealPingServer.Name" xml:space="preserve">
+    <value>menuRealPingServer</value>
+  </data>
   <data name="menuRealPingServer.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
   </data>
   <data name="menuRealPingServer.Text" xml:space="preserve">
     <value>Test servers real delay (Ctrl+R)</value>
+  </data>
+  <data name="&gt;&gt;menuRealPingServer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuRemoveDuplicateServer.Name" xml:space="preserve">
+    <value>menuRemoveDuplicateServer</value>
   </data>
   <data name="menuRemoveDuplicateServer.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
@@ -377,11 +605,23 @@
   <data name="menuRemoveDuplicateServer.Text" xml:space="preserve">
     <value>Remove duplicate servers</value>
   </data>
+  <data name="&gt;&gt;menuRemoveDuplicateServer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuRemoveServer.Name" xml:space="preserve">
+    <value>menuRemoveServer</value>
+  </data>
   <data name="menuRemoveServer.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
   </data>
   <data name="menuRemoveServer.Text" xml:space="preserve">
     <value>Remove selected servers (Delete)</value>
+  </data>
+  <data name="&gt;&gt;menuRemoveServer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuScanScreen.Name" xml:space="preserve">
+    <value>menuScanScreen</value>
   </data>
   <data name="menuScanScreen.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
@@ -389,11 +629,23 @@
   <data name="menuScanScreen.Text" xml:space="preserve">
     <value>Scan QR code on the screen (Ctrl+S)</value>
   </data>
+  <data name="&gt;&gt;menuScanScreen.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuScanScreen2.Name" xml:space="preserve">
+    <value>menuScanScreen2</value>
+  </data>
   <data name="menuScanScreen2.Size" type="System.Drawing.Size, System.Drawing">
     <value>264, 22</value>
   </data>
   <data name="menuScanScreen2.Text" xml:space="preserve">
     <value>Scan QR code on the screen</value>
+  </data>
+  <data name="&gt;&gt;menuScanScreen2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuSelectAll.Name" xml:space="preserve">
+    <value>menuSelectAll</value>
   </data>
   <data name="menuSelectAll.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
@@ -401,11 +653,23 @@
   <data name="menuSelectAll.Text" xml:space="preserve">
     <value>Select All (Ctrl+A)</value>
   </data>
+  <data name="&gt;&gt;menuSelectAll.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuServers.Name" xml:space="preserve">
+    <value>menuServers</value>
+  </data>
   <data name="menuServers.Size" type="System.Drawing.Size, System.Drawing">
     <value>264, 22</value>
   </data>
   <data name="menuServers.Text" xml:space="preserve">
     <value>Server</value>
+  </data>
+  <data name="&gt;&gt;menuServers.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuSetDefaultServer.Name" xml:space="preserve">
+    <value>menuSetDefaultServer</value>
   </data>
   <data name="menuSetDefaultServer.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
@@ -413,11 +677,23 @@
   <data name="menuSetDefaultServer.Text" xml:space="preserve">
     <value>Set as active server (Enter)</value>
   </data>
+  <data name="&gt;&gt;menuSetDefaultServer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuSpeedServer.Name" xml:space="preserve">
+    <value>menuSpeedServer</value>
+  </data>
   <data name="menuSpeedServer.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
   </data>
   <data name="menuSpeedServer.Text" xml:space="preserve">
     <value>Test servers download speed (Ctrl+T)</value>
+  </data>
+  <data name="&gt;&gt;menuSpeedServer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuSysAgentMode.Name" xml:space="preserve">
+    <value>menuSysAgentMode</value>
   </data>
   <data name="menuSysAgentMode.Size" type="System.Drawing.Size, System.Drawing">
     <value>264, 22</value>
@@ -425,17 +701,29 @@
   <data name="menuSysAgentMode.Text" xml:space="preserve">
     <value>Http proxy</value>
   </data>
+  <data name="&gt;&gt;menuSysAgentMode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuTcpingServer.Name" xml:space="preserve">
+    <value>menuTcpingServer</value>
+  </data>
   <data name="menuTcpingServer.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
   </data>
   <data name="menuTcpingServer.Text" xml:space="preserve">
     <value>Test servers with tcping (Ctrl+O)</value>
   </data>
+  <data name="&gt;&gt;menuTcpingServer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;notifyMain.Name" xml:space="preserve">
+    <value>notifyMain</value>
+  </data>
   <data name="notifyMain.Text" xml:space="preserve">
     <value>v2rayN</value>
   </data>
-  <data name="notifyMain.TrayLocation" type="System.Drawing.Point, System.Drawing">
-    <value>17, 17</value>
+  <data name="&gt;&gt;notifyMain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NotifyIcon, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="notifyMain.Visible" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -446,11 +734,23 @@
   <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 56</value>
   </data>
+  <data name="&gt;&gt;panel1.Name" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
   <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>952, 10</value>
   </data>
   <data name="panel1.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
+  </data>
+  <data name="&gt;&gt;panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="qrCodeControl.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -458,10 +758,22 @@
   <data name="qrCodeControl.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="&gt;&gt;qrCodeControl.Name" xml:space="preserve">
+    <value>qrCodeControl</value>
+  </data>
+  <data name="&gt;&gt;qrCodeControl.Parent" xml:space="preserve">
+    <value>splitContainer1.Panel2</value>
+  </data>
   <data name="qrCodeControl.Size" type="System.Drawing.Size, System.Drawing">
     <value>256, 331</value>
   </data>
   <data name="qrCodeControl.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;qrCodeControl.Type" xml:space="preserve">
+    <value>v2rayN.Forms.QRCodeControl, v2rayN, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;qrCodeControl.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="splitContainer1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
@@ -470,8 +782,38 @@
   <data name="splitContainer1.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 17</value>
   </data>
+  <data name="&gt;&gt;splitContainer1.Name" xml:space="preserve">
+    <value>splitContainer1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.Name" xml:space="preserve">
+    <value>splitContainer1.Panel1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.Parent" xml:space="preserve">
+    <value>splitContainer1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.Name" xml:space="preserve">
+    <value>splitContainer1.Panel2</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.Parent" xml:space="preserve">
+    <value>splitContainer1</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitterPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="splitContainer1.Panel2MinSize" type="System.Int32, mscorlib">
     <value>100</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.Parent" xml:space="preserve">
+    <value>groupBox1</value>
   </data>
   <data name="splitContainer1.Size" type="System.Drawing.Size, System.Drawing">
     <value>946, 331</value>
@@ -482,8 +824,20 @@
   <data name="splitContainer1.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
+  <data name="&gt;&gt;splitContainer1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.SplitContainer, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;splitContainer1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="ssMain.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 151</value>
+  </data>
+  <data name="&gt;&gt;ssMain.Name" xml:space="preserve">
+    <value>ssMain</value>
+  </data>
+  <data name="&gt;&gt;ssMain.Parent" xml:space="preserve">
+    <value>groupBox2</value>
   </data>
   <data name="ssMain.Size" type="System.Drawing.Size, System.Drawing">
     <value>946, 22</value>
@@ -494,35 +848,71 @@
   <data name="ssMain.Text" xml:space="preserve">
     <value>statusStrip1</value>
   </data>
-  <data name="ssMain.TrayLocation" type="System.Drawing.Point, System.Drawing">
-    <value>228, 18</value>
+  <data name="&gt;&gt;ssMain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.StatusStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ssMain.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="toolSslBlank1.Font" type="System.Drawing.Font, System.Drawing">
     <value>微软雅黑, 8pt</value>
   </data>
+  <data name="&gt;&gt;toolSslBlank1.Name" xml:space="preserve">
+    <value>toolSslBlank1</value>
+  </data>
   <data name="toolSslBlank1.Size" type="System.Drawing.Size, System.Drawing">
     <value>195, 17</value>
+  </data>
+  <data name="&gt;&gt;toolSslBlank1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="toolSslBlank2.Font" type="System.Drawing.Font, System.Drawing">
     <value>微软雅黑, 8pt</value>
   </data>
+  <data name="&gt;&gt;toolSslBlank2.Name" xml:space="preserve">
+    <value>toolSslBlank2</value>
+  </data>
   <data name="toolSslBlank2.Size" type="System.Drawing.Size, System.Drawing">
     <value>195, 17</value>
+  </data>
+  <data name="&gt;&gt;toolSslBlank2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="toolSslBlank3.Font" type="System.Drawing.Font, System.Drawing">
     <value>微软雅黑, 8pt</value>
   </data>
+  <data name="&gt;&gt;toolSslBlank3.Name" xml:space="preserve">
+    <value>toolSslBlank3</value>
+  </data>
   <data name="toolSslBlank3.Size" type="System.Drawing.Size, System.Drawing">
     <value>195, 17</value>
+  </data>
+  <data name="&gt;&gt;toolSslBlank3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolSslBlank4.Name" xml:space="preserve">
+    <value>toolSslBlank4</value>
   </data>
   <data name="toolSslBlank4.Size" type="System.Drawing.Size, System.Drawing">
     <value>0, 17</value>
   </data>
+  <data name="&gt;&gt;toolSslBlank4.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolSslHttpPort.Name" xml:space="preserve">
+    <value>toolSslHttpPort</value>
+  </data>
   <data name="toolSslHttpPort.Size" type="System.Drawing.Size, System.Drawing">
     <value>0, 17</value>
   </data>
+  <data name="&gt;&gt;toolSslHttpPort.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="toolSslHttpPortLab.Font" type="System.Drawing.Font, System.Drawing">
     <value>微软雅黑, 8pt</value>
+  </data>
+  <data name="&gt;&gt;toolSslHttpPortLab.Name" xml:space="preserve">
+    <value>toolSslHttpPortLab</value>
   </data>
   <data name="toolSslHttpPortLab.Size" type="System.Drawing.Size, System.Drawing">
     <value>39, 17</value>
@@ -530,11 +920,23 @@
   <data name="toolSslHttpPortLab.Text" xml:space="preserve">
     <value>HTTP:</value>
   </data>
+  <data name="&gt;&gt;toolSslHttpPortLab.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolSslPacPort.Name" xml:space="preserve">
+    <value>toolSslPacPort</value>
+  </data>
   <data name="toolSslPacPort.Size" type="System.Drawing.Size, System.Drawing">
     <value>0, 17</value>
   </data>
+  <data name="&gt;&gt;toolSslPacPort.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="toolSslPacPortLab.Font" type="System.Drawing.Font, System.Drawing">
     <value>微软雅黑, 8pt</value>
+  </data>
+  <data name="&gt;&gt;toolSslPacPortLab.Name" xml:space="preserve">
+    <value>toolSslPacPortLab</value>
   </data>
   <data name="toolSslPacPortLab.Size" type="System.Drawing.Size, System.Drawing">
     <value>33, 17</value>
@@ -542,11 +944,17 @@
   <data name="toolSslPacPortLab.Text" xml:space="preserve">
     <value>PAC:</value>
   </data>
+  <data name="&gt;&gt;toolSslPacPortLab.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="toolSslServerSpeed.AutoSize" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="toolSslServerSpeed.Font" type="System.Drawing.Font, System.Drawing">
     <value>微软雅黑, 8pt</value>
+  </data>
+  <data name="&gt;&gt;toolSslServerSpeed.Name" xml:space="preserve">
+    <value>toolSslServerSpeed</value>
   </data>
   <data name="toolSslServerSpeed.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
     <value>No</value>
@@ -560,11 +968,23 @@
   <data name="toolSslServerSpeed.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleRight</value>
   </data>
+  <data name="&gt;&gt;toolSslServerSpeed.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolSslSocksPort.Name" xml:space="preserve">
+    <value>toolSslSocksPort</value>
+  </data>
   <data name="toolSslSocksPort.Size" type="System.Drawing.Size, System.Drawing">
     <value>0, 17</value>
   </data>
+  <data name="&gt;&gt;toolSslSocksPort.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="toolSslSocksPortLab.Font" type="System.Drawing.Font, System.Drawing">
     <value>微软雅黑, 8pt</value>
+  </data>
+  <data name="&gt;&gt;toolSslSocksPortLab.Name" xml:space="preserve">
+    <value>toolSslSocksPortLab</value>
   </data>
   <data name="toolSslSocksPortLab.Size" type="System.Drawing.Size, System.Drawing">
     <value>52, 17</value>
@@ -572,44 +992,128 @@
   <data name="toolSslSocksPortLab.Text" xml:space="preserve">
     <value>SOCKS5:</value>
   </data>
+  <data name="&gt;&gt;toolSslSocksPortLab.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator1.Name" xml:space="preserve">
+    <value>toolStripSeparator1</value>
+  </data>
   <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
     <value>352, 6</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator10.Name" xml:space="preserve">
+    <value>toolStripSeparator10</value>
   </data>
   <data name="toolStripSeparator10.Size" type="System.Drawing.Size, System.Drawing">
     <value>6, 56</value>
   </data>
+  <data name="&gt;&gt;toolStripSeparator10.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator11.Name" xml:space="preserve">
+    <value>toolStripSeparator11</value>
+  </data>
   <data name="toolStripSeparator11.Size" type="System.Drawing.Size, System.Drawing">
     <value>6, 56</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator11.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator12.Name" xml:space="preserve">
+    <value>toolStripSeparator12</value>
   </data>
   <data name="toolStripSeparator12.Size" type="System.Drawing.Size, System.Drawing">
     <value>184, 6</value>
   </data>
+  <data name="&gt;&gt;toolStripSeparator12.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator13.Name" xml:space="preserve">
+    <value>toolStripSeparator13</value>
+  </data>
   <data name="toolStripSeparator13.Size" type="System.Drawing.Size, System.Drawing">
     <value>390, 6</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator13.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator2.Name" xml:space="preserve">
+    <value>toolStripSeparator2</value>
   </data>
   <data name="toolStripSeparator2.Size" type="System.Drawing.Size, System.Drawing">
     <value>261, 6</value>
   </data>
+  <data name="&gt;&gt;toolStripSeparator2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator3.Name" xml:space="preserve">
+    <value>toolStripSeparator3</value>
+  </data>
   <data name="toolStripSeparator3.Size" type="System.Drawing.Size, System.Drawing">
     <value>352, 6</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator4.Name" xml:space="preserve">
+    <value>toolStripSeparator4</value>
   </data>
   <data name="toolStripSeparator4.Size" type="System.Drawing.Size, System.Drawing">
     <value>6, 56</value>
   </data>
+  <data name="&gt;&gt;toolStripSeparator4.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator5.Name" xml:space="preserve">
+    <value>toolStripSeparator5</value>
+  </data>
   <data name="toolStripSeparator5.Size" type="System.Drawing.Size, System.Drawing">
     <value>6, 56</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator6.Name" xml:space="preserve">
+    <value>toolStripSeparator6</value>
   </data>
   <data name="toolStripSeparator6.Size" type="System.Drawing.Size, System.Drawing">
     <value>352, 6</value>
   </data>
+  <data name="&gt;&gt;toolStripSeparator6.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator7.Name" xml:space="preserve">
+    <value>toolStripSeparator7</value>
+  </data>
   <data name="toolStripSeparator7.Size" type="System.Drawing.Size, System.Drawing">
     <value>6, 56</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator7.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator8.Name" xml:space="preserve">
+    <value>toolStripSeparator8</value>
   </data>
   <data name="toolStripSeparator8.Size" type="System.Drawing.Size, System.Drawing">
     <value>6, 56</value>
   </data>
+  <data name="&gt;&gt;toolStripSeparator8.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator9.Name" xml:space="preserve">
+    <value>toolStripSeparator9</value>
+  </data>
   <data name="toolStripSeparator9.Size" type="System.Drawing.Size, System.Drawing">
     <value>352, 6</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator9.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tsbAbout.Name" xml:space="preserve">
+    <value>tsbAbout</value>
   </data>
   <data name="tsbAbout.Size" type="System.Drawing.Size, System.Drawing">
     <value>187, 22</value>
@@ -617,14 +1121,26 @@
   <data name="tsbAbout.Text" xml:space="preserve">
     <value>v2rayN Project</value>
   </data>
+  <data name="&gt;&gt;tsbAbout.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tsbCheckClearPACList.Name" xml:space="preserve">
+    <value>tsbCheckClearPACList</value>
+  </data>
   <data name="tsbCheckClearPACList.Size" type="System.Drawing.Size, System.Drawing">
     <value>393, 22</value>
   </data>
   <data name="tsbCheckClearPACList.Text" xml:space="preserve">
     <value>Simplify PAC (need to set Core route)</value>
   </data>
+  <data name="&gt;&gt;tsbCheckClearPACList.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="tsbCheckUpdate.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
+  </data>
+  <data name="&gt;&gt;tsbCheckUpdate.Name" xml:space="preserve">
+    <value>tsbCheckUpdate</value>
   </data>
   <data name="tsbCheckUpdate.Size" type="System.Drawing.Size, System.Drawing">
     <value>128, 53</value>
@@ -635,11 +1151,23 @@
   <data name="tsbCheckUpdate.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
     <value>ImageAboveText</value>
   </data>
+  <data name="&gt;&gt;tsbCheckUpdate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripDropDownButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tsbCheckUpdateCore.Name" xml:space="preserve">
+    <value>tsbCheckUpdateCore</value>
+  </data>
   <data name="tsbCheckUpdateCore.Size" type="System.Drawing.Size, System.Drawing">
     <value>393, 22</value>
   </data>
   <data name="tsbCheckUpdateCore.Text" xml:space="preserve">
     <value>Update v2rayCore</value>
+  </data>
+  <data name="&gt;&gt;tsbCheckUpdateCore.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tsbCheckUpdateN.Name" xml:space="preserve">
+    <value>tsbCheckUpdateN</value>
   </data>
   <data name="tsbCheckUpdateN.Size" type="System.Drawing.Size, System.Drawing">
     <value>393, 22</value>
@@ -647,21 +1175,33 @@
   <data name="tsbCheckUpdateN.Text" xml:space="preserve">
     <value>v2rayN (this software)</value>
   </data>
+  <data name="&gt;&gt;tsbCheckUpdateN.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tsbCheckUpdatePACList.Name" xml:space="preserve">
+    <value>tsbCheckUpdatePACList</value>
+  </data>
   <data name="tsbCheckUpdatePACList.Size" type="System.Drawing.Size, System.Drawing">
     <value>393, 22</value>
   </data>
   <data name="tsbCheckUpdatePACList.Text" xml:space="preserve">
     <value>Check for updated PAC (need the HTTP proxy are ON)</value>
   </data>
+  <data name="&gt;&gt;tsbCheckUpdatePACList.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="tsbClose.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAADJJREFUWEftzrENACAIRUFGdVMdTZkAG4zFXfI68kMAAD8ap9lUbpfyaDV19QAA
-        8FDEBl3RImu5VcdbAAAAAElFTkSuQmCC
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAySURBVFhH7c6xDQAgCEVBRnVTHU2ZABuMxV3yOvJDAAA/
+        GqfZVG6X8mg1dfUAAPBQxAZd0SJruVXHWwAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="tsbClose.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
+  </data>
+  <data name="&gt;&gt;tsbClose.Name" xml:space="preserve">
+    <value>tsbClose</value>
   </data>
   <data name="tsbClose.Size" type="System.Drawing.Size, System.Drawing">
     <value>52, 53</value>
@@ -672,8 +1212,14 @@
   <data name="tsbClose.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
     <value>ImageAboveText</value>
   </data>
+  <data name="&gt;&gt;tsbClose.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="tsbHelp.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
+  </data>
+  <data name="&gt;&gt;tsbHelp.Name" xml:space="preserve">
+    <value>tsbHelp</value>
   </data>
   <data name="tsbHelp.Size" type="System.Drawing.Size, System.Drawing">
     <value>48, 53</value>
@@ -684,11 +1230,23 @@
   <data name="tsbHelp.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
     <value>ImageAboveText</value>
   </data>
+  <data name="&gt;&gt;tsbHelp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripDropDownButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tsbLanguageDef.Name" xml:space="preserve">
+    <value>tsbLanguageDef</value>
+  </data>
   <data name="tsbLanguageDef.Size" type="System.Drawing.Size, System.Drawing">
     <value>187, 22</value>
   </data>
   <data name="tsbLanguageDef.Text" xml:space="preserve">
     <value>Language-[English]</value>
+  </data>
+  <data name="&gt;&gt;tsbLanguageDef.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tsbLanguageZhHans.Name" xml:space="preserve">
+    <value>tsbLanguageZhHans</value>
   </data>
   <data name="tsbLanguageZhHans.Size" type="System.Drawing.Size, System.Drawing">
     <value>187, 22</value>
@@ -696,8 +1254,14 @@
   <data name="tsbLanguageZhHans.Text" xml:space="preserve">
     <value>语言-[中文简体]</value>
   </data>
+  <data name="&gt;&gt;tsbLanguageZhHans.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="tsbOptionSetting.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
+  </data>
+  <data name="&gt;&gt;tsbOptionSetting.Name" xml:space="preserve">
+    <value>tsbOptionSetting</value>
   </data>
   <data name="tsbOptionSetting.Size" type="System.Drawing.Size, System.Drawing">
     <value>58, 53</value>
@@ -708,8 +1272,14 @@
   <data name="tsbOptionSetting.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
     <value>ImageAboveText</value>
   </data>
+  <data name="&gt;&gt;tsbOptionSetting.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="tsbPromotion.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
+  </data>
+  <data name="&gt;&gt;tsbPromotion.Name" xml:space="preserve">
+    <value>tsbPromotion</value>
   </data>
   <data name="tsbPromotion.Size" type="System.Drawing.Size, System.Drawing">
     <value>89, 53</value>
@@ -720,15 +1290,18 @@
   <data name="tsbPromotion.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
     <value>ImageAboveText</value>
   </data>
+  <data name="&gt;&gt;tsbPromotion.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="tsbReload.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAATdJREFUWEftloENAiEMRW8ER3AEN9ANdARHcAPdwBF0A91AN9INtC+5JvUCJwWM
-        mvCTFw3QUiiU65qa/lUTYT6Ato9rJZyERwT6GFNdU+EihCYNwVhsqmgm3AR1fheOAitd9PCfNvp0HDbY
-        FolV2MmZZCzX9J0FG0TRTlwFdbahIVE7Qe1IR5bYVnXCyr2yO5F1MNUBec25YtjomcCXSxhr9DmrV2Gr
-        flyL4GSrYcm9tmnEZ7JsAC7DgWr5ydbXA8hOAcVjG8FTD6ocQgvXKrW8MqFWUfc1DAXgmRwVFaJQAHsh
-        VbYUU87diqWA934sl/TZ7wV2Lesx0gBwsO5/1Sl5PQhLQb+G+E+bfTm9KXsRAVgHrMK+jO9gbNEzzMSh
-        6DlM9nANoa+kdCeLXLNLFtc9b2r6EXXdE4e4mdByNuG1AAAAAElFTkSuQmCC
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAE3SURBVFhH7ZaBDQIhDEVvBEdwBDfQDXQER3AD3cARdAPd
+        QDfSDbQvuSb1AicFjJrwkxcN0FIolOuamv5VE2E+gLaPayWchEcE+hhTXVPhIoQmDcFYbKpoJtwEdX4X
+        jgIrXfTwnzb6dBw22BaJVdjJmWQs1/SdBRtE0U5cBXW2oSFRO0HtSEeW2FZ1wsq9sjuRdTDVAXnNuWLY
+        6JnAl0sYa/Q5q1dhq35ci+Bkq2HJvbZpxGeybAAuw4Fq+cnW1wPITgHFYxvBUw+qHEIL1yq1vDKhVlH3
+        NQwF4JkcFRWiUAB7IVW2FFPO3YqlgPd+LJf02e8Fdi3rMdIAcLDuf9UpeT0IS0G/hvhPm305vSl7EQFY
+        B6zCvozvYGzRM8zEoeg5TPZwDaGvpHQni1yzSxbXPW9q+hF13ROHuJnQcjbhtQAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="tsbReload.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
@@ -736,6 +1309,9 @@
   </data>
   <data name="tsbReload.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
+  </data>
+  <data name="&gt;&gt;tsbReload.Name" xml:space="preserve">
+    <value>tsbReload</value>
   </data>
   <data name="tsbReload.Size" type="System.Drawing.Size, System.Drawing">
     <value>98, 53</value>
@@ -746,8 +1322,14 @@
   <data name="tsbReload.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
     <value>ImageAboveText</value>
   </data>
+  <data name="&gt;&gt;tsbReload.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="tsbServer.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
+  </data>
+  <data name="&gt;&gt;tsbServer.Name" xml:space="preserve">
+    <value>tsbServer</value>
   </data>
   <data name="tsbServer.Size" type="System.Drawing.Size, System.Drawing">
     <value>64, 53</value>
@@ -758,8 +1340,14 @@
   <data name="tsbServer.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
     <value>ImageAboveText</value>
   </data>
+  <data name="&gt;&gt;tsbServer.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripDropDownButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="tsbSub.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
     <value>Magenta</value>
+  </data>
+  <data name="&gt;&gt;tsbSub.Name" xml:space="preserve">
+    <value>tsbSub</value>
   </data>
   <data name="tsbSub.Size" type="System.Drawing.Size, System.Drawing">
     <value>99, 53</value>
@@ -770,11 +1358,23 @@
   <data name="tsbSub.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
     <value>ImageAboveText</value>
   </data>
+  <data name="&gt;&gt;tsbSub.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripDropDownButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tsbSubSetting.Name" xml:space="preserve">
+    <value>tsbSubSetting</value>
+  </data>
   <data name="tsbSubSetting.Size" type="System.Drawing.Size, System.Drawing">
     <value>125, 22</value>
   </data>
   <data name="tsbSubSetting.Text" xml:space="preserve">
     <value>Settings</value>
+  </data>
+  <data name="&gt;&gt;tsbSubSetting.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tsbSubUpdate.Name" xml:space="preserve">
+    <value>tsbSubUpdate</value>
   </data>
   <data name="tsbSubUpdate.Size" type="System.Drawing.Size, System.Drawing">
     <value>125, 22</value>
@@ -782,14 +1382,44 @@
   <data name="tsbSubUpdate.Text" xml:space="preserve">
     <value>Updates</value>
   </data>
+  <data name="&gt;&gt;tsbSubUpdate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tsbTestMe.Name" xml:space="preserve">
+    <value>tsbTestMe</value>
+  </data>
+  <data name="tsbTestMe.Size" type="System.Drawing.Size, System.Drawing">
+    <value>74, 53</value>
+  </data>
+  <data name="tsbTestMe.Text" xml:space="preserve">
+    <value>Test status</value>
+  </data>
+  <data name="tsbTestMe.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>BottomCenter</value>
+  </data>
+  <data name="&gt;&gt;tsbTestMe.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tsbV2rayWebsite.Name" xml:space="preserve">
+    <value>tsbV2rayWebsite</value>
+  </data>
   <data name="tsbV2rayWebsite.Size" type="System.Drawing.Size, System.Drawing">
     <value>187, 22</value>
   </data>
   <data name="tsbV2rayWebsite.Text" xml:space="preserve">
     <value>V2Ray Website</value>
   </data>
+  <data name="&gt;&gt;tsbV2rayWebsite.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="tsMain.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
+  </data>
+  <data name="&gt;&gt;tsMain.Name" xml:space="preserve">
+    <value>tsMain</value>
+  </data>
+  <data name="&gt;&gt;tsMain.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
   <data name="tsMain.Size" type="System.Drawing.Size, System.Drawing">
     <value>952, 56</value>
@@ -797,8 +1427,11 @@
   <data name="tsMain.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
   </data>
-  <data name="tsMain.TrayLocation" type="System.Drawing.Point, System.Drawing">
-    <value>409, 17</value>
+  <data name="&gt;&gt;tsMain.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tsMain.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
   <data name="txtMsgBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -812,6 +1445,12 @@
   <data name="txtMsgBox.Multiline" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <data name="&gt;&gt;txtMsgBox.Name" xml:space="preserve">
+    <value>txtMsgBox</value>
+  </data>
+  <data name="&gt;&gt;txtMsgBox.Parent" xml:space="preserve">
+    <value>groupBox2</value>
+  </data>
   <data name="txtMsgBox.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
     <value>Vertical</value>
   </data>
@@ -820,5 +1459,11 @@
   </data>
   <data name="txtMsgBox.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
+  </data>
+  <data name="&gt;&gt;txtMsgBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtMsgBox.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
 </root>

--- a/v2rayN/v2rayN/Forms/MainForm.zh-Hans.resx
+++ b/v2rayN/v2rayN/Forms/MainForm.zh-Hans.resx
@@ -363,6 +363,9 @@
   <data name="menuTcpingServer.Text" xml:space="preserve">
     <value>测试服务器延迟Tcping(多选) (Ctrl+O)</value>
   </data>
+  <data name="menuUpdateSubscriptions.Text" xml:space="preserve">
+    <value>更新订阅</value>
+  </data>
   <data name="toolSslServerSpeed.Text" xml:space="preserve">
     <value>网速显示未启用</value>
   </data>
@@ -494,8 +497,5 @@
   </data>
   <data name="tsbV2rayWebsite.Text" xml:space="preserve">
     <value>V2Ray 官网</value>
-  </data>
-  <data name="update_subscription.Text" xml:space="preserve">
-    <value>更新订阅</value>
   </data>
 </root>

--- a/v2rayN/v2rayN/Forms/MainForm.zh-Hans.resx
+++ b/v2rayN/v2rayN/Forms/MainForm.zh-Hans.resx
@@ -489,6 +489,9 @@
   <data name="tsbSubUpdate.Text" xml:space="preserve">
     <value>更新订阅</value>
   </data>
+  <data name="tsbTestMe.Text" xml:space="preserve">
+    <value>测试状态</value>
+  </data>
   <data name="tsbV2rayWebsite.Text" xml:space="preserve">
     <value>V2Ray 官网</value>
   </data>

--- a/v2rayN/v2rayN/Forms/MainForm.zh-Hans.resx
+++ b/v2rayN/v2rayN/Forms/MainForm.zh-Hans.resx
@@ -401,13 +401,13 @@
   </data>
   <data name="tsbReload.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsIAAA7CARUoSoAAAAE3SURBVFhH7ZaBDQIhDEVvBEdwBDfQDXQER3AD3cARdAPd
-        QDfSDbQvuSb1AicFjJrwkxcN0FIolOuamv5VE2E+gLaPayWchEcE+hhTXVPhIoQmDcFYbKpoJtwEdX4X
-        jgIrXfTwnzb6dBw22BaJVdjJmWQs1/SdBRtE0U5cBXW2oSFRO0HtSEeW2FZ1wsq9sjuRdTDVAXnNuWLY
-        6JnAl0sYa/Q5q1dhq35ci+Bkq2HJvbZpxGeybAAuw4Fq+cnW1wPITgHFYxvBUw+qHEIL1yq1vDKhVlH3
-        NQwF4JkcFRWiUAB7IVW2FFPO3YqlgPd+LJf02e8Fdi3rMdIAcLDuf9UpeT0IS0G/hvhPm305vSl7EQFY
-        B6zCvozvYGzRM8zEoeg5TPZwDaGvpHQni1yzSxbXPW9q+hF13ROHuJnQcjbhtQAAAABJRU5ErkJggg==
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wgAADsIBFShKgAAAATdJREFUWEftloENAiEMRW8ER3AEN9ANdARHcAPdwBF0A91AN9INtC+5JvUCJwWM
+        mvCTFw3QUiiU65qa/lUTYT6Ato9rJZyERwT6GFNdU+EihCYNwVhsqmgm3AR1fheOAitd9PCfNvp0HDbY
+        FolV2MmZZCzX9J0FG0TRTlwFdbahIVE7Qe1IR5bYVnXCyr2yO5F1MNUBec25YtjomcCXSxhr9DmrV2Gr
+        flyL4GSrYcm9tmnEZ7JsAC7DgWr5ydbXA8hOAcVjG8FTD6ocQgvXKrW8MqFWUfc1DAXgmRwVFaJQAHsh
+        VbYUU87diqWA934sl/TZ7wV2Lesx0gBwsO5/1Sl5PQhLQb+G+E+bfTm9KXsRAVgHrMK+jO9gbNEzzMSh
+        6DlM9nANoa+kdCeLXLNLFtc9b2r6EXXdE4e4mdByNuG1AAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="tsbReload.Size" type="System.Drawing.Size, System.Drawing">
@@ -463,12 +463,15 @@
   </data>
   <data name="tsbClose.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsIAAA7CARUoSoAAAAAySURBVFhH7c6xDQAgCEVBRnVTHU2ZABuMxV3yOvJDAAA/
-        GqfZVG6X8mg1dfUAAPBQxAZd0SJruVXHWwAAAABJRU5ErkJggg==
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wgAADsIBFShKgAAAADJJREFUWEftzrENACAIRUFGdVMdTZkAG4zFXfI68kMAAD8ap9lUbpfyaDV19QAA
+        8FDEBl3RImu5VcdbAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="tsbClose.Text" xml:space="preserve">
     <value>  关闭  </value>
+  </data>
+  <data name="update_subscription.Text" xml:space="preserve">
+    <value>更新订阅</value>
   </data>
 </root>

--- a/v2rayN/v2rayN/Forms/OptionSettingForm.cs
+++ b/v2rayN/v2rayN/Forms/OptionSettingForm.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Windows.Forms;
 using v2rayN.Handler;
 using v2rayN.Base;
+using v2rayN.HttpProxyHandler;
 
 namespace v2rayN.Forms
 {
@@ -67,7 +68,7 @@ namespace v2rayN.Forms
             //remoteDNS
             txtremoteDNS.Text = config.remoteDNS;
 
-            cmblistenerType.SelectedIndex = config.listenerType;
+            cmblistenerType.SelectedIndex = (int)config.listenerType;
         }
 
         /// <summary>
@@ -262,7 +263,8 @@ namespace v2rayN.Forms
             //remoteDNS
             config.remoteDNS = txtremoteDNS.Text.TrimEx();
 
-            config.listenerType = cmblistenerType.SelectedIndex;
+            config.listenerType = (ListenerType)Enum.ToObject(typeof(ListenerType), cmblistenerType.SelectedIndex);
+
             return 0;
         }
 

--- a/v2rayN/v2rayN/Global.cs
+++ b/v2rayN/v2rayN/Global.cs
@@ -16,6 +16,7 @@ namespace v2rayN
         /// </summary>
         public const string SpeedTestUrl = @"http://speedtest-sgp1.digitalocean.com/10mb.test";
         public const string SpeedPingTestUrl = @"https://www.google.com/generate_204";
+        public const string AvailabilityTestUrl = @"https://www.google.com/generate_204";
 
         /// <summary>
         /// CustomRoutingListUrl

--- a/v2rayN/v2rayN/Handler/DownloadHandle.cs
+++ b/v2rayN/v2rayN/Handler/DownloadHandle.cs
@@ -57,7 +57,7 @@ namespace v2rayN.Handler
         private readonly string coreLatestUrl = "https://github.com/v2ray/v2ray-core/releases/latest";
         private const string coreUrl = "https://github.com/v2ray/v2ray-core/releases/download/{0}/v2ray-windows-{1}.zip";
 
-        public async Task CheckUpdateAsync(string type)
+        public async void CheckUpdateAsync(string type)
         {
             Utils.SetSecurityProtocol();
             WebRequestHandler webRequestHandler = new WebRequestHandler

--- a/v2rayN/v2rayN/Handler/MainFormHandler.cs
+++ b/v2rayN/v2rayN/Handler/MainFormHandler.cs
@@ -32,7 +32,7 @@ namespace v2rayN.Handler
             try
             {
                 Color color = ColorTranslator.FromHtml("#3399CC");
-                int index = config.listenerType;
+                int index = (int)config.listenerType;
                 if (index > 0)
                 {
                     color = (new Color[] { Color.Red, Color.Purple, Color.DarkGreen, Color.Orange, Color.DarkSlateBlue, Color.RoyalBlue })[index - 1];

--- a/v2rayN/v2rayN/Handler/SpeedtestHandler.cs
+++ b/v2rayN/v2rayN/Handler/SpeedtestHandler.cs
@@ -156,7 +156,7 @@ namespace v2rayN.Handler
             {
                 int httpPort = _config.GetLocalPort(Global.InboundHttp);
 
-                Task<int> t = Task.Factory.StartNew(() =>
+                Task<int> t = Task.Run(() =>
                 {
                     try
                     {

--- a/v2rayN/v2rayN/Handler/SpeedtestHandler.cs
+++ b/v2rayN/v2rayN/Handler/SpeedtestHandler.cs
@@ -150,6 +150,37 @@ namespace v2rayN.Handler
             }
         }
 
+        public int RunAvailabilityCheck() // alias: isLive
+        {
+            try
+            {
+                int httpPort = _config.GetLocalPort(Global.InboundHttp);
+
+                Task<int> t = Task.Factory.StartNew(() =>
+                {
+                    try
+                    {
+                        WebProxy webProxy = new WebProxy(Global.Loopback, httpPort);
+                        int responseTime = -1;
+                        string status = GetRealPingTime(Global.AvailabilityTestUrl, webProxy, out responseTime);
+                        bool noError = Utils.IsNullOrEmpty(status);
+                        return noError ? responseTime : -1;
+                    }
+                    catch (Exception ex)
+                    {
+                        Utils.SaveLog(ex.Message, ex);
+                        return -1;
+                    }
+                });
+                return t.Result;
+            }
+            catch (Exception ex)
+            {
+                Utils.SaveLog(ex.Message, ex);
+                return -1;
+            }
+        }
+
         private void RunSpeedTest()
         {
             int pid = -1;

--- a/v2rayN/v2rayN/HttpProxyHandler/HttpProxyHandle.cs
+++ b/v2rayN/v2rayN/HttpProxyHandler/HttpProxyHandle.cs
@@ -4,6 +4,19 @@ using v2rayN.Mode;
 namespace v2rayN.HttpProxyHandler
 {
     /// <summary>
+    /// 系统代理(http)模式
+    /// </summary>
+    public enum ListenerType
+    {
+        noHttpProxy = 0,
+        GlobalHttp = 1,
+        GlobalPac = 2,
+        HttpOpenAndClear = 3,
+        PacOpenAndClear = 4,
+        HttpOpenOnly = 5,
+        PacOpenOnly = 6
+    }
+    /// <summary>
     /// 系统代理(http)总处理
     /// 启动privoxy提供http协议
     /// 设置IE系统代理或者PAC模式
@@ -12,29 +25,29 @@ namespace v2rayN.HttpProxyHandler
     {
         private static bool Update(Config config, bool forceDisable)
         {
-            int type = config.listenerType;
+            ListenerType type = config.listenerType;
 
             if (forceDisable)
             {
-                type = 0;
+                type = ListenerType.noHttpProxy;
             }
 
             try
             {
-                if (type != 0)
+                if (type != ListenerType.noHttpProxy)
                 {
                     int port = Global.httpPort;
                     if (port <= 0)
                     {
                         return false;
                     }
-                    if (type == 1)
+                    if (type == ListenerType.GlobalHttp)
                     {
                         //PACServerHandle.Stop();
                         //ProxySetting.SetProxy($"{Global.Loopback}:{port}", Global.IEProxyExceptions, 2);
                         SysProxyHandle.SetIEProxy(true, true, $"{Global.Loopback}:{port}");
                     }
-                    else if (type == 2)
+                    else if (type == ListenerType.GlobalPac)
                     {
                         string pacUrl = GetPacUrl();
                         //ProxySetting.SetProxy(pacUrl, "", 4);
@@ -42,24 +55,24 @@ namespace v2rayN.HttpProxyHandler
                         //PACServerHandle.Stop();
                         PACServerHandle.Init(config);
                     }
-                    else if (type == 3)
+                    else if (type == ListenerType.HttpOpenAndClear)
                     {
                         //PACServerHandle.Stop();
                         SysProxyHandle.ResetIEProxy();
                     }
-                    else if (type == 4)
+                    else if (type == ListenerType.PacOpenAndClear)
                     {
                         string pacUrl = GetPacUrl();
                         SysProxyHandle.ResetIEProxy();
                         //PACServerHandle.Stop();
                         PACServerHandle.Init(config);
                     }
-                    else if (type == 5)
+                    else if (type == ListenerType.HttpOpenOnly)
                     {
                         //PACServerHandle.Stop();
                         //SysProxyHandle.ResetIEProxy();
                     }
-                    else if (type == 6)
+                    else if (type == ListenerType.PacOpenOnly)
                     {
                         string pacUrl = GetPacUrl();
                         //SysProxyHandle.ResetIEProxy();
@@ -114,7 +127,7 @@ namespace v2rayN.HttpProxyHandler
         {
             try
             {
-                if (config.listenerType != 5 && config.listenerType != 6)
+                if (config.listenerType != ListenerType.HttpOpenOnly && config.listenerType != ListenerType.PacOpenOnly)
                 {
                     Update(config, true);
                 }
@@ -138,7 +151,7 @@ namespace v2rayN.HttpProxyHandler
         public static void RestartHttpAgent(Config config, bool forced)
         {
             bool isRestart = false;
-            if (config.listenerType == 0)
+            if (config.listenerType == ListenerType.noHttpProxy)
             {
                 // 关闭http proxy时，直接返回
                 return;

--- a/v2rayN/v2rayN/Mode/Config.cs
+++ b/v2rayN/v2rayN/Mode/Config.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using v2rayN.Base;
+using v2rayN.HttpProxyHandler;
+
 
 namespace v2rayN.Mode
 {
@@ -107,9 +109,9 @@ namespace v2rayN.Mode
         }
 
         /// <summary>
-        /// 监听状态 0-not 1-http 2-PAC
+        /// 监听状态
         /// </summary>
-        public int listenerType
+        public ListenerType listenerType
         {
             get; set;
         }

--- a/v2rayN/v2rayN/Resx/ResUI.Designer.cs
+++ b/v2rayN/v2rayN/Resx/ResUI.Designer.cs
@@ -780,5 +780,14 @@ namespace v2rayN.Resx {
                 return ResourceManager.GetString("SuccessfullyImportedServerViaScan", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   查找类似 The ping of current service: {0} 的本地化字符串。
+        /// </summary>
+        internal static string TestMeOutput {
+            get {
+                return ResourceManager.GetString("TestMeOutput", resourceCulture);
+            }
+        }
     }
 }

--- a/v2rayN/v2rayN/Resx/ResUI.resx
+++ b/v2rayN/v2rayN/Resx/ResUI.resx
@@ -264,11 +264,11 @@
   <data name="MsgStartGettingSubscriptions" xml:space="preserve">
     <value>Start getting subscriptions</value>
   </data>
-  <data name="MsgStartUpdatingPAC" xml:space="preserve">
-    <value>Start updating PAC...</value>
-  </data>
   <data name="MsgStartUpdating" xml:space="preserve">
     <value>Start updating {0}...</value>
+  </data>
+  <data name="MsgStartUpdatingPAC" xml:space="preserve">
+    <value>Start updating PAC...</value>
   </data>
   <data name="MsgSubscriptionDecodingFailed" xml:space="preserve">
     <value>Subscription content decoding failed (non-BASE64 code)</value>
@@ -357,5 +357,8 @@
   </data>
   <data name="SuccessfullyImportedServerViaScan" xml:space="preserve">
     <value>Scan import URL successfully</value>
+  </data>
+  <data name="TestMeOutput" xml:space="preserve">
+    <value>The ping of current service: {0}</value>
   </data>
 </root>

--- a/v2rayN/v2rayN/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/v2rayN/Resx/ResUI.zh-Hans.resx
@@ -264,11 +264,11 @@
   <data name="MsgStartGettingSubscriptions" xml:space="preserve">
     <value>开始获取订阅内容</value>
   </data>
-  <data name="MsgStartUpdatingPAC" xml:space="preserve">
-    <value>开始更新 PAC...</value>
-  </data>
   <data name="MsgStartUpdating" xml:space="preserve">
     <value>开始更新 {0}...</value>
+  </data>
+  <data name="MsgStartUpdatingPAC" xml:space="preserve">
+    <value>开始更新 PAC...</value>
   </data>
   <data name="MsgSubscriptionDecodingFailed" xml:space="preserve">
     <value>订阅内容解码失败(非BASE64码)</value>
@@ -357,5 +357,8 @@
   </data>
   <data name="SuccessfullyImportedServerViaScan" xml:space="preserve">
     <value>扫描导入URL成功</value>
+  </data>
+  <data name="TestMeOutput" xml:space="preserve">
+    <value>当前服务的访问延迟: {0}</value>
   </data>
 </root>

--- a/v2rayN/v2rayN/Tool/Utils.cs
+++ b/v2rayN/v2rayN/Tool/Utils.cs
@@ -804,21 +804,14 @@ namespace v2rayN
 
         public static string UnGzip(byte[] buf)
         {
-            byte[] buffer = new byte[1024];
-            int n;
-            using (MemoryStream sb = new MemoryStream())
+            MemoryStream sb = new MemoryStream();
+            using (GZipStream input = new GZipStream(new MemoryStream(buf),
+            CompressionMode.Decompress,
+            false))
             {
-                using (GZipStream input = new GZipStream(new MemoryStream(buf),
-                    CompressionMode.Decompress,
-                    false))
-                {
-                    while ((n = input.Read(buffer, 0, buffer.Length)) > 0)
-                    {
-                        sb.Write(buffer, 0, n);
-                    }
-                }
-                return Encoding.UTF8.GetString(sb.ToArray());
+                input.CopyTo(sb);
             }
+            return Encoding.UTF8.GetString(sb.ToArray());
         }
 
         #endregion

--- a/v2rayN/v2rayUpgrade/MainForm.cs
+++ b/v2rayN/v2rayUpgrade/MainForm.cs
@@ -41,8 +41,9 @@ namespace v2rayUpgrade
             }
             catch (Exception ex)
             {
-                showWarn("Failed to close v2rayN(关闭v2rayN失败)." + ex.StackTrace);
-                return;
+                // Access may be denied without admin right. The user may not be an administrator.
+                showWarn("Failed to close v2rayN(关闭v2rayN失败).\n" +
+                    "Close it manually, or the upgrade may fail.(请手动关闭正在运行的v2rayN，否则可能升级失败。\n\n" + ex.StackTrace);
             }
 
             try


### PR DESCRIPTION
* 界面：启用的服务器现在是粗体蓝色。
* 界面：新增隔行着色。如果大家不喜欢，可以再去掉。加用户选项的意义不大。
* 界面：合并 #494，托盘菜单现在有立即更新订阅。
* 界面：新增了一个测试当前代理延迟的按钮。主要用于测试、开发。按钮暂无图标。
* 修复：路径有空格的更新失败，权限不足的更新失败。作者请更新libs.zip以生效。
* 修复：解决一个闪退点（启动本地PAC服务器），也许缓解使用加速器闪退问题。没有加速器会员，暂时没有办法测。
* 改进：更新本软件及Core时，如果本软件的http代理可用，使用代理下载。
* 代码清理和重构。