### PR TITLE
Delete #routingobject

### DIFF
--- a/v2rayN/v2rayN/Forms/OptionSettingForm.cs
+++ b/v2rayN/v2rayN/Forms/OptionSettingForm.cs
@@ -444,7 +444,7 @@ namespace v2rayN.Forms
 
         private void linkLabelRoutingDoc_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            System.Diagnostics.Process.Start("https://www.v2fly.org/chapter_02/03_routing.html#routingobject");
+            System.Diagnostics.Process.Start("https://www.v2fly.org/chapter_02/03_routing.html");
         }
     }
 


### PR DESCRIPTION
打开页面时露出上方“路由功能”的描述