### PR TITLE
允许不安全连接 -> 允许不可信证书

### DIFF
--- a/v2rayN/v2rayN/Forms/AddServerForm.zh-Hans.resx
+++ b/v2rayN/v2rayN/Forms/AddServerForm.zh-Hans.resx
@@ -149,7 +149,7 @@
     <value>203, 12</value>
   </data>
   <data name="label21.Text" xml:space="preserve">
-    <value>允许不安全连接(allowInsecure)</value>
+    <value>允许不可信证书(allowInsecure)</value>
   </data>
   <data name="cmbAllowInsecure.Location" type="System.Drawing.Point, System.Drawing">
     <value>223, 7</value>

--- a/v2rayN/v2rayN/Forms/OptionSettingForm.zh-Hans.resx
+++ b/v2rayN/v2rayN/Forms/OptionSettingForm.zh-Hans.resx
@@ -128,7 +128,7 @@
     <value>222, 16</value>
   </data>
   <data name="chkdefAllowInsecure.Text" xml:space="preserve">
-    <value>底层传输安全选tls时，默认允许不安全连接(allowInsecure)</value>
+    <value>底层传输安全选tls时，默认允许不可信证书(allowInsecure)</value>
   </data>
   <data name="label16.Size" type="System.Drawing.Size, System.Drawing">
     <value>53, 12</value>


### PR DESCRIPTION
“不安全连接”的表述未指出哪里不安全，且有很大的歧义，可以是TLS协议降级攻击、已不安全的加密套件等，而此处单指证书不可信