### PR TITLE
添加“仅清除系统代理一次”的HTTP代理选项

### DIFF
--- a/v2rayN/v2rayN/Forms/MainForm.Designer.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.Designer.cs
@@ -72,6 +72,8 @@
             this.menuKeepPAC = new System.Windows.Forms.ToolStripMenuItem();
             this.menuKeepNothing = new System.Windows.Forms.ToolStripMenuItem();
             this.menuKeepPACNothing = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuClearAndKeepNothing = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuClearAndKeepPACNothing = new System.Windows.Forms.ToolStripMenuItem();
             this.menuServers = new System.Windows.Forms.ToolStripMenuItem();
             this.menuAddServers2 = new System.Windows.Forms.ToolStripMenuItem();
             this.menuScanScreen2 = new System.Windows.Forms.ToolStripMenuItem();
@@ -411,7 +413,9 @@
             this.menuKeep,
             this.menuKeepPAC,
             this.menuKeepNothing,
-            this.menuKeepPACNothing});
+            this.menuKeepPACNothing,
+            this.menuClearAndKeepNothing,
+            this.menuClearAndKeepPACNothing});
             this.menuSysAgentMode.Name = "menuSysAgentMode";
             // 
             // menuNotEnabledHttp
@@ -455,6 +459,18 @@
             resources.ApplyResources(this.menuKeepPACNothing, "menuKeepPACNothing");
             this.menuKeepPACNothing.Name = "menuKeepPACNothing";
             this.menuKeepPACNothing.Click += new System.EventHandler(this.menuKeepPACNothing_Click);
+            // 
+            // menuClearAndKeepNothing
+            // 
+            resources.ApplyResources(this.menuClearAndKeepNothing, "menuClearAndKeepNothing");
+            this.menuClearAndKeepNothing.Name = "menuClearAndKeepNothing";
+            this.menuClearAndKeepNothing.Click += new System.EventHandler(this.MenuClearAndKeepNothing_Click);
+            // 
+            // menuClearAndKeepPACNothing
+            // 
+            resources.ApplyResources(this.menuClearAndKeepPACNothing, "menuClearAndKeepPACNothing");
+            this.menuClearAndKeepPACNothing.Name = "menuClearAndKeepPACNothing";
+            this.menuClearAndKeepPACNothing.Click += new System.EventHandler(this.MenuClearAndKeepPACNothing_Click);
             // 
             // menuServers
             // 
@@ -933,6 +949,8 @@
         private System.Windows.Forms.ToolStripDropDownButton tsbService;
         private System.Windows.Forms.ToolStripMenuItem tsbReload;
         private System.Windows.Forms.ToolStripMenuItem tsbTestMe;
+        private System.Windows.Forms.ToolStripMenuItem menuClearAndKeepNothing;
+        private System.Windows.Forms.ToolStripMenuItem menuClearAndKeepPACNothing;
     }
 }
 

--- a/v2rayN/v2rayN/Forms/MainForm.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.cs
@@ -1161,6 +1161,16 @@ namespace v2rayN.Forms
         {
             SetListenerType(ListenerType.PacOpenOnly);
         }
