### PR TITLE
RefreshTaryIcon while DisplaySettingsChanged

### DIFF
--- a/v2rayN/v2rayN/Forms/MainForm.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.cs
@@ -54,6 +54,8 @@ namespace v2rayN.Forms
             {
                 statistics = new StatisticsHandler(config, UpdateStatisticsHandler);
             }
+
+            Microsoft.Win32.SystemEvents.DisplaySettingsChanged += new EventHandler(SystemEvents_DisplaySettingsChanged);
         }
 
         private void MainForm_VisibleChanged(object sender, EventArgs e)
@@ -341,6 +343,10 @@ namespace v2rayN.Forms
             //qrCodeControl.showQRCode(index, config);
         }
 
+        private void RefreshTaryIcon()
+        {
+            notifyMain.Icon = MainFormHandler.Instance.GetNotifyIcon(config, this.Icon);
+        }
         private void DisplayToolStatus()
         {
             toolSslSocksPort.Text =
@@ -367,7 +373,7 @@ namespace v2rayN.Forms
                 }
             }
 
-            notifyMain.Icon = MainFormHandler.Instance.GetNotifyIcon(config, this.Icon);
+            RefreshTaryIcon();
         }
         private void ssMain_ItemClicked(object sender, ToolStripItemClickedEventArgs e)
         {
@@ -1563,7 +1569,12 @@ namespace v2rayN.Forms
         }
 
 
+
         #endregion
+        private void SystemEvents_DisplaySettingsChanged(object sender, EventArgs e)
+        {
+            RefreshTaryIcon();
+        }
 
 
     }


### PR DESCRIPTION
缓解系统DPI变更（降低）后托盘图标画质劣化。

只测试了调整系统缩放级别，不确定跨显示器等情况。
多尺寸ico文件，使用`System.Drawing.Drawing2D.InterpolationMode.HighQualityBicubic`、`SystemInformation.SmallIconSize`等试过，不太管用。

.NET 4.7有改进DPI支持，但尝试修改没成功。
https://docs.microsoft.com/zh-cn/dotnet/framework/winforms/high-dpi-support-in-windows-forms