### PR TITLE
订阅链接中加入security字段

### DIFF
--- a/v2rayN/v2rayN/Handler/ConfigHandler.cs
+++ b/v2rayN/v2rayN/Handler/ConfigHandler.cs
@@ -385,7 +385,8 @@ namespace v2rayN.Handler
                         type = vmessItem.headerType,
                         host = vmessItem.requestHost,
                         path = vmessItem.path,
-                        tls = vmessItem.streamSecurity
+                        tls = vmessItem.streamSecurity,
+                        security = vmessItem.security
                     };
 
                     url = Utils.ToJson(vmessQRCode);

--- a/v2rayN/v2rayN/Handler/V2rayConfigHandler.cs
+++ b/v2rayN/v2rayN/Handler/V2rayConfigHandler.cs
@@ -1234,6 +1234,11 @@ namespace v2rayN.Handler
                         vmessItem.requestHost = Utils.ToString(vmessQRCode.host);
                         vmessItem.path = Utils.ToString(vmessQRCode.path);
                         vmessItem.streamSecurity = Utils.ToString(vmessQRCode.tls);
+
+                        if (!Utils.IsNullOrEmpty(vmessQRCode.security))
+                        {
+                            vmessItem.security = Utils.ToString(vmessQRCode.security);
+                        }
                     }
 
                     ConfigHandler.UpgradeServerVersion(ref vmessItem);

--- a/v2rayN/v2rayN/Mode/VmessQRCode.cs
+++ b/v2rayN/v2rayN/Mode/VmessQRCode.cs
@@ -49,5 +49,9 @@ namespace v2rayN.Mode
         /// 底层传输安全
         /// </summary>
         public string tls { get; set; } = string.Empty;
+        /// <summary>
+        /// 加密方式
+        /// </summary>
+        public string security { get; set; } = string.Empty;
     }    
 }


### PR DESCRIPTION
如果使用ws+tls的方式的话，因为tls本身就是比较安全的加密，所以也就不需要vmess的加密了，订阅链接里建议加上一个加密方式的字段，不然每次更新订阅都自动回auto了