+        private void MenuClearAndKeepNothing_Click(object sender, EventArgs e)
+        {
+            SysProxyHandle.ResetIEProxy();
+            SetListenerType(ListenerType.HttpOpenAndClearOnce);
+        }
+        private void MenuClearAndKeepPACNothing_Click(object sender, EventArgs e)
+        {
+            SysProxyHandle.ResetIEProxy();
+            SetListenerType(ListenerType.PacOpenAndClearOnce);
+        }
         private void SetListenerType(ListenerType type)
         {
             config.listenerType = type;

--- a/v2rayN/v2rayN/Forms/MainForm.resx
+++ b/v2rayN/v2rayN/Forms/MainForm.resx
@@ -321,6 +321,12 @@
   <data name="menuKeepPACNothing.Size" type="System.Drawing.Size, System.Drawing">
     <value>411, 22</value>
   </data>
+  <data name="menuClearAndKeepNothing.Size" type="System.Drawing.Size, System.Drawing">
+    <value>411, 22</value>
+  </data>
+  <data name="menuClearAndKeepPACNothing.Size" type="System.Drawing.Size, System.Drawing">
+    <value>411, 22</value>
+  </data>
   <data name="menuExport2ClientConfig.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>
   </data>
@@ -606,6 +612,12 @@
     <value>Check for updates</value>
   </data>
   <data name="&gt;&gt;menuKeepPACNothing.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuClearAndKeepNothing.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuClearAndKeepPACNothing.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;menuGlobal.Type" xml:space="preserve">
@@ -1024,6 +1036,12 @@
   <data name="&gt;&gt;menuKeepPACNothing.Name" xml:space="preserve">
     <value>menuKeepPACNothing</value>
   </data>
+  <data name="menuClearAndKeepNothing.Name" xml:space="preserve">
+    <value>menuClearAndKeepNothing</value>
+  </data>
+  <data name="menuClearAndKeepPACNothing.Name" xml:space="preserve">
+    <value>menuClearAndKeepPACNothing</value>
+  </data>
   <data name="tsbCheckUpdatePACList.Text" xml:space="preserve">
     <value>Check for updated PAC (need the HTTP proxy are ON)</value>
   </data>
@@ -1098,6 +1116,12 @@
   </data>
   <data name="menuKeepPACNothing.Text" xml:space="preserve">
     <value>Only open PAC and do nothing</value>
+  </data>
+  <data name="menuClearAndKeepNothing.Text" xml:space="preserve">
+    <value>Only open Http proxy and clear the proxy settings once</value>
+  </data>
+  <data name="menuClearAndKeepPACNothing.Text" xml:space="preserve">
+    <value>Only open PAC and clear the proxy settings once</value>
   </data>
   <data name="menuSelectAll.Size" type="System.Drawing.Size, System.Drawing">
     <value>355, 22</value>

--- a/v2rayN/v2rayN/Forms/MainForm.zh-Hans.resx
+++ b/v2rayN/v2rayN/Forms/MainForm.zh-Hans.resx
@@ -336,6 +336,18 @@
   <data name="menuKeepPACNothing.Text" xml:space="preserve">
     <value>仅开启PAC,不改变系统代理</value>
   </data>
+  <data name="menuClearAndKeepNothing.Size" type="System.Drawing.Size, System.Drawing">
+    <value>316, 22</value>
+  </data>
+  <data name="menuClearAndKeepNothing.Text" xml:space="preserve">
+    <value>仅开启Http代理,并清除系统代理一次</value>
+  </data>
+  <data name="menuClearAndKeepPACNothing.Size" type="System.Drawing.Size, System.Drawing">
+    <value>316, 22</value>
+  </data>
+  <data name="menuClearAndKeepPACNothing.Text" xml:space="preserve">
+    <value>仅开启PAC,并清除系统代理一次</value>
+  </data>
   <data name="menuSysAgentMode.Size" type="System.Drawing.Size, System.Drawing">
     <value>195, 22</value>
   </data>

--- a/v2rayN/v2rayN/Forms/OptionSettingForm.Designer.cs
+++ b/v2rayN/v2rayN/Forms/OptionSettingForm.Designer.cs
@@ -186,7 +186,9 @@
             resources.GetString("cmblistenerType.Items3"),
             resources.GetString("cmblistenerType.Items4"),
             resources.GetString("cmblistenerType.Items5"),
-            resources.GetString("cmblistenerType.Items6")});
+            resources.GetString("cmblistenerType.Items6"),
+            resources.GetString("cmblistenerType.Items7"),
+            resources.GetString("cmblistenerType.Items8")});
             this.cmblistenerType.Name = "cmblistenerType";
             // 
             // chksniffingEnabled2

--- a/v2rayN/v2rayN/Forms/OptionSettingForm.cs
+++ b/v2rayN/v2rayN/Forms/OptionSettingForm.cs
@@ -176,6 +176,9 @@ namespace v2rayN.Forms
                 return;
             }
 
