### PR TITLE
正确处理 存在空字段的 或 密码中包含冒号或 at 符号的 shadowsocks 分享 URL

### DIFF
--- a/v2rayN/v2rayN/Handler/V2rayConfigHandler.cs
+++ b/v2rayN/v2rayN/Handler/V2rayConfigHandler.cs
@@ -1266,22 +1266,44 @@ namespace v2rayN.Handler
                         result = Utils.Base64Decode(result);
                     }
 
-                    string[] arr1 = result.Split('@');
-                    if (arr1.Length != 2)
+                    //密码中可能包含“@”，所以从后往前搜索
+                    int indexAddressAndPort = result.LastIndexOf("@");
+                    if (indexAddressAndPort < 0)
                     {
                         return null;
                     }
-                    string[] arr21 = arr1[0].Split(':');
-                    //string[] arr22 = arr1[1].Split(':');
-                    int indexPort = arr1[1].LastIndexOf(":");
-                    if (arr21.Length != 2 || indexPort < 0)
+                    string addressAndPort = result.Substring(indexAddressAndPort + 1);
+                    string securityAndId = result.Substring(0, indexAddressAndPort);
+
+                    //IPv6地址中包含“:”，所以从后往前搜索
+                    int indexPort = addressAndPort.LastIndexOf(":");
+                    if (indexPort < 0)
                     {
                         return null;
                     }
