### PR TITLE
在 v2rayN.exe 所在的文件夹运行 v2rayUpgrade.exe

### DIFF
--- a/v2rayN/v2rayN/Forms/MainForm.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.cs
@@ -1298,7 +1298,16 @@ namespace v2rayN.Forms
                         try
                         {
                             string fileName = Utils.GetPath(downloadHandle.DownloadFileName);
-                            Process process = Process.Start("v2rayUpgrade.exe", "\"" + fileName + "\"");
+                            Process process = new Process
+                            {
+                                StartInfo = new ProcessStartInfo
+                                {
+                                    FileName = "v2rayUpgrade.exe",
+                                    Arguments = "\"" + fileName + "\"",
+                                    WorkingDirectory = Utils.StartupPath()
+                                }
+                            };
+                            process.Start();
                             if (process.Id > 0)
                             {
                                 menuExit_Click(null, null);


### PR DESCRIPTION
## 异常

由于工作文件夹（ Working Directory ）的问题，在某些情况下现在的`v2rayN.exe`可能无法找到其所在文件夹下的`v2rayUpgrade.exe`，导致更新错误：

```
开始更新 v2rayN...
解析v2rayN成功
下载开始...
...0%
...10%
...20%
...30%
...40%
...50%
...60%
...70%
...80%
...90%
...100%
下载V2ray成功
系统找不到指定的文件。    <---
```

## 复现方法及解释

以下各方法都是要将当前工作文件夹改为不是`v2rayN.exe`所在的文件夹。

### 方法一

在以下代码前添加`Directory.SetCurrentDirectory("C:");`，运行`v2rayN.exe`并执行更新：

https://github.com/2dust/v2rayN/blob/a799420d0f86e2cce753e23214131259f0894314/v2rayN/v2rayN/Forms/MainForm.cs#L1301

这会修改`v2rayN.exe`的工作文件夹到 C 分区的根（可能不会有人把 v2rayN 直接放到这里运行）。

### 方法二

打开 cmd 或者 powershell ，切换工作文件夹到非`v2rayN.exe`所在的文件夹，用相对路径或绝对路径运行`v2rayN.exe`并执行更新。

这会使`v2rayN.exe`的工作文件夹为当前的 cmd 或 ps 的工作文件夹。

### 方法三

使 Windows 在启动时运行`v2rayN.exe`，并执行更新。

经测试，`HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run`中的 v2rayN 运行时的工作文件夹为`C:\Windows\system32`。

## 解决方法

在创建`v2rayUpgrade.exe`进程时使用 [ProcessStartInfo.WorkingDirectory](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.workingdirectory) 属性指定工作文件夹路径（本 PR ），或者在 v2rayN 的初始化过程中使用 [Directory.SetCurrentDirectory](https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.setcurrentdirectory) 修改工作文件夹。

## 可能有关的 Issues 及影响范围

### Issues

#766 https://github.com/2dust/v2rayN/issues/754#issuecomment-622955601 #627 #595 https://github.com/2dust/v2rayN/issues/560#issuecomment-601031902 #343 ……

### 范围

从 https://github.com/2dust/v2rayN/commit/5cadf59e10cf0df617078fd68b43abadddaa8719#diff-9334c28f8212861045cf1769f79f189aR1174 到现在（ https://github.com/2dust/v2rayN/commit/a799420d0f86e2cce753e23214131259f0894314 ），包含版本 [3.0](https://github.com/2dust/v2rayN/releases/tag/3.0) - [3.19](https://github.com/2dust/v2rayN/releases/tag/3.19) 。

---

请仔细检查我的修改，如果有错请指出，谢谢。