+            if (config.listenerType == ListenerType.HttpOpenAndClearOnce || config.listenerType == ListenerType.PacOpenAndClearOnce) {
+                SysProxyHandle.ResetIEProxy();
+            }
             if (ConfigHandler.SaveConfig(ref config) == 0)
             {
                 this.DialogResult = DialogResult.OK;

--- a/v2rayN/v2rayN/Forms/OptionSettingForm.resx
+++ b/v2rayN/v2rayN/Forms/OptionSettingForm.resx
@@ -420,6 +420,12 @@
   <data name="cmblistenerType.Items6" xml:space="preserve">
     <value>Only open PAC and do nothing</value>
   </data>
+  <data name="cmblistenerType.Items7" xml:space="preserve">
+    <value>Only open Http proxy, and clear the system proxy once</value>
+  </data>
+  <data name="cmblistenerType.Items8" xml:space="preserve">
+    <value>Only open PAC, and clear the system proxy once</value>
+  </data>
   <data name="cmblistenerType.Location" type="System.Drawing.Point, System.Drawing">
     <value>124, 94</value>
   </data>

--- a/v2rayN/v2rayN/Forms/OptionSettingForm.zh-Hans.resx
+++ b/v2rayN/v2rayN/Forms/OptionSettingForm.zh-Hans.resx
@@ -228,6 +228,12 @@
   <data name="cmblistenerType.Items6" xml:space="preserve">
     <value>仅开启PAC,不改变系统代理</value>
   </data>
+  <data name="cmblistenerType.Items7" xml:space="preserve">
+    <value>仅开启Http代理,并清除系统代理一次</value>
+  </data>
+  <data name="cmblistenerType.Items8" xml:space="preserve">
+    <value>仅开启PAC,并清除系统代理一次</value>
+  </data>
   <data name="cmbroutingMode.Items" xml:space="preserve">
     <value>全局</value>
   </data>

--- a/v2rayN/v2rayN/HttpProxyHandler/HttpProxyHandle.cs
+++ b/v2rayN/v2rayN/HttpProxyHandler/HttpProxyHandle.cs
@@ -14,7 +14,9 @@ namespace v2rayN.HttpProxyHandler
         HttpOpenAndClear = 3,
         PacOpenAndClear = 4,
         HttpOpenOnly = 5,
-        PacOpenOnly = 6
+        PacOpenOnly = 6,
+        HttpOpenAndClearOnce = 7,
+        PacOpenAndClearOnce = 8
     }
     /// <summary>
     /// 系统代理(http)总处理
@@ -67,12 +69,12 @@ namespace v2rayN.HttpProxyHandler
                         //PACServerHandle.Stop();
                         PACServerHandle.Init(config);
                     }
-                    else if (type == ListenerType.HttpOpenOnly)
+                    else if (type == ListenerType.HttpOpenOnly || type == ListenerType.HttpOpenAndClearOnce)
                     {
                         //PACServerHandle.Stop();
                         //SysProxyHandle.ResetIEProxy();
                     }
-                    else if (type == ListenerType.PacOpenOnly)
+                    else if (type == ListenerType.PacOpenOnly || type == ListenerType.PacOpenAndClearOnce)
                     {
                         string pacUrl = GetPacUrl();
                         //SysProxyHandle.ResetIEProxy();
@@ -127,7 +129,7 @@ namespace v2rayN.HttpProxyHandler
         {
             try
             {
-                if (config.listenerType != ListenerType.HttpOpenOnly && config.listenerType != ListenerType.PacOpenOnly)
+                if (config.listenerType != ListenerType.HttpOpenOnly && config.listenerType != ListenerType.PacOpenOnly && config.listenerType != ListenerType.HttpOpenAndClearOnce && config.listenerType != ListenerType.PacOpenAndClearOnce)
                 {
                     Update(config, true);
                 }


### PR DESCRIPTION
适用情形：
开启全局模式，之后想关闭全局代理但不关闭HTTP代理，又不希望程序总是清除系统代理，
此时只能点击“仅开启HTTP代理，并清除系统代理”后，再点击“仅开启HTTP代理，不改变系统代理”。

解决方案：
增加一个HTTP代理选项，在选中/设置时清除一次系统代理，之后不再更改系统代理状态。