-                    vmessItem.address = arr1[1].Substring(0, indexPort);
-                    vmessItem.port = Utils.ToInt(arr1[1].Substring(indexPort + 1, arr1[1].Length - (indexPort + 1)));
-                    vmessItem.security = arr21[0];
-                    vmessItem.id = arr21[1];
+
+                    //加密方式中不包含“:”，所以从前往后搜索
+                    int indexId = securityAndId.IndexOf(":");
+                    if (indexId < 0)
+                    {
+                        return null;
+                    }
+
+                    string address = addressAndPort.Substring(0, indexPort);
+                    string port = addressAndPort.Substring(indexPort + 1);
+                    string security = securityAndId.Substring(0, indexId);
+                    string id = securityAndId.Substring(indexId + 1);
+
+                    //所有字段均不能为空
+                    if (address.Length == 0 || port.Length == 0 || security.Length == 0 || id.Length == 0)
+                    {
+                        return null;
+                    }
+
+                    vmessItem.address = address;
+                    vmessItem.port = Utils.ToInt(port);
+                    vmessItem.security = security;
+                    vmessItem.id = id;
                 }
                 else if (result.StartsWith(Global.socksProtocol))
                 {


### PR DESCRIPTION
## 异常

由于对 ss URL 的分析不正确，导致：

1. 存在空字段的 ss URL 可以被导入；
2. 密码中包含冒号“:”或 at 符号“@”的 ss URL 无法被导入。

## 解决方法

不使用 [String.Split](https://docs.microsoft.com/en-us/dotnet/api/system.string.split) 方法直接按冒号或 at 符号分割字符串，而是使用 [String.IndexOf](https://docs.microsoft.com/en-us/dotnet/api/system.string.indexof) 或 [String.LastIndexOf](https://docs.microsoft.com/en-us/dotnet/api/system.string.lastindexof) 方法从前往后或从后往前搜索它们，通过符号的位置正确切割字符串，并检查切割后字符串的长度以避免空字段。

更好的方法是使用正则表达式，例如 [shadowsocks/shadowsocks-windows/shadowsocks-csharp/Model/Server.cs#L20](https://github.com/shadowsocks/shadowsocks-windows/blob/82b58d8ca0569db624f5570eb363cb8d934dedba/shadowsocks-csharp/Model/Server.cs#L20) 。

## 影响范围

从 https://github.com/2dust/v2rayN/commit/8bbb50ceb2d5aea76f5e68fd0d07fbb25679ccc7#diff-c46f4bdc0eda5d52ad9a994c2500ab75R1197-R1241 到现在（ https://github.com/2dust/v2rayN/commit/a799420d0f86e2cce753e23214131259f0894314 ），包含版本 [2.44 (Pre-release)](https://github.com/2dust/v2rayN/releases/tag/2.44) - [3.19](https://github.com/2dust/v2rayN/releases/tag/3.19) 。

## 测试用例

### 用于异常 1

下表中所有的 ss URL 均**能**导入到当前的 v2rayN ，除非应用了本 PR 中的修改：

| ss URL | Base64 decoded | Security | Id | Address | Port |
|:- |:- |:- |:- |:- |:- |
| ss://OmFAYS5jb206MTIzNA== | :a@a.com:1234 |  | a | a.com | 1234 |
| ss://Y2hhY2hhMjA6QGEuY29tOjEyMzQ= | chacha20:@a.com:1234 | chacha20 |  | a.com | 1234 |
| ss://Y2hhY2hhMjA6YUA6MTIzNA== | chacha20:a@:1234 | chacha20 | a |  | 1234 |
| ss://Y2hhY2hhMjA6YUBhLmNvbTo= | chacha20:a@a.com: | chacha20 | a | a.com |  |
| ss://Y2hhY2hhMjA6YUA6 | chacha20:a@: | chacha20 | a |  |  |
| ss://Y2hhY2hhMjA6QGEuY29tOg== | chacha20:@a.com: | chacha20 |  | a.com |  |
| ss://Y2hhY2hhMjA6QDoxMjM0 | chacha20:@:1234 | chacha20 |  |  | 1234 |
| ss://OmFAYS5jb206 | :a@a.com: |  | a | a.com |  |
| ss://OmFAOjEyMzQ= | :a@:1234 |  | a |  | 1234 |
| ss://OkBhLmNvbToxMjM0 | :@a.com:1234 |  |  | a.com | 1234 |
| ss://Y2hhY2hhMjA6QDo= | chacha20:@: | chacha20 |  |  |  |
| ss://OmFAOg== | :a@: |  | a |  |  |
| ss://OkBhLmNvbTo= | :@a.com: |  |  | a.com |  |
| ss://OkA6MTIzNA== | :@:1234 |  |  |  | 1234 |
| ss://OkA6 | :@: |  |  |  |  |

<details>
<summary>纯文本</summary>
<pre>
ss://OmFAYS5jb206MTIzNA==
ss://Y2hhY2hhMjA6QGEuY29tOjEyMzQ=
ss://Y2hhY2hhMjA6YUA6MTIzNA==
ss://Y2hhY2hhMjA6YUBhLmNvbTo=
ss://Y2hhY2hhMjA6YUA6
ss://Y2hhY2hhMjA6QGEuY29tOg==
ss://Y2hhY2hhMjA6QDoxMjM0
ss://OmFAYS5jb206
ss://OmFAOjEyMzQ=
ss://OkBhLmNvbToxMjM0
ss://Y2hhY2hhMjA6QDo=
ss://OmFAOg==
ss://OkBhLmNvbTo=
ss://OkA6MTIzNA==
ss://OkA6
</pre>
</details>

### 用于异常 2

下表中所有的 ss URL 均**不能**导入到当前的 v2rayN ，除非应用了本 PR 中的修改：

| ss URL | Base64 decoded | Security | Id | Address | Port |
|:- |:- |:- |:- |:- |:- |
| ss://Y2hhY2hhMjA6OkBhLmNvbToxMjM0 | chacha20::@a.com:1234 | chacha20 | : | a.com | 1234 |
| ss://Y2hhY2hhMjA6QEBhLmNvbToxMjM0 | chacha20:@@a.com:1234 | chacha20 | @ | a.com | 1234 |
| ss://Y2hhY2hhMjA6OkBAYS5jb206MTIzNA== | chacha20::@@a.com:1234 | chacha20 | :@ | a.com | 1234 |
| ss://Y2hhY2hhMjA6QDpAYS5jb206MTIzNA== | chacha20:@:@a.com:1234 | chacha20 | @: | a.com | 1234 |
| ss://Y2hhY2hhMjA6QEBAYS5jb206MTIzNA== | chacha20:@@@a.com:1234 | chacha20 | @@ | a.com | 1234 |
| ss://Y2hhY2hhMjA6OjpAYS5jb206MTIzNA== | chacha20:::@a.com:1234 | chacha20 | :: | a.com | 1234 |

<details>
<summary>纯文本</summary>
<pre>
ss://Y2hhY2hhMjA6OkBhLmNvbToxMjM0
ss://Y2hhY2hhMjA6QEBhLmNvbToxMjM0
ss://Y2hhY2hhMjA6OkBAYS5jb206MTIzNA==
ss://Y2hhY2hhMjA6QDpAYS5jb206MTIzNA==
ss://Y2hhY2hhMjA6QEBAYS5jb206MTIzNA==
ss://Y2hhY2hhMjA6OjpAYS5jb206MTIzNA==
</pre>
</details>

### 用于回归测试

无论是否应用了本 PR 中的修改，下表中所有的 ss URL 均不能、也不应该被导入到 v2rayN ：

| ss URL | Base64 decoded |
|:- |:- |
| ss://Y2hhY2hhMjA6YUBhLmNvbQ== | chacha20:a@a.com |
| ss://Y2hhY2hhMjA6YUA= | chacha20:a@ |
| ss://Y2hhY2hhMjBAYS5jb206MTIzNA== | chacha20@a.com:1234 |
| ss://QGEuY29tOjEyMzQ= | @a.com:1234 |
| ss://OkA= | :@ |
| ss://QDo= | @: |
| ss://QA== | @ |
| ss://Og== | : |
| ss:// |  |

<details>
<summary>纯文本</summary>
<pre>
ss://Y2hhY2hhMjA6YUBhLmNvbQ==
ss://Y2hhY2hhMjA6YUA=
ss://Y2hhY2hhMjBAYS5jb206MTIzNA==
ss://QGEuY29tOjEyMzQ=
ss://OkA=
ss://QDo=
ss://QA==
ss://Og==
ss://
</pre>
</details>

## 参考

- [Shadowsocks - SIP002 URI Scheme](https://shadowsocks.org/en/spec/SIP002-URI-Scheme.html)

---

请仔细检查我的修改，如果有错请指出，谢谢。
