### PR TITLE
Add hotkey setting option.

### DIFF
--- a/v2rayN/v2rayN/Forms/MainForm.Designer.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.Designer.cs
@@ -78,6 +78,7 @@
             this.menuScanScreen2 = new System.Windows.Forms.ToolStripMenuItem();
             this.menuCopyPACUrl = new System.Windows.Forms.ToolStripMenuItem();
             this.menuUpdateSubscriptions = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuQuicklyAddUserPAC = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.menuExit = new System.Windows.Forms.ToolStripMenuItem();
             this.bgwScan = new System.ComponentModel.BackgroundWorker();
@@ -400,6 +401,7 @@
             this.menuScanScreen2,
             this.menuCopyPACUrl,
             this.menuUpdateSubscriptions,
+            this.menuQuicklyAddUserPAC,
             this.toolStripSeparator2,
             this.menuExit});
             this.cmsMain.Name = "contextMenuStrip1";
@@ -490,6 +492,12 @@
             this.menuUpdateSubscriptions.Name = "menuUpdateSubscriptions";
             resources.ApplyResources(this.menuUpdateSubscriptions, "menuUpdateSubscriptions");
             this.menuUpdateSubscriptions.Click += new System.EventHandler(this.menuUpdateSubscriptions_Click);
+            // 
+            // menuQuicklyAddUserPAC
+            // 
+            this.menuQuicklyAddUserPAC.Name = "menuQuicklyAddUserPAC";
+            resources.ApplyResources(this.menuQuicklyAddUserPAC, "menuQuicklyAddUserPAC");
+            this.menuQuicklyAddUserPAC.Click += new System.EventHandler(this.menuQuicklyAddUserPAC_Click);
             // 
             // toolStripSeparator2
             // 
@@ -936,6 +944,7 @@
         private System.Windows.Forms.ToolStripMenuItem tsbTestMe;
         private System.Windows.Forms.ToolStripButton tsbReload;
         private System.Windows.Forms.ToolStripButton tsbQRCodeSwitch;
+        private System.Windows.Forms.ToolStripMenuItem menuQuicklyAddUserPAC;
     }
 }
 

--- a/v2rayN/v2rayN/Forms/MainForm.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.cs
@@ -11,6 +11,7 @@ using v2rayN.Tool;
 using System.Diagnostics;
 using System.Drawing;
 using System.Net;
+using v2rayN.Handler.Hotkey;
 
 namespace v2rayN.Forms
 {
@@ -19,6 +20,7 @@ namespace v2rayN.Forms
         private V2rayHandler v2rayHandler;
         private List<int> lvSelecteds = new List<int>();
         private StatisticsHandler statistics = null;
+        private QuicklyAddUserPACForm fmQuickAddUserPAC;
 
         #region Window 事件
 
@@ -49,6 +51,18 @@ namespace v2rayN.Forms
             ConfigHandler.LoadConfig(ref config);
             v2rayHandler = new V2rayHandler();
             v2rayHandler.ProcessEvent += v2rayHandler_ProcessEvent;
+            
+            v2rayHandler.StopProxyEvent += this.menuNotEnabledHttp_Click;
+            v2rayHandler.StartGlobalProxyModeEvent += this.menuGlobal_Click;
+            v2rayHandler.StartPACProxyModeEvent += this.menuGlobalPAC_Click;
+            v2rayHandler.ShowAddUserPACEvent += this.menuQuicklyAddUserPAC_Click;
+
+            Hotkeys.Init(v2rayHandler);
+            
+            if (config.hotkeyConfig.regHotkeyAtStartup)
+            {
+                HotkeyReg.RegAllHotkeys(config.hotkeyConfig);
+            }
 
             if (config.enableStatistics)
             {
@@ -1216,6 +1230,28 @@ namespace v2rayN.Forms
         private void menuKeepPACNothing_Click(object sender, EventArgs e)
         {
             SetListenerType(ListenerType.PacOpenOnly);
+        }
+        private void menuQuicklyAddUserPAC_Click(object sender, EventArgs e)
+        {
+            if (fmQuickAddUserPAC == null)
+            {
+                fmQuickAddUserPAC = new QuicklyAddUserPACForm();                
+            }
+
+            if (fmQuickAddUserPAC.Visible == false)
+            {                
+                fmQuickAddUserPAC.ShowDialog();                
+            }
+            else
+            {
+                fmQuickAddUserPAC.Activate();
+            }
+            
+            if (fmQuickAddUserPAC.DialogResult == DialogResult.OK)
+            {
+                //刷新
+                LoadV2ray();
+            }
         }
         private void SetListenerType(ListenerType type)
         {

--- a/v2rayN/v2rayN/Forms/MainForm.resx
+++ b/v2rayN/v2rayN/Forms/MainForm.resx
@@ -506,6 +506,12 @@
   <data name="menuUpdateSubscriptions.Text" xml:space="preserve">
     <value>Update subscriptions</value>
   </data>
+  <data name="menuQuicklyAddUserPAC.Size" type="System.Drawing.Size, System.Drawing">
+    <value>264, 22</value>
+  </data>
+  <data name="menuQuicklyAddUserPAC.Text" xml:space="preserve">
+    <value>Quickly add user PAC rule</value>
+  </data>
   <data name="toolStripSeparator2.Size" type="System.Drawing.Size, System.Drawing">
     <value>261, 6</value>
   </data>
@@ -516,7 +522,7 @@
     <value>Exit</value>
   </data>
   <data name="cmsMain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>265, 164</value>
+    <value>265, 208</value>
   </data>
   <data name="&gt;&gt;cmsMain.Name" xml:space="preserve">
     <value>cmsMain</value>
@@ -1248,6 +1254,12 @@
     <value>menuUpdateSubscriptions</value>
   </data>
   <data name="&gt;&gt;menuUpdateSubscriptions.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuQuicklyAddUserPAC.Name" xml:space="preserve">
+    <value>menuQuicklyAddUserPAC</value>
+  </data>
+  <data name="&gt;&gt;menuQuicklyAddUserPAC.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;toolStripSeparator2.Name" xml:space="preserve">

--- a/v2rayN/v2rayN/Forms/MainForm.zh-Hans.resx
+++ b/v2rayN/v2rayN/Forms/MainForm.zh-Hans.resx
@@ -372,6 +372,12 @@
   <data name="menuUpdateSubscriptions.Text" xml:space="preserve">
     <value>更新订阅</value>
   </data>
+  <data name="menuQuicklyAddUserPAC.Size" type="System.Drawing.Size, System.Drawing">
+    <value>195, 22</value>
+  </data>
+  <data name="menuQuicklyAddUserPAC.Text" xml:space="preserve">
+    <value>添加一条用户PAC规则</value>
+  </data>
   <data name="toolStripSeparator2.Size" type="System.Drawing.Size, System.Drawing">
     <value>192, 6</value>
   </data>

--- a/v2rayN/v2rayN/Forms/OptionSettingForm.Designer.cs
+++ b/v2rayN/v2rayN/Forms/OptionSettingForm.Designer.cs
@@ -97,6 +97,16 @@
             this.txtuserPacRule = new System.Windows.Forms.TextBox();
             this.panel4 = new System.Windows.Forms.Panel();
             this.label4 = new System.Windows.Forms.Label();
+            this.tabPage10 = new System.Windows.Forms.TabPage();
+            this.chkRegHotkeyAtStartup = new System.Windows.Forms.CheckBox();
+            this.txtHotkeyAddUserPAC = new System.Windows.Forms.TextBox();
+            this.lblHotkeyAddUserPAC = new System.Windows.Forms.Label();
+            this.txtHotkeyPACProxyMode = new System.Windows.Forms.TextBox();
+            this.lblHotkeyPACProxyMode = new System.Windows.Forms.Label();
+            this.txtHotkeyGlobalProxyMode = new System.Windows.Forms.TextBox();
+            this.lblHotkeyGlobalProxyMode = new System.Windows.Forms.Label();
+            this.txtHotkeyStopProxy = new System.Windows.Forms.TextBox();
+            this.lblHotkeyStopProxy = new System.Windows.Forms.Label();
             this.panel2 = new System.Windows.Forms.Panel();
             this.btnOK = new System.Windows.Forms.Button();
             this.panel1 = new System.Windows.Forms.Panel();
@@ -115,6 +125,7 @@
             this.tabPage7.SuspendLayout();
             this.tabPage9.SuspendLayout();
             this.panel4.SuspendLayout();
+            this.tabPage10.SuspendLayout();
             this.panel2.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -134,6 +145,7 @@
             this.tabControl1.Controls.Add(this.tabPage6);
             this.tabControl1.Controls.Add(this.tabPage7);
             this.tabControl1.Controls.Add(this.tabPage9);
+            this.tabControl1.Controls.Add(this.tabPage10);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
             // 
@@ -603,6 +615,83 @@
             this.label4.ForeColor = System.Drawing.Color.Brown;
             this.label4.Name = "label4";
             // 
+            // tabPage10
+            // 
+            resources.ApplyResources(this.tabPage10, "tabPage10");
+            this.tabPage10.Controls.Add(this.chkRegHotkeyAtStartup);
+            this.tabPage10.Controls.Add(this.txtHotkeyAddUserPAC);
+            this.tabPage10.Controls.Add(this.lblHotkeyAddUserPAC);
+            this.tabPage10.Controls.Add(this.txtHotkeyPACProxyMode);
+            this.tabPage10.Controls.Add(this.lblHotkeyPACProxyMode);
+            this.tabPage10.Controls.Add(this.txtHotkeyGlobalProxyMode);
+            this.tabPage10.Controls.Add(this.lblHotkeyGlobalProxyMode);
+            this.tabPage10.Controls.Add(this.txtHotkeyStopProxy);
+            this.tabPage10.Controls.Add(this.lblHotkeyStopProxy);
+            this.tabPage10.Name = "tabPage10";
+            this.tabPage10.UseVisualStyleBackColor = true;
+            // 
+            // chkRegHotkeyAtStartup
+            // 
+            resources.ApplyResources(this.chkRegHotkeyAtStartup, "chkRegHotkeyAtStartup");
+            this.chkRegHotkeyAtStartup.Name = "chkRegHotkeyAtStartup";
+            this.chkRegHotkeyAtStartup.UseVisualStyleBackColor = true;
+            // 
+            // txtHotkeyAddUserPAC
+            // 
+            resources.ApplyResources(this.txtHotkeyAddUserPAC, "txtHotkeyAddUserPAC");
+            this.txtHotkeyAddUserPAC.BackColor = System.Drawing.SystemColors.Window;
+            this.txtHotkeyAddUserPAC.Name = "txtHotkeyAddUserPAC";
+            this.txtHotkeyAddUserPAC.ReadOnly = true;
+            this.txtHotkeyAddUserPAC.KeyDown += new System.Windows.Forms.KeyEventHandler(this.HotkeyDown);
+            this.txtHotkeyAddUserPAC.KeyUp += new System.Windows.Forms.KeyEventHandler(this.HotkeyUp);
+            // 
+            // lblHotkeyAddUserPAC
+            // 
+            resources.ApplyResources(this.lblHotkeyAddUserPAC, "lblHotkeyAddUserPAC");
+            this.lblHotkeyAddUserPAC.Name = "lblHotkeyAddUserPAC";
+            // 
+            // txtHotkeyPACProxyMode
+            // 
+            resources.ApplyResources(this.txtHotkeyPACProxyMode, "txtHotkeyPACProxyMode");
+            this.txtHotkeyPACProxyMode.BackColor = System.Drawing.SystemColors.Window;
+            this.txtHotkeyPACProxyMode.Name = "txtHotkeyPACProxyMode";
+            this.txtHotkeyPACProxyMode.ReadOnly = true;
+            this.txtHotkeyPACProxyMode.KeyDown += new System.Windows.Forms.KeyEventHandler(this.HotkeyDown);
+            this.txtHotkeyPACProxyMode.KeyUp += new System.Windows.Forms.KeyEventHandler(this.HotkeyUp);
+            // 
+            // lblHotkeyPACProxyMode
+            // 
+            resources.ApplyResources(this.lblHotkeyPACProxyMode, "lblHotkeyPACProxyMode");
+            this.lblHotkeyPACProxyMode.Name = "lblHotkeyPACProxyMode";
+            // 
+            // txtHotkeyGlobalProxyMode
+            // 
+            resources.ApplyResources(this.txtHotkeyGlobalProxyMode, "txtHotkeyGlobalProxyMode");
+            this.txtHotkeyGlobalProxyMode.BackColor = System.Drawing.SystemColors.Window;
+            this.txtHotkeyGlobalProxyMode.Name = "txtHotkeyGlobalProxyMode";
+            this.txtHotkeyGlobalProxyMode.ReadOnly = true;
+            this.txtHotkeyGlobalProxyMode.KeyDown += new System.Windows.Forms.KeyEventHandler(this.HotkeyDown);
+            this.txtHotkeyGlobalProxyMode.KeyUp += new System.Windows.Forms.KeyEventHandler(this.HotkeyUp);
+            // 
+            // lblHotkeyGlobalProxyMode
+            // 
+            resources.ApplyResources(this.lblHotkeyGlobalProxyMode, "lblHotkeyGlobalProxyMode");
+            this.lblHotkeyGlobalProxyMode.Name = "lblHotkeyGlobalProxyMode";
+            // 
+            // txtHotkeyStopProxy
+            // 
+            resources.ApplyResources(this.txtHotkeyStopProxy, "txtHotkeyStopProxy");
+            this.txtHotkeyStopProxy.BackColor = System.Drawing.SystemColors.Window;
+            this.txtHotkeyStopProxy.Name = "txtHotkeyStopProxy";
+            this.txtHotkeyStopProxy.ReadOnly = true;
+            this.txtHotkeyStopProxy.KeyDown += new System.Windows.Forms.KeyEventHandler(this.HotkeyDown);
+            this.txtHotkeyStopProxy.KeyUp += new System.Windows.Forms.KeyEventHandler(this.HotkeyUp);
+            // 
+            // lblHotkeyStopProxy
+            // 
+            resources.ApplyResources(this.lblHotkeyStopProxy, "lblHotkeyStopProxy");
+            this.lblHotkeyStopProxy.Name = "lblHotkeyStopProxy";
+            // 
             // panel2
             // 
             resources.ApplyResources(this.panel2, "panel2");
@@ -656,6 +745,8 @@
             this.tabPage9.ResumeLayout(false);
             this.tabPage9.PerformLayout();
             this.panel4.ResumeLayout(false);
+            this.tabPage10.ResumeLayout(false);
+            this.tabPage10.PerformLayout();
             this.panel2.ResumeLayout(false);
             this.ResumeLayout(false);
 
@@ -734,5 +825,15 @@
         private System.Windows.Forms.CheckBox chkKeepOlderDedupl;
         private System.Windows.Forms.LinkLabel linkLabelRoutingDoc;
         private System.Windows.Forms.CheckBox chkdefAllowInsecure;
+        private System.Windows.Forms.TabPage tabPage10;
+        private System.Windows.Forms.TextBox txtHotkeyAddUserPAC;
+        private System.Windows.Forms.Label lblHotkeyAddUserPAC;
+        private System.Windows.Forms.TextBox txtHotkeyPACProxyMode;
+        private System.Windows.Forms.Label lblHotkeyPACProxyMode;
+        private System.Windows.Forms.TextBox txtHotkeyGlobalProxyMode;
+        private System.Windows.Forms.Label lblHotkeyGlobalProxyMode;
+        private System.Windows.Forms.TextBox txtHotkeyStopProxy;
+        private System.Windows.Forms.Label lblHotkeyStopProxy;
+        private System.Windows.Forms.CheckBox chkRegHotkeyAtStartup;
     }
 }

--- a/v2rayN/v2rayN/Forms/OptionSettingForm.resx
+++ b/v2rayN/v2rayN/Forms/OptionSettingForm.resx
@@ -118,1954 +118,2197 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="chkAllowIn2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;txtKcpwriteBufferSize.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="panel2.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;txtremoteDNS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabControl2.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;labRoutingTips.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="label13.Location" type="System.Drawing.Point, System.Drawing">
-    <value>30, 176</value>
-  </data>
-  <data name="chklogEnabled.Text" xml:space="preserve">
-    <value>Record local logs</value>
-  </data>
-  <data name="tabPage4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>634, 460</value>
-  </data>
-  <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
+  <data name="groupBox2.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
   </data>
-  <data name="tabPage6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;label11.Parent" xml:space="preserve">
+    <value>tabPage6</value>
   </data>
-  <data name="&gt;&gt;txtKcpwriteBufferSize.Name" xml:space="preserve">
-    <value>txtKcpwriteBufferSize</value>
-  </data>
-  <data name="&gt;&gt;txtuserPacRule.Name" xml:space="preserve">
-    <value>txtuserPacRule</value>
-  </data>
-  <data name="&gt;&gt;lbFreshrate.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="label3.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;chkAllowLANConn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabPage6.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="txtKcpmtu.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="txtKcpwriteBufferSize.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 21</value>
-  </data>
-  <data name="txtKcpuplinkCapacity.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;chkudpEnabled.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;txtuserPacRule.Parent" xml:space="preserve">
-    <value>tabPage9</value>
-  </data>
-  <data name="&gt;&gt;label3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;linkLabelRoutingDoc.Name" xml:space="preserve">
-    <value>linkLabelRoutingDoc</value>
-  </data>
-  <data name="chksniffingEnabled2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>468, 60</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="panel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="chkdefAllowInsecure.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 16</value>
-  </data>
-  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;txtKcptti.Name" xml:space="preserve">
-    <value>txtKcptti</value>
-  </data>
-  <data name="&gt;&gt;tabPage3.Name" xml:space="preserve">
-    <value>tabPage3</value>
-  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="tabPage9.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="&gt;&gt;cmblistenerType.Name" xml:space="preserve">
-    <value>cmblistenerType</value>
-  </data>
-  <data name="tabPage3.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="tabPage5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>634, 460</value>
-  </data>
-  <data name="txtUseragent.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="txtKcpreadBufferSize.Location" type="System.Drawing.Point, System.Drawing">
-    <value>111, 100</value>
-  </data>
-  <data name="label14.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;label14.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="txtUserblock.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="labRoutingTips.Size" type="System.Drawing.Size, System.Drawing">
-    <value>598, 16</value>
-  </data>
-  <data name="tabPage1.Text" xml:space="preserve">
-    <value>Core: basic settings</value>
-  </data>
-  <data name="chkEnableStatistics.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chksniffingEnabled.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 16</value>
-  </data>
-  <data name="label14.Size" type="System.Drawing.Size, System.Drawing">
-    <value>281, 12</value>
-  </data>
-  <data name="&gt;&gt;labRoutingTips.Parent" xml:space="preserve">
-    <value>panel3</value>
-  </data>
-  <data name="chksniffingEnabled2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label7.Text" xml:space="preserve">
-    <value>tti</value>
-  </data>
-  <data name="&gt;&gt;chksniffingEnabled2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkudpEnabled.Size" type="System.Drawing.Size, System.Drawing">
-    <value>84, 16</value>
-  </data>
-  <data name="&gt;&gt;chklogEnabled.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="label16.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 12</value>
-  </data>
-  <data name="txtUserdirect.Size" type="System.Drawing.Size, System.Drawing">
-    <value>628, 454</value>
-  </data>
-  <data name="&gt;&gt;chkAutoRun.Parent" xml:space="preserve">
-    <value>tabPage7</value>
-  </data>
-  <data name="cmblistenerType.Items4" xml:space="preserve">
-    <value>Only open PAC, do not automatically configure PAC</value>
-  </data>
-  <data name="label11.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="panel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>662, 60</value>
-  </data>
-  <data name="panel4.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
-  </data>
-  <data name="cmbprotocol2.Items1" xml:space="preserve">
-    <value>http</value>
-  </data>
-  <data name="txtKcptti.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;chkdefAllowInsecure.Name" xml:space="preserve">
-    <value>chkdefAllowInsecure</value>
-  </data>
-  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>648, 573</value>
-  </data>
-  <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>206, 64</value>
-  </data>
-  <data name="label10.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 12</value>
-  </data>
-  <data name="&gt;&gt;txtKcpdownlinkCapacity.Parent" xml:space="preserve">
-    <value>tabPage6</value>
-  </data>
-  <data name="label10.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;btnSetDefRountingRule.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkAllowIn2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 63</value>
-  </data>
-  <data name="&gt;&gt;tabPage4.Parent" xml:space="preserve">
-    <value>tabControl2</value>
-  </data>
-  <data name="label3.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;txtUserdirect.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="txtUserdirect.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="chkudpEnabled2.Text" xml:space="preserve">
-    <value>Enable UDP</value>
-  </data>
-  <data name="txtKcpdownlinkCapacity.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 21</value>
-  </data>
-  <data name="&gt;&gt;txtlocalPort2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="groupBox2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="btnClose.Text" xml:space="preserve">
-    <value>&amp;Cancel</value>
-  </data>
-  <data name="&gt;&gt;label10.Name" xml:space="preserve">
-    <value>label10</value>
-  </data>
-  <data name="groupBox2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>648, 573</value>
-  </data>
-  <data name="txtUseragent.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
-    <value>Vertical</value>
-  </data>
-  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
+  <data name="&gt;&gt;cmbprotocol.Parent" xml:space="preserve">
     <value>groupBox1</value>
   </data>
   <data name="&gt;&gt;chkudpEnabled2.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="txtuserPacRule.MaxLength" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;panel4.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="cmbroutingMode.Items1" xml:space="preserve">
-    <value>Bypassing the LAN address</value>
-  </data>
-  <data name="&gt;&gt;chkAllowIn2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="cmbroutingMode.Items3" xml:space="preserve">
-    <value>Bypassing LAN and mainland address</value>
-  </data>
-  <data name="cmbroutingMode.Items2" xml:space="preserve">
-    <value>Bypass mainland address</value>
-  </data>
-  <data name="panel3.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="groupBox2.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;txtKcpmtu.Name" xml:space="preserve">
-    <value>txtKcpmtu</value>
-  </data>
-  <data name="&gt;&gt;lbFreshrate.Name" xml:space="preserve">
-    <value>lbFreshrate</value>
-  </data>
-  <data name="tabPage2.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;label11.Name" xml:space="preserve">
-    <value>label11</value>
-  </data>
-  <data name="chkEnableStatistics.TabIndex" type="System.Int32, mscorlib">
-    <value>29</value>
-  </data>
-  <data name="&gt;&gt;panel3.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="label16.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="chksniffingEnabled2.Text" xml:space="preserve">
-    <value>Turn on Sniffing</value>
-  </data>
-  <data name="cmblistenerType.Items3" xml:space="preserve">
-    <value>Only open Http proxy, do not automatically configure proxy server (direct mode)</value>
-  </data>
-  <data name="chkAllowIn2.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="label6.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;txtKcpwriteBufferSize.Parent" xml:space="preserve">
-    <value>tabPage6</value>
-  </data>
-  <data name="chksniffingEnabled2.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;tabPage3.Parent" xml:space="preserve">
-    <value>tabControl2</value>
-  </data>
-  <data name="&gt;&gt;btnSetDefRountingRule.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;tabControl1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;chkmuxEnabled.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;cmbdomainStrategy.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;chkAllowLANConn.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;label7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtuserPacRule.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="label11.Text" xml:space="preserve">
-    <value>readBufferSize</value>
-  </data>
-  <data name="&gt;&gt;groupBox2.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;label7.Parent" xml:space="preserve">
-    <value>tabPage6</value>
-  </data>
-  <data name="tabPage8.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="chkAutoRun.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chkudpEnabled2.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="txtuserPacRule.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="&gt;&gt;label10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="txturlGFWList.Multiline" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chkKcpcongestion.Text" xml:space="preserve">
-    <value>congestion</value>
-  </data>
-  <data name="chkdefAllowInsecure.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;cmbprotocol2.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;cmbdomainStrategy.Parent" xml:space="preserve">
-    <value>panel3</value>
-  </data>
-  <data name="&gt;&gt;btnClose.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="tabPage8.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>89, 12</value>
-  </data>
-  <data name="cmbloglevel.Items1" xml:space="preserve">
-    <value>info</value>
-  </data>
-  <data name="&gt;&gt;txtUseragent.Name" xml:space="preserve">
-    <value>txtUseragent</value>
-  </data>
-  <data name="&gt;&gt;tabPage4.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;chkEnableStatistics.Parent" xml:space="preserve">
-    <value>tabPage7</value>
-  </data>
-  <data name="tabPage7.Text" xml:space="preserve">
-    <value>v2rayN settings</value>
-  </data>
-  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>20</value>
-  </data>
-  <data name="&gt;&gt;chkdefAllowInsecure.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;chklogEnabled.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="cmblistenerType.Items" xml:space="preserve">
-    <value>Not Enabled Http Proxy</value>
-  </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="chksniffingEnabled2.TabIndex" type="System.Int32, mscorlib">
-    <value>32</value>
-  </data>
-  <data name="txtUserblock.Size" type="System.Drawing.Size, System.Drawing">
-    <value>628, 454</value>
-  </data>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 12</value>
-  </data>
-  <data name="&gt;&gt;chkudpEnabled2.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;tabPage4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmbdomainStrategy.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtKcpdownlinkCapacity.Name" xml:space="preserve">
-    <value>txtKcpdownlinkCapacity</value>
-  </data>
-  <data name="chkKeepOlderDedupl.Size" type="System.Drawing.Size, System.Drawing">
-    <value>198, 16</value>
-  </data>
-  <data name="chkAutoRun.Text" xml:space="preserve">
-    <value>Automatically start at system startup</value>
-  </data>
-  <data name="tabPage2.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="&gt;&gt;txtKcpwriteBufferSize.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="label16.Text" xml:space="preserve">
-    <value>Http proxy</value>
-  </data>
-  <data name="tabPage9.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;chkAllowIn2.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;label11.Parent" xml:space="preserve">
-    <value>tabPage6</value>
-  </data>
-  <data name="btnClose.Location" type="System.Drawing.Point, System.Drawing">
-    <value>355, 16</value>
-  </data>
-  <data name="tabPage1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="cmbprotocol.Size" type="System.Drawing.Size, System.Drawing">
-    <value>97, 20</value>
-  </data>
-  <data name="tabPage7.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="tabControl1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>662, 605</value>
-  </data>
-  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>33, 29</value>
-  </data>
-  <data name="&gt;&gt;label16.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="txtlocalPort.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 21</value>
-  </data>
-  <data name="labRoutingTips.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 45</value>
-  </data>
-  <data name="label14.Text" xml:space="preserve">
-    <value>Custom DNS (multiple, separated by commas (,))</value>
-  </data>
-  <data name="&gt;&gt;tabPage1.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;chkmuxEnabled.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>598, 16</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>v2rayN.Forms.BaseForm, v2rayN, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="cmbloglevel.Items2" xml:space="preserve">
-    <value>warning</value>
-  </data>
-  <data name="&gt;&gt;label14.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;tabPage3.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txturlGFWList.Parent" xml:space="preserve">
-    <value>tabPage7</value>
-  </data>
-  <data name="lbFreshrate.Text" xml:space="preserve">
-    <value>Statistics freshrate</value>
-  </data>
-  <data name="&gt;&gt;label5.Name" xml:space="preserve">
-    <value>label5</value>
-  </data>
-  <data name="chkAllowIn2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 16</value>
-  </data>
-  <data name="chkKcpcongestion.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
-  </data>
-  <data name="label11.Size" type="System.Drawing.Size, System.Drawing">
-    <value>89, 12</value>
-  </data>
-  <data name="cmblistenerType.Items5" xml:space="preserve">
-    <value>Only open Http proxy and do nothing</value>
-  </data>
-  <data name="&gt;&gt;tabPage5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label9.Location" type="System.Drawing.Point, System.Drawing">
-    <value>18, 66</value>
-  </data>
-  <data name="chkKcpcongestion.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 143</value>
-  </data>
-  <data name="txtKcpdownlinkCapacity.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="&gt;&gt;txtKcpuplinkCapacity.Parent" xml:space="preserve">
-    <value>tabPage6</value>
-  </data>
-  <data name="&gt;&gt;btnClose.Name" xml:space="preserve">
-    <value>btnClose</value>
-  </data>
-  <data name="chksniffingEnabled.Text" xml:space="preserve">
-    <value>Turn on Sniffing</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>18, 28</value>
-  </data>
-  <data name="txtremoteDNS.TabIndex" type="System.Int32, mscorlib">
-    <value>30</value>
-  </data>
-  <data name="label16.TabIndex" type="System.Int32, mscorlib">
-    <value>34</value>
-  </data>
-  <data name="chkmuxEnabled.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
-  </data>
-  <data name="chkAllowLANConn.TabIndex" type="System.Int32, mscorlib">
-    <value>29</value>
-  </data>
-  <data name="txtUseragent.MaxLength" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="cmbroutingMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>21, 17</value>
-  </data>
-  <data name="&gt;&gt;labRoutingTips.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmblistenerType.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;tabPage1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="txtlocalPort2.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="panel3.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="tabPage3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="label4.Text" xml:space="preserve">
-    <value>*Set user pac rules, separated by commas (,)</value>
-  </data>
-  <data name="label8.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;chksniffingEnabled.Name" xml:space="preserve">
-    <value>chksniffingEnabled</value>
-  </data>
-  <data name="&gt;&gt;label14.ZOrder" xml:space="preserve">
+  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
-  </data>
-  <data name="chkmuxEnabled.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 16</value>
-  </data>
-  <data name="cmbdomainStrategy.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;chkdefAllowInsecure.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="label11.Location" type="System.Drawing.Point, System.Drawing">
-    <value>18, 104</value>
-  </data>
-  <data name="&gt;&gt;tabPage2.Name" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="chkKeepOlderDedupl.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="cmbprotocol2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>97, 20</value>
-  </data>
-  <data name="cmbprotocol2.Items" xml:space="preserve">
-    <value>socks</value>
-  </data>
-  <data name="&gt;&gt;tabPage5.Name" xml:space="preserve">
-    <value>tabPage5</value>
-  </data>
-  <data name="chkEnableStatistics.Size" type="System.Drawing.Size, System.Drawing">
-    <value>576, 16</value>
-  </data>
-  <data name="&gt;&gt;txtKcpmtu.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="cmblistenerType.Size" type="System.Drawing.Size, System.Drawing">
-    <value>464, 20</value>
-  </data>
-  <data name="&gt;&gt;cmbprotocol2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabPage9.Name" xml:space="preserve">
-    <value>tabPage9</value>
-  </data>
-  <data name="txtremoteDNS.Multiline" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;label10.Parent" xml:space="preserve">
-    <value>tabPage6</value>
-  </data>
-  <data name="labRoutingTips.Text" xml:space="preserve">
-    <value>*Set the rules, separated by commas (,); support Domain (pure string / regular / subdomain) and IP</value>
-  </data>
-  <data name="&gt;&gt;txtUseragent.Parent" xml:space="preserve">
-    <value>tabPage3</value>
-  </data>
-  <data name="lbFreshrate.TabIndex" type="System.Int32, mscorlib">
-    <value>30</value>
-  </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>53, 12</value>
-  </data>
-  <data name="&gt;&gt;cmbloglevel.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;label8.Name" xml:space="preserve">
-    <value>label8</value>
-  </data>
-  <data name="chksniffingEnabled.Location" type="System.Drawing.Point, System.Drawing">
-    <value>468, 27</value>
-  </data>
-  <data name="&gt;&gt;label13.Name" xml:space="preserve">
-    <value>label13</value>
-  </data>
-  <data name="&gt;&gt;chkAutoRun.Name" xml:space="preserve">
-    <value>chkAutoRun</value>
-  </data>
-  <data name="&gt;&gt;tabPage8.Parent" xml:space="preserve">
-    <value>tabControl2</value>
-  </data>
-  <data name="tabPage9.Size" type="System.Drawing.Size, System.Drawing">
-    <value>654, 579</value>
-  </data>
-  <data name="&gt;&gt;txtuserPacRule.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="txtKcpdownlinkCapacity.Location" type="System.Drawing.Point, System.Drawing">
-    <value>345, 62</value>
-  </data>
-  <data name="&gt;&gt;chkudpEnabled.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="tabControl2.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="txtUserblock.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;chkudpEnabled.Name" xml:space="preserve">
-    <value>chkudpEnabled</value>
-  </data>
-  <data name="label10.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label14.Location" type="System.Drawing.Point, System.Drawing">
-    <value>33, 253</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="&gt;&gt;txtKcpdownlinkCapacity.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;txtKcpreadBufferSize.Parent" xml:space="preserve">
-    <value>tabPage6</value>
-  </data>
-  <data name="&gt;&gt;tabPage6.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;btnOK.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtremoteDNS.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;btnSetDefRountingRule.Name" xml:space="preserve">
-    <value>btnSetDefRountingRule</value>
-  </data>
-  <data name="txtUserblock.Multiline" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;txturlGFWList.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="cbFreshrate.TabIndex" type="System.Int32, mscorlib">
-    <value>32</value>
-  </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
-  </data>
-  <data name="chkKcpcongestion.Size" type="System.Drawing.Size, System.Drawing">
-    <value>84, 16</value>
-  </data>
-  <data name="&gt;&gt;cmbroutingMode.Parent" xml:space="preserve">
-    <value>tabPage8</value>
-  </data>
-  <data name="chklogEnabled.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
-    <value>panel4</value>
-  </data>
-  <data name="&gt;&gt;label7.Name" xml:space="preserve">
-    <value>label7</value>
-  </data>
-  <data name="chkdefAllowInsecure.Text" xml:space="preserve">
-    <value>allowInsecure</value>
-  </data>
-  <data name="&gt;&gt;txtlocalPort.Name" xml:space="preserve">
-    <value>txtlocalPort</value>
-  </data>
-  <data name="btnSetDefRountingRule.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cbFreshrate.Parent" xml:space="preserve">
-    <value>tabPage7</value>
-  </data>
-  <data name="panel3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 17</value>
-  </data>
-  <data name="txtuserPacRule.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 40</value>
-  </data>
-  <data name="&gt;&gt;labRoutingTips.Name" xml:space="preserve">
-    <value>labRoutingTips</value>
-  </data>
-  <data name="&gt;&gt;tabPage2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="tabPage3.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="txtlocalPort.Location" type="System.Drawing.Point, System.Drawing">
-    <value>124, 25</value>
-  </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>protocol</value>
-  </data>
-  <data name="&gt;&gt;cmblistenerType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabControl2.Name" xml:space="preserve">
-    <value>tabControl2</value>
-  </data>
-  <data name="btnSetDefRountingRule.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="chkmuxEnabled.Text" xml:space="preserve">
-    <value>Turn on Mux Multiplexing </value>
-  </data>
-  <data name="label13.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>23, 12</value>
-  </data>
-  <data name="&gt;&gt;cmbloglevel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="txtremoteDNS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>555, 100</value>
-  </data>
-  <data name="cmbprotocol.Items" xml:space="preserve">
-    <value>socks</value>
-  </data>
-  <data name="&gt;&gt;chkKeepOlderDedupl.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="&gt;&gt;label13.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkAllowLANConn.Name" xml:space="preserve">
-    <value>chkAllowLANConn</value>
-  </data>
-  <data name="chkudpEnabled2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>84, 16</value>
-  </data>
-  <data name="&gt;&gt;chkudpEnabled.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabPage9.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabControl1.Name" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="label7.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;label8.Parent" xml:space="preserve">
-    <value>tabPage6</value>
-  </data>
-  <data name="&gt;&gt;tabPage8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkAllowLANConn.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 38</value>
-  </data>
-  <data name="&gt;&gt;txtUserblock.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chksniffingEnabled2.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="chkudpEnabled.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="chkudpEnabled2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>369, 62</value>
-  </data>
-  <data name="&gt;&gt;cmbprotocol.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="tabPage3.Text" xml:space="preserve">
-    <value>1.Proxy Domain or IP</value>
-  </data>
-  <data name="&gt;&gt;chkmuxEnabled.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;btnSetDefRountingRule.Parent" xml:space="preserve">
-    <value>panel3</value>
-  </data>
-  <data name="label4.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="tabPage2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>654, 579</value>
-  </data>
-  <data name="&gt;&gt;chkEnableStatistics.Name" xml:space="preserve">
-    <value>chkEnableStatistics</value>
-  </data>
-  <data name="cmbroutingMode.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;chkAllowIn2.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="btnClose.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="cmbprotocol.Items1" xml:space="preserve">
-    <value>http</value>
-  </data>
-  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>53, 12</value>
-  </data>
-  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>193, 162</value>
-  </data>
-  <data name="chkKeepOlderDedupl.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;label10.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="txtUserdirect.MaxLength" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtKcpuplinkCapacity.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtKcpmtu.Parent" xml:space="preserve">
-    <value>tabPage6</value>
-  </data>
-  <data name="&gt;&gt;label2.Name" xml:space="preserve">
-    <value>label2</value>
-  </data>
-  <data name="cmbdomainStrategy.Size" type="System.Drawing.Size, System.Drawing">
-    <value>165, 20</value>
-  </data>
-  <data name="txtlocalPort2.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;cmbprotocol.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtUseragent.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="txtUseragent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="chklogEnabled.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;label16.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="tabPage8.Text" xml:space="preserve">
-    <value>4.Pre-defined rules</value>
-  </data>
-  <data name="label8.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 12</value>
-  </data>
-  <data name="&gt;&gt;chkEnableStatistics.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="cmbprotocol.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="label13.Size" type="System.Drawing.Size, System.Drawing">
-    <value>431, 12</value>
-  </data>
-  <data name="linkLabelRoutingDoc.Text" xml:space="preserve">
-    <value>Domain strategy</value>
-  </data>
-  <data name="&gt;&gt;cmbprotocol.Name" xml:space="preserve">
-    <value>cmbprotocol</value>
-  </data>
-  <data name="panel4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>648, 37</value>
-  </data>
-  <data name="txtUseragent.Multiline" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chkEnableStatistics.Text" xml:space="preserve">
-    <value>Enable Statistics (Realtime netspeed and traffic records. Require restart the v2rayN client)</value>
-  </data>
-  <data name="&gt;&gt;tabControl2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label11.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
     <value>Listening port</value>
   </data>
-  <data name="txtuserPacRule.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
-    <value>Vertical</value>
+  <data name="&gt;&gt;label9.ZOrder" xml:space="preserve">
+    <value>8</value>
   </data>
-  <data name="groupBox1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="txtUseragent.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="tabPage4.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;tabPage7.Name" xml:space="preserve">
+    <value>tabPage7</value>
+  </data>
+  <data name="btnClose.Location" type="System.Drawing.Point, System.Drawing">
+    <value>355, 16</value>
+  </data>
+  <data name="&gt;&gt;cbFreshrate.Parent" xml:space="preserve">
+    <value>tabPage7</value>
+  </data>
+  <data name="&gt;&gt;txtHotkeyGlobalProxyMode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="cmbloglevel.Items3" xml:space="preserve">
+    <value>error</value>
+  </data>
+  <data name="chkmuxEnabled.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 129</value>
+  </data>
+  <data name="label11.Text" xml:space="preserve">
+    <value>readBufferSize</value>
+  </data>
+  <data name="chklogEnabled.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tabPage5.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="panel2.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="label6.Text" xml:space="preserve">
+    <value>mtu</value>
+  </data>
+  <data name="&gt;&gt;txtHotkeyAddUserPAC.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="&gt;&gt;cbFreshrate.Type" xml:space="preserve">
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="txtUserblock.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
-    <value>Vertical</value>
-  </data>
-  <data name="&gt;&gt;tabPage2.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="txturlGFWList.TabIndex" type="System.Int32, mscorlib">
-    <value>28</value>
-  </data>
-  <data name="cmbprotocol2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>257, 60</value>
-  </data>
-  <data name="&gt;&gt;groupBox2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="txtKcpmtu.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 21</value>
-  </data>
-  <data name="label3.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;cmbprotocol2.Name" xml:space="preserve">
-    <value>cmbprotocol2</value>
-  </data>
-  <data name="cmblistenerType.Items1" xml:space="preserve">
-    <value>Open Http proxy and automatically configure proxy server (global mode)</value>
-  </data>
-  <data name="&gt;&gt;panel3.Parent" xml:space="preserve">
-    <value>groupBox2</value>
-  </data>
-  <data name="&gt;&gt;chkKeepOlderDedupl.Name" xml:space="preserve">
-    <value>chkKeepOlderDedupl</value>
-  </data>
-  <data name="chkmuxEnabled.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 129</value>
-  </data>
-  <data name="cmbroutingMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>255, 20</value>
-  </data>
-  <data name="label6.Text" xml:space="preserve">
-    <value>mtu</value>
-  </data>
-  <data name="chkudpEnabled2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chkKcpcongestion.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chksniffingEnabled.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;chkKcpcongestion.Name" xml:space="preserve">
-    <value>chkKcpcongestion</value>
-  </data>
-  <data name="&gt;&gt;label16.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;chkKcpcongestion.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="cmbprotocol.Location" type="System.Drawing.Point, System.Drawing">
-    <value>257, 25</value>
-  </data>
-  <data name="tabControl2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 84</value>
-  </data>
-  <data name="&gt;&gt;cmblistenerType.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="panel4.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="chkAllowIn2.Text" xml:space="preserve">
-    <value>listening port 2</value>
-  </data>
-  <data name="cmbloglevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>97, 20</value>
-  </data>
-  <data name="&gt;&gt;chkAllowIn2.Name" xml:space="preserve">
-    <value>chkAllowIn2</value>
-  </data>
-  <data name="&gt;&gt;groupBox2.Parent" xml:space="preserve">
-    <value>tabPage2</value>
-  </data>
-  <data name="&gt;&gt;panel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="txtUserdirect.Multiline" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chkAllowLANConn.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="cmbprotocol2.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
   <data name="&gt;&gt;tabPage8.ZOrder" xml:space="preserve">
     <value>3</value>
-  </data>
-  <data name="chkKeepOlderDedupl.TabIndex" type="System.Int32, mscorlib">
-    <value>33</value>
-  </data>
-  <data name="tabPage1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="panel1.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="txturlGFWList.Size" type="System.Drawing.Size, System.Drawing">
-    <value>541, 100</value>
-  </data>
-  <data name="tabPage6.Text" xml:space="preserve">
-    <value>Core: KCP settings</value>
-  </data>
-  <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="cmbloglevel.Items3" xml:space="preserve">
-    <value>error</value>
-  </data>
-  <data name="chklogEnabled.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 160</value>
-  </data>
-  <data name="linkLabelRoutingDoc.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 12</value>
-  </data>
-  <data name="linkLabelRoutingDoc.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 14</value>
-  </data>
-  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;chkEnableStatistics.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="tabPage3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>634, 460</value>
-  </data>
-  <data name="&gt;&gt;txtlocalPort2.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="chksniffingEnabled2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 16</value>
-  </data>
-  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>662, 10</value>
-  </data>
-  <data name="&gt;&gt;txtlocalPort2.Name" xml:space="preserve">
-    <value>txtlocalPort2</value>
-  </data>
-  <data name="cmblistenerType.Items6" xml:space="preserve">
-    <value>Only open PAC and do nothing</value>
-  </data>
-  <data name="label9.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="tabControl2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="&gt;&gt;txtremoteDNS.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="tabPage7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>654, 579</value>
-  </data>
-  <data name="&gt;&gt;txtKcpuplinkCapacity.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="label13.TabIndex" type="System.Int32, mscorlib">
-    <value>27</value>
-  </data>
-  <data name="label8.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="chkudpEnabled2.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="txtUserdirect.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
-    <value>Vertical</value>
-  </data>
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>206, 29</value>
-  </data>
-  <data name="label9.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;txtUserdirect.Name" xml:space="preserve">
-    <value>txtUserdirect</value>
-  </data>
-  <data name="&gt;&gt;chkudpEnabled2.Name" xml:space="preserve">
-    <value>chkudpEnabled2</value>
-  </data>
-  <data name="&gt;&gt;tabControl2.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtUserdirect.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="txtuserPacRule.Size" type="System.Drawing.Size, System.Drawing">
-    <value>648, 536</value>
-  </data>
-  <data name="chkAllowLANConn.Text" xml:space="preserve">
-    <value>Allow connections from the LAN</value>
-  </data>
-  <data name="cbFreshrate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>161, 84</value>
-  </data>
-  <data name="&gt;&gt;panel3.Name" xml:space="preserve">
-    <value>panel3</value>
-  </data>
-  <data name="&gt;&gt;linkLabelRoutingDoc.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;chkKcpcongestion.Parent" xml:space="preserve">
-    <value>tabPage6</value>
-  </data>
-  <data name="&gt;&gt;tabPage5.Parent" xml:space="preserve">
-    <value>tabControl2</value>
-  </data>
-  <data name="lbFreshrate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>30, 87</value>
-  </data>
-  <data name="&gt;&gt;txtKcpreadBufferSize.Name" xml:space="preserve">
-    <value>txtKcpreadBufferSize</value>
-  </data>
-  <data name="&gt;&gt;chksniffingEnabled.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;btnClose.Parent" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;tabPage7.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="btnOK.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="chkdefAllowInsecure.TabIndex" type="System.Int32, mscorlib">
-    <value>35</value>
-  </data>
-  <data name="&gt;&gt;tabPage6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="tabPage9.Text" xml:space="preserve">
-    <value>User PAC settings</value>
-  </data>
-  <data name="linkLabelRoutingDoc.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 12</value>
-  </data>
-  <data name="&gt;&gt;lbFreshrate.Parent" xml:space="preserve">
-    <value>tabPage7</value>
-  </data>
-  <data name="&gt;&gt;cmbprotocol2.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="cmbloglevel.Items4" xml:space="preserve">
-    <value>none</value>
   </data>
   <data name="label5.Text" xml:space="preserve">
     <value>Log level</value>
   </data>
-  <data name="&gt;&gt;tabPage2.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="label3.Text" xml:space="preserve">
-    <value>protocol</value>
-  </data>
-  <data name="label7.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;tabPage4.Name" xml:space="preserve">
-    <value>tabPage4</value>
-  </data>
-  <data name="lbFreshrate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="tabPage6.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="cmbdomainStrategy.Items" xml:space="preserve">
-    <value>AsIs</value>
-  </data>
-  <data name="chkEnableStatistics.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 62</value>
-  </data>
-  <data name="&gt;&gt;chkAutoRun.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;label13.Parent" xml:space="preserve">
-    <value>tabPage7</value>
-  </data>
-  <data name="tabControl2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>642, 486</value>
-  </data>
-  <data name="tabPage8.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="cbFreshrate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 20</value>
-  </data>
-  <data name="&gt;&gt;txtlocalPort.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;panel2.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="label16.Location" type="System.Drawing.Point, System.Drawing">
-    <value>42, 98</value>
-  </data>
-  <data name="txtKcpreadBufferSize.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="labRoutingTips.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="tabPage5.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="label8.Text" xml:space="preserve">
-    <value>downlinkCapacity</value>
-  </data>
-  <data name="label11.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="txtlocalPort2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 21</value>
-  </data>
-  <data name="&gt;&gt;chkKeepOlderDedupl.Parent" xml:space="preserve">
-    <value>tabPage7</value>
-  </data>
-  <data name="chkdefAllowInsecure.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="linkLabelRoutingDoc.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;tabControl1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label5.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;cmbroutingMode.Name" xml:space="preserve">
-    <value>cmbroutingMode</value>
-  </data>
-  <data name="&gt;&gt;label9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="txtUserdirect.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>23, 12</value>
-  </data>
-  <data name="chkmuxEnabled.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label5.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="chkudpEnabled.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="tabPage4.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="label13.Text" xml:space="preserve">
-    <value>Custom GFWList address (please fill in the blank without customization)</value>
-  </data>
-  <data name="txtKcpwriteBufferSize.Location" type="System.Drawing.Point, System.Drawing">
-    <value>345, 100</value>
-  </data>
-  <data name="&gt;&gt;linkLabelRoutingDoc.Parent" xml:space="preserve">
-    <value>panel3</value>
-  </data>
-  <data name="btnClose.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
-  <data name="tabPage6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>654, 579</value>
-  </data>
-  <data name="tabControl1.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="chkAllowLANConn.Size" type="System.Drawing.Size, System.Drawing">
-    <value>204, 16</value>
-  </data>
-  <data name="cmbprotocol2.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="txtUseragent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>628, 454</value>
-  </data>
-  <data name="cmbloglevel.Items" xml:space="preserve">
-    <value>debug</value>
-  </data>
-  <data name="&gt;&gt;lbFreshrate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label13.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;btnOK.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;txtUserblock.Name" xml:space="preserve">
-    <value>txtUserblock</value>
-  </data>
-  <data name="btnSetDefRountingRule.Size" type="System.Drawing.Size, System.Drawing">
-    <value>229, 23</value>
-  </data>
-  <data name="&gt;&gt;txtKcpreadBufferSize.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabPage1.Name" xml:space="preserve">
-    <value>tabPage1</value>
-  </data>
-  <data name="txtKcpwriteBufferSize.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;tabPage5.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;tabPage3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnClose.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;txtKcpmtu.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="btnSetDefRountingRule.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="chklogEnabled.Size" type="System.Drawing.Size, System.Drawing">
-    <value>126, 16</value>
-  </data>
-  <data name="txtKcptti.Location" type="System.Drawing.Point, System.Drawing">
-    <value>345, 24</value>
-  </data>
-  <data name="chksniffingEnabled2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="tabPage4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="&gt;&gt;cmbdomainStrategy.Name" xml:space="preserve">
-    <value>cmbdomainStrategy</value>
-  </data>
-  <data name="cmbprotocol.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="cmbloglevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>257, 158</value>
-  </data>
-  <data name="&gt;&gt;txtlocalPort.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="btnOK.Text" xml:space="preserve">
-    <value>&amp;OK</value>
-  </data>
-  <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="tabPage8.Size" type="System.Drawing.Size, System.Drawing">
-    <value>634, 460</value>
-  </data>
-  <data name="&gt;&gt;panel2.Name" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="&gt;&gt;txtKcpuplinkCapacity.Name" xml:space="preserve">
-    <value>txtKcpuplinkCapacity</value>
-  </data>
-  <data name="cmbdomainStrategy.Location" type="System.Drawing.Point, System.Drawing">
-    <value>115, 10</value>
-  </data>
-  <data name="&gt;&gt;linkLabelRoutingDoc.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtUserdirect.Parent" xml:space="preserve">
-    <value>tabPage4</value>
-  </data>
-  <data name="&gt;&gt;chklogEnabled.Name" xml:space="preserve">
-    <value>chklogEnabled</value>
-  </data>
-  <data name="&gt;&gt;chksniffingEnabled2.Name" xml:space="preserve">
-    <value>chksniffingEnabled2</value>
-  </data>
-  <data name="&gt;&gt;tabPage7.Name" xml:space="preserve">
-    <value>tabPage7</value>
-  </data>
-  <data name="panel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>642, 67</value>
-  </data>
-  <data name="&gt;&gt;cmbroutingMode.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tabPage2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;panel4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtUserblock.Parent" xml:space="preserve">
-    <value>tabPage5</value>
-  </data>
-  <data name="&gt;&gt;chkudpEnabled2.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;label5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="cmbdomainStrategy.Items1" xml:space="preserve">
-    <value>IPIfNonMatch</value>
-  </data>
-  <data name="&gt;&gt;cmbloglevel.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="tabPage7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="chkAutoRun.TabIndex" type="System.Int32, mscorlib">
-    <value>23</value>
-  </data>
-  <data name="tabPage5.Text" xml:space="preserve">
-    <value>3.Block Domain or IP</value>
-  </data>
-  <data name="&gt;&gt;label3.Name" xml:space="preserve">
-    <value>label3</value>
-  </data>
-  <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="label8.Location" type="System.Drawing.Point, System.Drawing">
-    <value>236, 66</value>
-  </data>
-  <data name="&gt;&gt;chkAllowLANConn.Parent" xml:space="preserve">
-    <value>tabPage7</value>
-  </data>
-  <data name="&gt;&gt;panel2.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;chklogEnabled.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="lbFreshrate.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;label9.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;txtremoteDNS.Name" xml:space="preserve">
-    <value>txtremoteDNS</value>
-  </data>
-  <data name="groupBox2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="panel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 615</value>
-  </data>
-  <data name="chkAllowIn2.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="cmblistenerType.TabIndex" type="System.Int32, mscorlib">
-    <value>33</value>
-  </data>
-  <data name="txtKcptti.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 21</value>
-  </data>
-  <data name="tabPage5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="label10.Text" xml:space="preserve">
-    <value>writeBufferSize</value>
-  </data>
-  <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;panel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="label9.Size" type="System.Drawing.Size, System.Drawing">
-    <value>89, 12</value>
-  </data>
-  <data name="&gt;&gt;label6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtUserblock.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="chksniffingEnabled.TabIndex" type="System.Int32, mscorlib">
-    <value>31</value>
-  </data>
-  <data name="chkudpEnabled.Location" type="System.Drawing.Point, System.Drawing">
-    <value>369, 27</value>
-  </data>
-  <data name="&gt;&gt;tabPage9.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;label4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="tabControl1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="&gt;&gt;tabPage6.Name" xml:space="preserve">
-    <value>tabPage6</value>
-  </data>
-  <data name="&gt;&gt;txtlocalPort2.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;chksniffingEnabled2.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="&gt;&gt;txtKcpdownlinkCapacity.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel4.Name" xml:space="preserve">
-    <value>panel4</value>
-  </data>
-  <data name="label6.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label14.TabIndex" type="System.Int32, mscorlib">
-    <value>29</value>
-  </data>
-  <data name="txtUserblock.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="txtuserPacRule.Multiline" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="txtUserdirect.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>OptionSettingForm</value>
-  </data>
-  <data name="cmblistenerType.Location" type="System.Drawing.Point, System.Drawing">
-    <value>124, 94</value>
-  </data>
-  <data name="tabPage2.Text" xml:space="preserve">
-    <value>Core: Routing settings</value>
-  </data>
-  <data name="label4.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;tabPage8.Name" xml:space="preserve">
-    <value>tabPage8</value>
-  </data>
-  <data name="label2.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="label10.Location" type="System.Drawing.Point, System.Drawing">
-    <value>236, 104</value>
-  </data>
-  <data name="&gt;&gt;txturlGFWList.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <data name="cmblistenerType.Items2" xml:space="preserve">
     <value>Open PAC and automatically configure PAC (PAC mode)</value>
   </data>
-  <data name="&gt;&gt;chkKeepOlderDedupl.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
+    <value>panel4</value>
   </data>
-  <data name="chkEnableStatistics.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="&gt;&gt;panel1.Name" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;label7.Parent" xml:space="preserve">
+    <value>tabPage6</value>
   </data>
   <data name="&gt;&gt;panel4.Parent" xml:space="preserve">
     <value>tabPage9</value>
   </data>
-  <data name="txtKcpreadBufferSize.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 21</value>
+  <data name="&gt;&gt;chksniffingEnabled.Parent" xml:space="preserve">
+    <value>groupBox1</value>
   </data>
-  <data name="btnOK.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+  <data name="&gt;&gt;tabPage3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="chkAutoRun.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 16</value>
+  <data name="tabPage2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
   </data>
-  <data name="txtremoteDNS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>33, 277</value>
+  <data name="chkdefAllowInsecure.TabIndex" type="System.Int32, mscorlib">
+    <value>35</value>
   </data>
-  <data name="&gt;&gt;txtUseragent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;chksniffingEnabled.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
-  <data name="linkLabelRoutingDoc.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
+  <data name="chkudpEnabled.Text" xml:space="preserve">
+    <value>Enable UDP</value>
   </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>662, 675</value>
+  <data name="btnSetDefRountingRule.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
   </data>
-  <data name="label9.Text" xml:space="preserve">
-    <value>uplinkCapacity</value>
+  <data name="&gt;&gt;chklogEnabled.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="cmbdomainStrategy.Items2" xml:space="preserve">
-    <value>IPOnDemand</value>
-  </data>
-  <data name="chksniffingEnabled.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label16.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="cmbloglevel.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;cbFreshrate.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;chkKeepOlderDedupl.Name" xml:space="preserve">
+    <value>chkKeepOlderDedupl</value>
   </data>
   <data name="&gt;&gt;tabControl1.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="$this.Text" xml:space="preserve">
-    <value>Settings</value>
-  </data>
-  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tabPage6.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="panel4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="txturlGFWList.Location" type="System.Drawing.Point, System.Drawing">
-    <value>32, 205</value>
-  </data>
-  <data name="&gt;&gt;cmbloglevel.Name" xml:space="preserve">
-    <value>cmbloglevel</value>
-  </data>
-  <data name="txtKcpuplinkCapacity.Location" type="System.Drawing.Point, System.Drawing">
-    <value>111, 62</value>
+  <data name="txtremoteDNS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>33, 277</value>
   </data>
   <data name="&gt;&gt;tabPage9.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;label4.Name" xml:space="preserve">
-    <value>label4</value>
+  <data name="&gt;&gt;linkLabelRoutingDoc.Name" xml:space="preserve">
+    <value>linkLabelRoutingDoc</value>
   </data>
-  <data name="&gt;&gt;panel3.Type" xml:space="preserve">
+  <data name="label2.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="cmbprotocol.Location" type="System.Drawing.Point, System.Drawing">
+    <value>257, 25</value>
+  </data>
+  <data name="chkAutoRun.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 16</value>
+  </data>
+  <data name="cmbprotocol2.Items" xml:space="preserve">
+    <value>socks</value>
+  </data>
+  <data name="lbFreshrate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>125, 12</value>
+  </data>
+  <data name="&gt;&gt;cbFreshrate.Name" xml:space="preserve">
+    <value>cbFreshrate</value>
+  </data>
+  <data name="lbFreshrate.Text" xml:space="preserve">
+    <value>Statistics freshrate</value>
+  </data>
+  <data name="lblHotkeyStopProxy.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 19</value>
+  </data>
+  <data name="lblHotkeyPACProxyMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>161, 12</value>
+  </data>
+  <data name="&gt;&gt;lblHotkeyPACProxyMode.Parent" xml:space="preserve">
+    <value>tabPage10</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="label8.Text" xml:space="preserve">
+    <value>downlinkCapacity</value>
+  </data>
+  <data name="chkAllowIn2.Text" xml:space="preserve">
+    <value>listening port 2</value>
+  </data>
+  <data name="chkAllowIn2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;txtUserdirect.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panel4.Type" xml:space="preserve">
     <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;groupBox2.Name" xml:space="preserve">
+  <data name="&gt;&gt;txtlocalPort.Name" xml:space="preserve">
+    <value>txtlocalPort</value>
+  </data>
+  <data name="chkudpEnabled.Size" type="System.Drawing.Size, System.Drawing">
+    <value>84, 16</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tabPage6.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="chkAllowIn2.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;txtKcpuplinkCapacity.Parent" xml:space="preserve">
+    <value>tabPage6</value>
+  </data>
+  <data name="&gt;&gt;chksniffingEnabled.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tabPage5.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="lblHotkeyStopProxy.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;chkRegHotkeyAtStartup.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;txturlGFWList.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
+    <value>193, 162</value>
+  </data>
+  <data name="&gt;&gt;tabPage2.Name" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="&gt;&gt;linkLabelRoutingDoc.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="cmblistenerType.Items1" xml:space="preserve">
+    <value>Open Http proxy and automatically configure proxy server (global mode)</value>
+  </data>
+  <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>206, 64</value>
+  </data>
+  <data name="label9.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="tabPage10.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;btnSetDefRountingRule.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="chkudpEnabled2.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="label8.Location" type="System.Drawing.Point, System.Drawing">
+    <value>236, 66</value>
+  </data>
+  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="label11.Location" type="System.Drawing.Point, System.Drawing">
+    <value>18, 104</value>
+  </data>
+  <data name="linkLabelRoutingDoc.Size" type="System.Drawing.Size, System.Drawing">
+    <value>95, 12</value>
+  </data>
+  <data name="&gt;&gt;cmbloglevel.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;chkEnableStatistics.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;label14.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;chkKeepOlderDedupl.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="chkEnableStatistics.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 62</value>
+  </data>
+  <data name="txtlocalPort.Location" type="System.Drawing.Point, System.Drawing">
+    <value>124, 25</value>
+  </data>
+  <data name="chksniffingEnabled.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cmbroutingMode.Items1" xml:space="preserve">
+    <value>Bypassing the LAN address</value>
+  </data>
+  <data name="&gt;&gt;chkKeepOlderDedupl.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="panel3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 17</value>
+  </data>
+  <data name="cmbroutingMode.Items2" xml:space="preserve">
+    <value>Bypass mainland address</value>
+  </data>
+  <data name="labRoutingTips.Location" type="System.Drawing.Point, System.Drawing">
+    <value>5, 45</value>
+  </data>
+  <data name="panel1.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;tabPage5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtKcpreadBufferSize.Parent" xml:space="preserve">
+    <value>tabPage6</value>
+  </data>
+  <data name="tabPage1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="&gt;&gt;linkLabelRoutingDoc.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tabPage4.Name" xml:space="preserve">
+    <value>tabPage4</value>
+  </data>
+  <data name="&gt;&gt;chkEnableStatistics.Name" xml:space="preserve">
+    <value>chkEnableStatistics</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>OptionSettingForm</value>
+  </data>
+  <data name="chksniffingEnabled.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 16</value>
+  </data>
+  <data name="&gt;&gt;lbFreshrate.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;tabControl2.Parent" xml:space="preserve">
     <value>groupBox2</value>
+  </data>
+  <data name="&gt;&gt;label14.Name" xml:space="preserve">
+    <value>label14</value>
+  </data>
+  <data name="&gt;&gt;groupBox2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="txtremoteDNS.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chklogEnabled.Text" xml:space="preserve">
+    <value>Record local logs</value>
+  </data>
+  <data name="&gt;&gt;txtuserPacRule.Parent" xml:space="preserve">
+    <value>tabPage9</value>
+  </data>
+  <data name="tabPage4.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="label4.Text" xml:space="preserve">
+    <value>*Set user pac rules, separated by commas (,)</value>
+  </data>
+  <data name="&gt;&gt;txturlGFWList.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;tabPage5.Name" xml:space="preserve">
+    <value>tabPage5</value>
+  </data>
+  <data name="tabControl2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 84</value>
+  </data>
+  <data name="&gt;&gt;txturlGFWList.Parent" xml:space="preserve">
+    <value>tabPage7</value>
+  </data>
+  <data name="btnSetDefRountingRule.Size" type="System.Drawing.Size, System.Drawing">
+    <value>229, 23</value>
+  </data>
+  <data name="cmbdomainStrategy.Items2" xml:space="preserve">
+    <value>IPOnDemand</value>
+  </data>
+  <data name="&gt;&gt;labRoutingTips.Name" xml:space="preserve">
+    <value>labRoutingTips</value>
+  </data>
+  <data name="tabPage3.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="tabControl2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="&gt;&gt;tabPage2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tabPage9.Parent" xml:space="preserve">
+    <value>tabControl1</value>
+  </data>
+  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>33, 29</value>
+  </data>
+  <data name="txtKcpdownlinkCapacity.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="chkRegHotkeyAtStartup.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="chkdefAllowInsecure.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 192</value>
+  </data>
+  <data name="&gt;&gt;chkudpEnabled2.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="label13.Text" xml:space="preserve">
+    <value>Custom GFWList address (please fill in the blank without customization)</value>
+  </data>
+  <data name="btnOK.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="&gt;&gt;tabPage2.Parent" xml:space="preserve">
+    <value>tabControl1</value>
+  </data>
+  <data name="&gt;&gt;chkRegHotkeyAtStartup.Parent" xml:space="preserve">
+    <value>tabPage10</value>
+  </data>
+  <data name="&gt;&gt;tabPage8.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmbloglevel.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="tabPage6.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="&gt;&gt;chkAllowLANConn.Parent" xml:space="preserve">
+    <value>tabPage7</value>
+  </data>
+  <data name="&gt;&gt;lbFreshrate.Name" xml:space="preserve">
+    <value>lbFreshrate</value>
+  </data>
+  <data name="label5.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;txtKcpuplinkCapacity.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;chkudpEnabled.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="tabPage9.Size" type="System.Drawing.Size, System.Drawing">
+    <value>654, 579</value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="txtKcpwriteBufferSize.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="tabPage6.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tabControl1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>662, 605</value>
+  </data>
+  <data name="txtHotkeyGlobalProxyMode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>201, 50</value>
+  </data>
+  <data name="lbFreshrate.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;label10.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;panel2.Name" xml:space="preserve">
+    <value>panel2</value>
+  </data>
+  <data name="cmblistenerType.Items" xml:space="preserve">
+    <value>Not Enabled Http Proxy</value>
+  </data>
+  <data name="chksniffingEnabled.TabIndex" type="System.Int32, mscorlib">
+    <value>31</value>
+  </data>
+  <data name="&gt;&gt;btnClose.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="txtUseragent.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="labRoutingTips.Text" xml:space="preserve">
+    <value>*Set the rules, separated by commas (,); support Domain (pure string / regular / subdomain) and IP</value>
+  </data>
+  <data name="tabPage8.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="chkdefAllowInsecure.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tabPage8.Text" xml:space="preserve">
+    <value>4.Pre-defined rules</value>
+  </data>
+  <data name="&gt;&gt;txtHotkeyPACProxyMode.Name" xml:space="preserve">
+    <value>txtHotkeyPACProxyMode</value>
+  </data>
+  <data name="tabPage5.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="cmbloglevel.Items4" xml:space="preserve">
+    <value>none</value>
+  </data>
+  <data name="&gt;&gt;cmbdomainStrategy.Name" xml:space="preserve">
+    <value>cmbdomainStrategy</value>
+  </data>
+  <data name="txtKcptti.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="tabPage5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>634, 460</value>
+  </data>
+  <data name="&gt;&gt;label10.Name" xml:space="preserve">
+    <value>label10</value>
+  </data>
+  <data name="chkAllowIn2.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="txtKcpreadBufferSize.Size" type="System.Drawing.Size, System.Drawing">
+    <value>94, 21</value>
+  </data>
+  <data name="txtKcpreadBufferSize.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="tabPage5.Text" xml:space="preserve">
+    <value>3.Block Domain or IP</value>
+  </data>
+  <data name="txtlocalPort.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 21</value>
+  </data>
+  <data name="txtlocalPort.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;cmbroutingMode.Name" xml:space="preserve">
+    <value>cmbroutingMode</value>
+  </data>
+  <data name="label10.Location" type="System.Drawing.Point, System.Drawing">
+    <value>236, 104</value>
+  </data>
+  <data name="label3.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="label9.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;label11.Name" xml:space="preserve">
+    <value>label11</value>
+  </data>
+  <data name="label11.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;label16.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtHotkeyAddUserPAC.Parent" xml:space="preserve">
+    <value>tabPage10</value>
+  </data>
+  <data name="&gt;&gt;tabControl1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblHotkeyPACProxyMode.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;label14.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="txtKcpuplinkCapacity.Location" type="System.Drawing.Point, System.Drawing">
+    <value>111, 62</value>
+  </data>
+  <data name="label8.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="chklogEnabled.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 160</value>
+  </data>
+  <data name="cmbloglevel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>97, 20</value>
+  </data>
+  <data name="lblHotkeyAddUserPAC.Text" xml:space="preserve">
+    <value>Quickly add a user PAC rule</value>
+  </data>
+  <data name="&gt;&gt;label5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox2.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="chkAutoRun.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
+  </data>
+  <data name="&gt;&gt;cmbloglevel.Name" xml:space="preserve">
+    <value>cmbloglevel</value>
+  </data>
+  <data name="txtUserdirect.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
   </data>
   <data name="&gt;&gt;label16.Name" xml:space="preserve">
     <value>label16</value>
   </data>
-  <data name="&gt;&gt;btnOK.Name" xml:space="preserve">
-    <value>btnOK</value>
+  <data name="&gt;&gt;tabPage4.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="btnSetDefRountingRule.Text" xml:space="preserve">
-    <value>Set default custom routing rules</value>
+  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
+    <value>groupBox1</value>
   </data>
-  <data name="&gt;&gt;txtKcptti.Parent" xml:space="preserve">
+  <data name="chkKeepOlderDedupl.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;tabPage7.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;panel3.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;chkdefAllowInsecure.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="txtUseragent.Size" type="System.Drawing.Size, System.Drawing">
+    <value>628, 454</value>
+  </data>
+  <data name="&gt;&gt;chkudpEnabled2.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="label5.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label10.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="cbFreshrate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 20</value>
+  </data>
+  <data name="lblHotkeyPACProxyMode.Text" xml:space="preserve">
+    <value>Start using PAC proxy mode</value>
+  </data>
+  <data name="&gt;&gt;lblHotkeyStopProxy.Name" xml:space="preserve">
+    <value>lblHotkeyStopProxy</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>v2rayN.Forms.BaseForm, v2rayN, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="cbFreshrate.Location" type="System.Drawing.Point, System.Drawing">
+    <value>161, 84</value>
+  </data>
+  <data name="chksniffingEnabled.Location" type="System.Drawing.Point, System.Drawing">
+    <value>468, 27</value>
+  </data>
+  <data name="&gt;&gt;cmbprotocol2.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;cmbprotocol2.Name" xml:space="preserve">
+    <value>cmbprotocol2</value>
+  </data>
+  <data name="&gt;&gt;txtHotkeyStopProxy.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="cmbroutingMode.Items3" xml:space="preserve">
+    <value>Bypassing LAN and mainland address</value>
+  </data>
+  <data name="chkudpEnabled2.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;btnSetDefRountingRule.Name" xml:space="preserve">
+    <value>btnSetDefRountingRule</value>
+  </data>
+  <data name="&gt;&gt;chkAutoRun.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="lblHotkeyAddUserPAC.Size" type="System.Drawing.Size, System.Drawing">
+    <value>167, 12</value>
+  </data>
+  <data name="panel2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 615</value>
+  </data>
+  <data name="&gt;&gt;txtUserdirect.Name" xml:space="preserve">
+    <value>txtUserdirect</value>
+  </data>
+  <data name="chkAllowLANConn.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="panel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Bottom</value>
+  </data>
+  <data name="tabPage10.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="label7.Text" xml:space="preserve">
+    <value>tti</value>
+  </data>
+  <data name="chkEnableStatistics.Size" type="System.Drawing.Size, System.Drawing">
+    <value>576, 16</value>
+  </data>
+  <data name="&gt;&gt;txtUseragent.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tabPage5.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="&gt;&gt;tabPage1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="panel3.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="&gt;&gt;chkmuxEnabled.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;label11.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;txtKcpdownlinkCapacity.Parent" xml:space="preserve">
     <value>tabPage6</value>
   </data>
-  <data name="&gt;&gt;txturlGFWList.Name" xml:space="preserve">
-    <value>txturlGFWList</value>
+  <data name="tabPage2.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="&gt;&gt;cmbdomainStrategy.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="cmblistenerType.Items6" xml:space="preserve">
+    <value>Only open PAC and do nothing</value>
+  </data>
+  <data name="chklogEnabled.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="txtKcpwriteBufferSize.Size" type="System.Drawing.Size, System.Drawing">
+    <value>94, 21</value>
+  </data>
+  <data name="&gt;&gt;label10.Parent" xml:space="preserve">
+    <value>tabPage6</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="&gt;&gt;chklogEnabled.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="label9.Size" type="System.Drawing.Size, System.Drawing">
+    <value>89, 12</value>
+  </data>
+  <data name="tabPage9.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="txtUserblock.Size" type="System.Drawing.Size, System.Drawing">
+    <value>628, 454</value>
   </data>
   <data name="&gt;&gt;chkmuxEnabled.Name" xml:space="preserve">
     <value>chkmuxEnabled</value>
   </data>
+  <data name="&gt;&gt;btnOK.Name" xml:space="preserve">
+    <value>btnOK</value>
+  </data>
+  <data name="tabPage1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;panel3.Parent" xml:space="preserve">
+    <value>groupBox2</value>
+  </data>
+  <data name="&gt;&gt;label2.Name" xml:space="preserve">
+    <value>label2</value>
+  </data>
+  <data name="&gt;&gt;txtremoteDNS.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="txtUserdirect.MaxLength" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;label8.Parent" xml:space="preserve">
+    <value>tabPage6</value>
+  </data>
+  <data name="tabPage4.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;tabPage1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label13.Name" xml:space="preserve">
+    <value>label13</value>
+  </data>
+  <data name="cmbprotocol2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>97, 20</value>
+  </data>
+  <data name="chkmuxEnabled.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="txtKcpreadBufferSize.Location" type="System.Drawing.Point, System.Drawing">
+    <value>111, 100</value>
+  </data>
+  <data name="&gt;&gt;label13.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="tabPage9.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="txtUserblock.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="&gt;&gt;txtKcpwriteBufferSize.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="btnClose.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="linkLabelRoutingDoc.Location" type="System.Drawing.Point, System.Drawing">
+    <value>5, 14</value>
+  </data>
+  <data name="label3.Text" xml:space="preserve">
+    <value>protocol</value>
+  </data>
+  <data name="txtUseragent.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tabControl2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>642, 486</value>
+  </data>
+  <data name="&gt;&gt;tabPage5.Parent" xml:space="preserve">
+    <value>tabControl2</value>
+  </data>
+  <data name="label14.Text" xml:space="preserve">
+    <value>Custom DNS (multiple, separated by commas (,))</value>
+  </data>
+  <data name="cmblistenerType.Items5" xml:space="preserve">
+    <value>Only open Http proxy and do nothing</value>
+  </data>
+  <data name="&gt;&gt;txturlGFWList.Name" xml:space="preserve">
+    <value>txturlGFWList</value>
+  </data>
+  <data name="&gt;&gt;txtHotkeyAddUserPAC.Name" xml:space="preserve">
+    <value>txtHotkeyAddUserPAC</value>
+  </data>
+  <data name="&gt;&gt;lblHotkeyGlobalProxyMode.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;chklogEnabled.Name" xml:space="preserve">
+    <value>chklogEnabled</value>
+  </data>
+  <data name="txtKcpdownlinkCapacity.Location" type="System.Drawing.Point, System.Drawing">
+    <value>345, 62</value>
+  </data>
+  <data name="lblHotkeyStopProxy.Text" xml:space="preserve">
+    <value>Stop the proxy service</value>
+  </data>
+  <data name="&gt;&gt;cmbloglevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 12</value>
+  </data>
+  <data name="&gt;&gt;txtHotkeyGlobalProxyMode.Parent" xml:space="preserve">
+    <value>tabPage10</value>
+  </data>
+  <data name="tabPage6.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;labRoutingTips.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="txtUserblock.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="&gt;&gt;chkAllowLANConn.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="label14.Location" type="System.Drawing.Point, System.Drawing">
+    <value>33, 253</value>
+  </data>
+  <data name="txtuserPacRule.MaxLength" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="lblHotkeyAddUserPAC.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 124</value>
+  </data>
+  <data name="txtKcpmtu.Location" type="System.Drawing.Point, System.Drawing">
+    <value>111, 24</value>
+  </data>
+  <data name="&gt;&gt;txtHotkeyPACProxyMode.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="lblHotkeyPACProxyMode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 89</value>
+  </data>
+  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="tabPage3.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="&gt;&gt;txtKcpmtu.Name" xml:space="preserve">
+    <value>txtKcpmtu</value>
+  </data>
+  <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="groupBox1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="lblHotkeyGlobalProxyMode.Text" xml:space="preserve">
+    <value>Start using global proxy mode</value>
+  </data>
+  <data name="&gt;&gt;txtUserdirect.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="chkudpEnabled2.Text" xml:space="preserve">
+    <value>Enable UDP</value>
+  </data>
+  <data name="&gt;&gt;chkRegHotkeyAtStartup.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmbdomainStrategy.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="cmblistenerType.Location" type="System.Drawing.Point, System.Drawing">
+    <value>124, 94</value>
+  </data>
+  <data name="label6.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="chkdefAllowInsecure.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 16</value>
+  </data>
+  <data name="cmbdomainStrategy.Items" xml:space="preserve">
+    <value>AsIs</value>
+  </data>
+  <data name="chkKcpcongestion.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cmbdomainStrategy.Items1" xml:space="preserve">
+    <value>IPIfNonMatch</value>
+  </data>
+  <data name="txtuserPacRule.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="groupBox2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="cmbloglevel.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;txtHotkeyStopProxy.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>662, 675</value>
+  </data>
+  <data name="&gt;&gt;txtremoteDNS.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;txtKcpwriteBufferSize.Name" xml:space="preserve">
+    <value>txtKcpwriteBufferSize</value>
+  </data>
+  <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
+    <value>18, 28</value>
+  </data>
+  <data name="label8.Size" type="System.Drawing.Size, System.Drawing">
+    <value>101, 12</value>
+  </data>
+  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>662, 10</value>
+  </data>
+  <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
+    <value>236, 28</value>
+  </data>
+  <data name="&gt;&gt;label13.Parent" xml:space="preserve">
+    <value>tabPage7</value>
+  </data>
+  <data name="&gt;&gt;chkudpEnabled.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="chkEnableStatistics.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;lblHotkeyStopProxy.Parent" xml:space="preserve">
+    <value>tabPage10</value>
+  </data>
+  <data name="cmblistenerType.Items4" xml:space="preserve">
+    <value>Only open PAC, do not automatically configure PAC</value>
+  </data>
+  <data name="btnClose.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="lblHotkeyGlobalProxyMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>179, 12</value>
+  </data>
+  <data name="panel4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="txtremoteDNS.TabIndex" type="System.Int32, mscorlib">
+    <value>30</value>
+  </data>
+  <data name="linkLabelRoutingDoc.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="panel4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>648, 37</value>
+  </data>
+  <data name="&gt;&gt;chkAutoRun.Parent" xml:space="preserve">
+    <value>tabPage7</value>
+  </data>
+  <data name="tabPage2.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="txtlocalPort2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>124, 60</value>
+  </data>
+  <data name="&gt;&gt;lblHotkeyAddUserPAC.Parent" xml:space="preserve">
+    <value>tabPage10</value>
+  </data>
+  <data name="&gt;&gt;chksniffingEnabled.Name" xml:space="preserve">
+    <value>chksniffingEnabled</value>
+  </data>
+  <data name="&gt;&gt;tabPage3.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tabPage8.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="txtUseragent.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
+    <value>Vertical</value>
+  </data>
+  <data name="&gt;&gt;chksniffingEnabled2.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="chkKeepOlderDedupl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>198, 16</value>
+  </data>
+  <data name="&gt;&gt;btnClose.Name" xml:space="preserve">
+    <value>btnClose</value>
+  </data>
+  <data name="chkKeepOlderDedupl.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 110</value>
+  </data>
+  <data name="cmbdomainStrategy.Size" type="System.Drawing.Size, System.Drawing">
+    <value>165, 20</value>
+  </data>
+  <data name="tabControl1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 10</value>
+  </data>
+  <data name="txtUserblock.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtKcptti.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="label13.TabIndex" type="System.Int32, mscorlib">
+    <value>27</value>
+  </data>
+  <data name="chksniffingEnabled2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label16.Location" type="System.Drawing.Point, System.Drawing">
+    <value>42, 98</value>
+  </data>
+  <data name="&gt;&gt;chkRegHotkeyAtStartup.Name" xml:space="preserve">
+    <value>chkRegHotkeyAtStartup</value>
+  </data>
+  <data name="tabControl2.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="cmbprotocol2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>257, 60</value>
+  </data>
+  <data name="&gt;&gt;txtUserdirect.Parent" xml:space="preserve">
+    <value>tabPage4</value>
+  </data>
+  <data name="cmbdomainStrategy.Location" type="System.Drawing.Point, System.Drawing">
+    <value>115, 10</value>
+  </data>
+  <data name="&gt;&gt;cbFreshrate.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>53, 12</value>
+  </data>
+  <data name="txtUserdirect.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="panel4.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="txtHotkeyGlobalProxyMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>207, 21</value>
+  </data>
+  <data name="label8.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="txtKcpmtu.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="tabPage3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>634, 460</value>
+  </data>
+  <data name="btnSetDefRountingRule.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="txtHotkeyAddUserPAC.Size" type="System.Drawing.Size, System.Drawing">
+    <value>207, 21</value>
+  </data>
+  <data name="chksniffingEnabled.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;txtKcptti.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>598, 16</value>
+  </data>
+  <data name="&gt;&gt;txtlocalPort.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="txtHotkeyAddUserPAC.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;lbFreshrate.Parent" xml:space="preserve">
+    <value>tabPage7</value>
+  </data>
+  <data name="linkLabelRoutingDoc.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="chkKcpcongestion.Size" type="System.Drawing.Size, System.Drawing">
+    <value>84, 16</value>
+  </data>
+  <data name="tabPage10.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="label4.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="lblHotkeyGlobalProxyMode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 54</value>
+  </data>
+  <data name="label16.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 12</value>
+  </data>
+  <data name="tabPage7.Size" type="System.Drawing.Size, System.Drawing">
+    <value>654, 579</value>
+  </data>
+  <data name="&gt;&gt;txtHotkeyPACProxyMode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="lblHotkeyStopProxy.Size" type="System.Drawing.Size, System.Drawing">
+    <value>137, 12</value>
+  </data>
+  <data name="txturlGFWList.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tabPage2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>654, 579</value>
+  </data>
+  <data name="lbFreshrate.Location" type="System.Drawing.Point, System.Drawing">
+    <value>30, 87</value>
+  </data>
+  <data name="&gt;&gt;tabPage7.Parent" xml:space="preserve">
+    <value>tabControl1</value>
+  </data>
+  <data name="&gt;&gt;lblHotkeyAddUserPAC.Name" xml:space="preserve">
+    <value>lblHotkeyAddUserPAC</value>
+  </data>
+  <data name="&gt;&gt;btnOK.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
+    <value>tabPage1</value>
+  </data>
+  <data name="txtHotkeyStopProxy.Location" type="System.Drawing.Point, System.Drawing">
+    <value>201, 15</value>
+  </data>
+  <data name="tabControl1.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;txtKcpdownlinkCapacity.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtHotkeyStopProxy.Parent" xml:space="preserve">
+    <value>tabPage10</value>
+  </data>
+  <data name="&gt;&gt;txtlocalPort2.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;label6.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="txtUserdirect.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkdefAllowInsecure.Text" xml:space="preserve">
+    <value>allowInsecure</value>
+  </data>
+  <data name="labRoutingTips.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;txtKcpmtu.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;panel4.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;chkKeepOlderDedupl.Parent" xml:space="preserve">
+    <value>tabPage7</value>
+  </data>
+  <data name="lblHotkeyPACProxyMode.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tabPage6.Size" type="System.Drawing.Size, System.Drawing">
+    <value>654, 579</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>protocol</value>
+  </data>
+  <data name="&gt;&gt;chkdefAllowInsecure.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="txtHotkeyAddUserPAC.Location" type="System.Drawing.Point, System.Drawing">
+    <value>201, 120</value>
+  </data>
+  <data name="chkKcpcongestion.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;tabControl2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="chkudpEnabled.Location" type="System.Drawing.Point, System.Drawing">
+    <value>369, 27</value>
+  </data>
+  <data name="&gt;&gt;label2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkudpEnabled.Name" xml:space="preserve">
+    <value>chkudpEnabled</value>
+  </data>
+  <data name="&gt;&gt;lblHotkeyPACProxyMode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="txtlocalPort2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>78, 21</value>
+  </data>
+  <data name="&gt;&gt;txtUserblock.Parent" xml:space="preserve">
+    <value>tabPage5</value>
+  </data>
+  <data name="txturlGFWList.Size" type="System.Drawing.Size, System.Drawing">
+    <value>541, 100</value>
+  </data>
+  <data name="&gt;&gt;btnOK.Parent" xml:space="preserve">
+    <value>panel2</value>
+  </data>
+  <data name="&gt;&gt;tabPage1.Parent" xml:space="preserve">
+    <value>tabControl1</value>
+  </data>
+  <data name="&gt;&gt;label7.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="txtUserblock.MaxLength" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="chkudpEnabled.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;tabPage6.Parent" xml:space="preserve">
+    <value>tabControl1</value>
+  </data>
+  <data name="tabPage1.Text" xml:space="preserve">
+    <value>Core: basic settings</value>
+  </data>
+  <data name="label7.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;txtUserblock.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="lblHotkeyAddUserPAC.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;linkLabelRoutingDoc.Parent" xml:space="preserve">
+    <value>panel3</value>
+  </data>
+  <data name="tabPage9.Text" xml:space="preserve">
+    <value>User PAC settings</value>
+  </data>
+  <data name="&gt;&gt;chkmuxEnabled.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtUserblock.Name" xml:space="preserve">
+    <value>txtUserblock</value>
+  </data>
+  <data name="&gt;&gt;groupBox2.Parent" xml:space="preserve">
+    <value>tabPage2</value>
+  </data>
+  <data name="cmbroutingMode.Items" xml:space="preserve">
+    <value>Global</value>
+  </data>
+  <data name="&gt;&gt;label3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox2.Name" xml:space="preserve">
+    <value>groupBox2</value>
+  </data>
+  <data name="&gt;&gt;tabPage8.Name" xml:space="preserve">
+    <value>tabPage8</value>
+  </data>
+  <data name="txtKcpuplinkCapacity.Size" type="System.Drawing.Size, System.Drawing">
+    <value>94, 21</value>
+  </data>
+  <data name="&gt;&gt;tabPage10.Name" xml:space="preserve">
+    <value>tabPage10</value>
+  </data>
+  <data name="txtUseragent.MaxLength" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;chkAutoRun.Name" xml:space="preserve">
+    <value>chkAutoRun</value>
+  </data>
+  <data name="&gt;&gt;label8.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnClose.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="tabPage4.Text" xml:space="preserve">
+    <value>2.Direct Domain or IP</value>
+  </data>
+  <data name="&gt;&gt;label6.Name" xml:space="preserve">
+    <value>label6</value>
+  </data>
+  <data name="label3.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;chkdefAllowInsecure.Name" xml:space="preserve">
+    <value>chkdefAllowInsecure</value>
+  </data>
+  <data name="&gt;&gt;label3.Name" xml:space="preserve">
+    <value>label3</value>
+  </data>
+  <data name="&gt;&gt;tabPage9.Name" xml:space="preserve">
+    <value>tabPage9</value>
+  </data>
+  <data name="&gt;&gt;label4.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tabPage4.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="btnSetDefRountingRule.Text" xml:space="preserve">
+    <value>Set default custom routing rules</value>
+  </data>
+  <data name="&gt;&gt;tabPage3.Name" xml:space="preserve">
+    <value>tabPage3</value>
+  </data>
+  <data name="&gt;&gt;txtKcptti.Name" xml:space="preserve">
+    <value>txtKcptti</value>
+  </data>
+  <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 12</value>
+  </data>
+  <data name="txtHotkeyPACProxyMode.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="chkRegHotkeyAtStartup.Size" type="System.Drawing.Size, System.Drawing">
+    <value>298, 24</value>
+  </data>
+  <data name="tabPage7.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="label4.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;chkudpEnabled.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="txturlGFWList.TabIndex" type="System.Int32, mscorlib">
+    <value>28</value>
+  </data>
+  <data name="lbFreshrate.TabIndex" type="System.Int32, mscorlib">
+    <value>30</value>
+  </data>
+  <data name="txtHotkeyStopProxy.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;txtKcpwriteBufferSize.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;tabControl1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label9.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="label10.Text" xml:space="preserve">
+    <value>writeBufferSize</value>
+  </data>
+  <data name="panel4.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="panel2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>662, 60</value>
+  </data>
+  <data name="&gt;&gt;txtKcpdownlinkCapacity.Name" xml:space="preserve">
+    <value>txtKcpdownlinkCapacity</value>
+  </data>
+  <data name="&gt;&gt;label4.Name" xml:space="preserve">
+    <value>label4</value>
+  </data>
+  <data name="chkKeepOlderDedupl.Text" xml:space="preserve">
+    <value>Keep older when deduplication</value>
+  </data>
+  <data name="&gt;&gt;label8.Name" xml:space="preserve">
+    <value>label8</value>
+  </data>
+  <data name="txtUserblock.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
+    <value>Vertical</value>
+  </data>
+  <data name="cmbloglevel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>257, 158</value>
+  </data>
+  <data name="lblHotkeyPACProxyMode.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="lbFreshrate.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnClose.Text" xml:space="preserve">
+    <value>&amp;Cancel</value>
+  </data>
+  <data name="&gt;&gt;txtKcpmtu.Parent" xml:space="preserve">
+    <value>tabPage6</value>
+  </data>
+  <data name="tabPage7.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="&gt;&gt;label16.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;chkAllowLANConn.Name" xml:space="preserve">
+    <value>chkAllowLANConn</value>
+  </data>
+  <data name="chksniffingEnabled2.TabIndex" type="System.Int32, mscorlib">
+    <value>32</value>
+  </data>
+  <data name="cbFreshrate.TabIndex" type="System.Int32, mscorlib">
+    <value>32</value>
+  </data>
+  <data name="cmbprotocol2.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="chkRegHotkeyAtStartup.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 154</value>
+  </data>
+  <data name="&gt;&gt;label6.Parent" xml:space="preserve">
+    <value>tabPage6</value>
+  </data>
+  <data name="&gt;&gt;tabPage8.Parent" xml:space="preserve">
+    <value>tabControl2</value>
+  </data>
+  <data name="&gt;&gt;label13.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmbroutingMode.Parent" xml:space="preserve">
+    <value>tabPage8</value>
+  </data>
+  <data name="label11.Size" type="System.Drawing.Size, System.Drawing">
+    <value>89, 12</value>
+  </data>
+  <data name="&gt;&gt;chkAutoRun.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="cmbprotocol2.Items1" xml:space="preserve">
+    <value>http</value>
+  </data>
+  <data name="txtremoteDNS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>555, 100</value>
+  </data>
+  <data name="label13.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="txtuserPacRule.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 40</value>
+  </data>
+  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>89, 12</value>
+  </data>
+  <data name="cmbprotocol.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;cmbprotocol2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="chkAutoRun.Text" xml:space="preserve">
+    <value>Automatically start at system startup</value>
+  </data>
+  <data name="chkKcpcongestion.Text" xml:space="preserve">
+    <value>congestion</value>
+  </data>
+  <data name="&gt;&gt;panel2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tabPage10.Text" xml:space="preserve">
+    <value>Hotkey settings</value>
+  </data>
+  <data name="label13.Size" type="System.Drawing.Size, System.Drawing">
+    <value>431, 12</value>
+  </data>
+  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="cmbprotocol.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="cmbprotocol.Size" type="System.Drawing.Size, System.Drawing">
+    <value>97, 20</value>
+  </data>
+  <data name="&gt;&gt;btnSetDefRountingRule.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;cmbroutingMode.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="cmbroutingMode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>21, 17</value>
+  </data>
+  <data name="&gt;&gt;chkKcpcongestion.Parent" xml:space="preserve">
+    <value>tabPage6</value>
+  </data>
+  <data name="&gt;&gt;lblHotkeyGlobalProxyMode.Parent" xml:space="preserve">
+    <value>tabPage10</value>
+  </data>
+  <data name="tabPage4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="panel3.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;tabPage3.Parent" xml:space="preserve">
+    <value>tabControl2</value>
+  </data>
+  <data name="&gt;&gt;cmbprotocol.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtHotkeyPACProxyMode.Parent" xml:space="preserve">
+    <value>tabPage10</value>
+  </data>
+  <data name="chkmuxEnabled.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;chkAllowIn2.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;txtremoteDNS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="txtUserdirect.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="txtKcptti.Location" type="System.Drawing.Point, System.Drawing">
+    <value>345, 24</value>
+  </data>
+  <data name="panel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="&gt;&gt;txtHotkeyGlobalProxyMode.Name" xml:space="preserve">
+    <value>txtHotkeyGlobalProxyMode</value>
+  </data>
+  <data name="chksniffingEnabled2.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="chkKeepOlderDedupl.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="tabPage3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="chkAllowIn2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 16</value>
+  </data>
+  <data name="&gt;&gt;txtHotkeyStopProxy.Name" xml:space="preserve">
+    <value>txtHotkeyStopProxy</value>
+  </data>
+  <data name="lblHotkeyAddUserPAC.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="btnOK.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="cmbloglevel.Items2" xml:space="preserve">
+    <value>warning</value>
+  </data>
+  <data name="cmbdomainStrategy.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;cmbroutingMode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="label3.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label9.Location" type="System.Drawing.Point, System.Drawing">
+    <value>18, 66</value>
+  </data>
+  <data name="chkAllowLANConn.Text" xml:space="preserve">
+    <value>Allow connections from the LAN</value>
+  </data>
+  <data name="txtUseragent.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="chkdefAllowInsecure.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="cmbroutingMode.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;tabPage10.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panel3.Name" xml:space="preserve">
+    <value>panel3</value>
+  </data>
+  <data name="chkAutoRun.Size" type="System.Drawing.Size, System.Drawing">
+    <value>246, 16</value>
+  </data>
+  <data name="&gt;&gt;tabPage1.Name" xml:space="preserve">
+    <value>tabPage1</value>
+  </data>
+  <data name="&gt;&gt;chkAllowIn2.Name" xml:space="preserve">
+    <value>chkAllowIn2</value>
+  </data>
+  <data name="chkudpEnabled2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>369, 62</value>
+  </data>
+  <data name="txtKcpmtu.Size" type="System.Drawing.Size, System.Drawing">
+    <value>94, 21</value>
+  </data>
+  <data name="tabControl1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="&gt;&gt;labRoutingTips.Parent" xml:space="preserve">
+    <value>panel3</value>
+  </data>
+  <data name="&gt;&gt;txtuserPacRule.Name" xml:space="preserve">
+    <value>txtuserPacRule</value>
+  </data>
+  <data name="label6.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkudpEnabled.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;chkKcpcongestion.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="lblHotkeyStopProxy.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="chkEnableStatistics.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;chkAllowIn2.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="chkmuxEnabled.Text" xml:space="preserve">
+    <value>Turn on Mux Multiplexing </value>
+  </data>
+  <data name="tabPage1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="cmblistenerType.Size" type="System.Drawing.Size, System.Drawing">
+    <value>464, 20</value>
+  </data>
+  <data name="&gt;&gt;txtlocalPort.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;txtUseragent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="txtUserblock.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="txtKcpdownlinkCapacity.Size" type="System.Drawing.Size, System.Drawing">
+    <value>94, 21</value>
+  </data>
+  <data name="&gt;&gt;panel3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="chksniffingEnabled.Text" xml:space="preserve">
+    <value>Turn on Sniffing</value>
+  </data>
+  <data name="cmbprotocol.Items" xml:space="preserve">
+    <value>socks</value>
+  </data>
+  <data name="chkudpEnabled2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;txtHotkeyGlobalProxyMode.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="cmblistenerType.TabIndex" type="System.Int32, mscorlib">
+    <value>33</value>
+  </data>
+  <data name="chkEnableStatistics.TabIndex" type="System.Int32, mscorlib">
+    <value>29</value>
+  </data>
+  <data name="cmbprotocol.Items1" xml:space="preserve">
+    <value>http</value>
+  </data>
+  <data name="&gt;&gt;btnOK.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="txtuserPacRule.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="&gt;&gt;cmbprotocol.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;txtUseragent.Name" xml:space="preserve">
+    <value>txtUseragent</value>
+  </data>
+  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;txtKcpdownlinkCapacity.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="linkLabelRoutingDoc.Text" xml:space="preserve">
+    <value>Domain strategy</value>
+  </data>
+  <data name="&gt;&gt;chklogEnabled.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;label5.Name" xml:space="preserve">
+    <value>label5</value>
+  </data>
+  <data name="&gt;&gt;panel2.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
   <data name="tabPage1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>654, 579</value>
+  </data>
+  <data name="&gt;&gt;txtKcpreadBufferSize.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tabPage8.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="&gt;&gt;label9.Name" xml:space="preserve">
+    <value>label9</value>
+  </data>
+  <data name="&gt;&gt;label14.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="txtKcpwriteBufferSize.Location" type="System.Drawing.Point, System.Drawing">
+    <value>345, 100</value>
+  </data>
+  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;cmblistenerType.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="txtuserPacRule.Size" type="System.Drawing.Size, System.Drawing">
+    <value>648, 536</value>
+  </data>
+  <data name="txtHotkeyGlobalProxyMode.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;lblHotkeyAddUserPAC.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="btnOK.Location" type="System.Drawing.Point, System.Drawing">
+    <value>267, 16</value>
+  </data>
+  <data name="&gt;&gt;txtKcpuplinkCapacity.Name" xml:space="preserve">
+    <value>txtKcpuplinkCapacity</value>
+  </data>
+  <data name="tabPage7.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="btnSetDefRountingRule.Location" type="System.Drawing.Point, System.Drawing">
+    <value>322, 10</value>
+  </data>
+  <data name="label16.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>206, 29</value>
+  </data>
+  <data name="&gt;&gt;tabControl2.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tabPage4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>634, 460</value>
+  </data>
+  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>648, 573</value>
+  </data>
+  <data name="&gt;&gt;labRoutingTips.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="txtHotkeyPACProxyMode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>201, 85</value>
+  </data>
+  <data name="label16.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;tabPage10.Parent" xml:space="preserve">
+    <value>tabControl1</value>
+  </data>
+  <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>5, 11</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;tabControl2.Name" xml:space="preserve">
+    <value>tabControl2</value>
+  </data>
+  <data name="&gt;&gt;lbFreshrate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblHotkeyAddUserPAC.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="btnOK.Text" xml:space="preserve">
+    <value>&amp;OK</value>
+  </data>
+  <data name="&gt;&gt;cmblistenerType.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="tabPage8.Size" type="System.Drawing.Size, System.Drawing">
+    <value>634, 460</value>
+  </data>
+  <data name="&gt;&gt;chkudpEnabled2.Name" xml:space="preserve">
+    <value>chkudpEnabled2</value>
+  </data>
+  <data name="label14.Size" type="System.Drawing.Size, System.Drawing">
+    <value>281, 12</value>
+  </data>
+  <data name="&gt;&gt;tabPage6.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="chkKcpcongestion.Location" type="System.Drawing.Point, System.Drawing">
+    <value>20, 143</value>
+  </data>
+  <data name="&gt;&gt;tabPage4.Parent" xml:space="preserve">
+    <value>tabControl2</value>
+  </data>
+  <data name="cmbroutingMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>255, 20</value>
+  </data>
+  <data name="chkAutoRun.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="tabPage3.Text" xml:space="preserve">
+    <value>1.Proxy Domain or IP</value>
+  </data>
+  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
+    <value>20</value>
+  </data>
+  <data name="chklogEnabled.Size" type="System.Drawing.Size, System.Drawing">
+    <value>126, 16</value>
+  </data>
+  <data name="txtlocalPort2.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 12</value>
+  </data>
+  <data name="&gt;&gt;lblHotkeyGlobalProxyMode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtKcpwriteBufferSize.Parent" xml:space="preserve">
+    <value>tabPage6</value>
+  </data>
+  <data name="&gt;&gt;label7.Name" xml:space="preserve">
+    <value>label7</value>
+  </data>
+  <data name="label11.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chksniffingEnabled2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 16</value>
+  </data>
+  <data name="&gt;&gt;chksniffingEnabled2.Name" xml:space="preserve">
+    <value>chksniffingEnabled2</value>
+  </data>
+  <data name="label10.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;txtremoteDNS.Name" xml:space="preserve">
+    <value>txtremoteDNS</value>
+  </data>
+  <data name="label16.Text" xml:space="preserve">
+    <value>Http proxy</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtlocalPort2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkEnableStatistics.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="chkAllowLANConn.Size" type="System.Drawing.Size, System.Drawing">
+    <value>204, 16</value>
+  </data>
+  <data name="txturlGFWList.Location" type="System.Drawing.Point, System.Drawing">
+    <value>32, 205</value>
+  </data>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 12</value>
+  </data>
+  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="panel3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>642, 67</value>
+  </data>
+  <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;lblHotkeyStopProxy.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="tabPage7.Text" xml:space="preserve">
+    <value>v2rayN settings</value>
+  </data>
+  <data name="chksniffingEnabled2.Text" xml:space="preserve">
+    <value>Turn on Sniffing</value>
+  </data>
+  <data name="linkLabelRoutingDoc.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="tabPage2.Text" xml:space="preserve">
+    <value>Core: Routing settings</value>
+  </data>
+  <data name="&gt;&gt;cmbprotocol2.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="txtlocalPort2.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="chkAllowIn2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 63</value>
+  </data>
+  <data name="chkAllowLANConn.Location" type="System.Drawing.Point, System.Drawing">
+    <value>15, 38</value>
+  </data>
+  <data name="&gt;&gt;txtlocalPort2.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="groupBox2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="chkEnableStatistics.Text" xml:space="preserve">
+    <value>Enable Statistics (Realtime netspeed and traffic records. Require restart the v2rayN client)</value>
+  </data>
+  <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tabPage10.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;btnClose.Parent" xml:space="preserve">
+    <value>panel2</value>
+  </data>
+  <data name="&gt;&gt;txtlocalPort2.Name" xml:space="preserve">
+    <value>txtlocalPort2</value>
+  </data>
+  <data name="lblHotkeyGlobalProxyMode.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="cmbloglevel.Items" xml:space="preserve">
+    <value>debug</value>
+  </data>
+  <data name="&gt;&gt;txtUserblock.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="cmbloglevel.Items1" xml:space="preserve">
+    <value>info</value>
+  </data>
+  <data name="&gt;&gt;panel4.Name" xml:space="preserve">
+    <value>panel4</value>
+  </data>
+  <data name="txtUserdirect.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
+    <value>Vertical</value>
+  </data>
+  <data name="tabPage6.Text" xml:space="preserve">
+    <value>Core: KCP settings</value>
+  </data>
+  <data name="&gt;&gt;tabControl1.Name" xml:space="preserve">
+    <value>tabControl1</value>
+  </data>
+  <data name="txtHotkeyStopProxy.Size" type="System.Drawing.Size, System.Drawing">
+    <value>207, 21</value>
+  </data>
+  <data name="label10.Size" type="System.Drawing.Size, System.Drawing">
+    <value>95, 12</value>
+  </data>
+  <data name="&gt;&gt;chkAllowLANConn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtKcpuplinkCapacity.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tabPage9.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="chksniffingEnabled2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>468, 60</value>
+  </data>
+  <data name="&gt;&gt;panel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>53, 12</value>
+  </data>
+  <data name="label14.TabIndex" type="System.Int32, mscorlib">
+    <value>29</value>
+  </data>
+  <data name="&gt;&gt;txtKcpreadBufferSize.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkdefAllowInsecure.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;chkKcpcongestion.Name" xml:space="preserve">
+    <value>chkKcpcongestion</value>
+  </data>
+  <data name="&gt;&gt;chksniffingEnabled2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tabPage2.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="cmbprotocol2.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;chkKcpcongestion.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;cmbdomainStrategy.Parent" xml:space="preserve">
+    <value>panel3</value>
+  </data>
+  <data name="chkKeepOlderDedupl.TabIndex" type="System.Int32, mscorlib">
+    <value>33</value>
+  </data>
+  <data name="&gt;&gt;chkmuxEnabled.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;chksniffingEnabled2.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;txtUseragent.Parent" xml:space="preserve">
+    <value>tabPage3</value>
+  </data>
+  <data name="tabPage10.Size" type="System.Drawing.Size, System.Drawing">
     <value>654, 579</value>
   </data>
   <data name="&gt;&gt;label9.Parent" xml:space="preserve">
     <value>tabPage6</value>
   </data>
-  <data name="&gt;&gt;tabPage7.Parent" xml:space="preserve">
-    <value>tabControl1</value>
+  <data name="txtuserPacRule.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
   </data>
-  <data name="tabPage1.TabIndex" type="System.Int32, mscorlib">
+  <data name="groupBox2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>648, 573</value>
+  </data>
+  <data name="&gt;&gt;label10.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="txtUserdirect.Size" type="System.Drawing.Size, System.Drawing">
+    <value>628, 454</value>
+  </data>
+  <data name="&gt;&gt;btnSetDefRountingRule.Parent" xml:space="preserve">
+    <value>panel3</value>
+  </data>
+  <data name="chkAllowLANConn.TabIndex" type="System.Int32, mscorlib">
+    <value>29</value>
+  </data>
+  <data name="label13.Location" type="System.Drawing.Point, System.Drawing">
+    <value>30, 176</value>
+  </data>
+  <data name="&gt;&gt;txtKcpmtu.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;chkAllowIn2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="chkRegHotkeyAtStartup.Text" xml:space="preserve">
+    <value>Register the hotkeys at startup</value>
+  </data>
+  <data name="&gt;&gt;txtHotkeyAddUserPAC.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmbprotocol.Name" xml:space="preserve">
+    <value>cmbprotocol</value>
+  </data>
+  <data name="txtKcptti.Size" type="System.Drawing.Size, System.Drawing">
+    <value>94, 21</value>
+  </data>
+  <data name="chkmuxEnabled.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 16</value>
+  </data>
+  <data name="&gt;&gt;label11.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="label16.TabIndex" type="System.Int32, mscorlib">
+    <value>34</value>
+  </data>
+  <data name="label14.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;txtuserPacRule.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="chkKeepOlderDedupl.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 110</value>
+  <data name="chkudpEnabled2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>84, 16</value>
   </data>
-  <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 11</value>
+  <data name="&gt;&gt;txtKcpreadBufferSize.Name" xml:space="preserve">
+    <value>txtKcpreadBufferSize</value>
   </data>
-  <data name="txtUserblock.MaxLength" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="&gt;&gt;lblHotkeyGlobalProxyMode.Name" xml:space="preserve">
+    <value>lblHotkeyGlobalProxyMode</value>
   </data>
-  <data name="&gt;&gt;cmbroutingMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;txtKcptti.Parent" xml:space="preserve">
+    <value>tabPage6</value>
+  </data>
+  <data name="&gt;&gt;lblHotkeyPACProxyMode.Name" xml:space="preserve">
+    <value>lblHotkeyPACProxyMode</value>
+  </data>
+  <data name="&gt;&gt;chkEnableStatistics.Parent" xml:space="preserve">
+    <value>tabPage7</value>
+  </data>
+  <data name="label7.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;cmblistenerType.Name" xml:space="preserve">
+    <value>cmblistenerType</value>
+  </data>
+  <data name="txtKcpuplinkCapacity.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
   </data>
   <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="chkudpEnabled.Text" xml:space="preserve">
-    <value>Enable UDP</value>
+  <data name="&gt;&gt;label16.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;chkAutoRun.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="chksniffingEnabled2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="tabPage7.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+  <data name="label9.Text" xml:space="preserve">
+    <value>uplinkCapacity</value>
   </data>
-  <data name="&gt;&gt;cmbprotocol.Parent" xml:space="preserve">
-    <value>groupBox1</value>
+  <data name="txtHotkeyPACProxyMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>207, 21</value>
+  </data>
+  <data name="btnSetDefRountingRule.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="&gt;&gt;lblHotkeyStopProxy.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="txtuserPacRule.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
+    <value>Vertical</value>
   </data>
   <data name="&gt;&gt;txtlocalPort.ZOrder" xml:space="preserve">
     <value>19</value>
   </data>
-  <data name="tabPage4.Text" xml:space="preserve">
-    <value>2.Direct Domain or IP</value>
+  <data name="labRoutingTips.Size" type="System.Drawing.Size, System.Drawing">
+    <value>598, 16</value>
   </data>
-  <data name="btnOK.Location" type="System.Drawing.Point, System.Drawing">
-    <value>267, 16</value>
+  <data name="lblHotkeyGlobalProxyMode.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="cmbroutingMode.Items" xml:space="preserve">
-    <value>Global</value>
+  <data name="cmblistenerType.Items3" xml:space="preserve">
+    <value>Only open Http proxy, do not automatically configure proxy server (direct mode)</value>
   </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="txtUseragent.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="&gt;&gt;txtKcptti.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtKcptti.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="btnSetDefRountingRule.Location" type="System.Drawing.Point, System.Drawing">
-    <value>322, 10</value>
-  </data>
-  <data name="chkdefAllowInsecure.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 192</value>
-  </data>
-  <data name="&gt;&gt;tabPage1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="txtKcpuplinkCapacity.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 21</value>
-  </data>
-  <data name="&gt;&gt;txtKcpreadBufferSize.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="chkKeepOlderDedupl.Text" xml:space="preserve">
-    <value>Keep older when deduplication</value>
-  </data>
-  <data name="tabPage5.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>236, 28</value>
-  </data>
-  <data name="panel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Bottom</value>
-  </data>
-  <data name="txtlocalPort.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+  <data name="&gt;&gt;cmblistenerType.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="&gt;&gt;tabPage7.Type" xml:space="preserve">
     <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;chkdefAllowInsecure.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;chksniffingEnabled.Parent" xml:space="preserve">
-    <value>groupBox1</value>
-  </data>
-  <data name="lbFreshrate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 12</value>
-  </data>
-  <data name="tabPage9.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;chkKcpcongestion.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chksniffingEnabled.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="txtlocalPort2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>124, 60</value>
-  </data>
-  <data name="&gt;&gt;cbFreshrate.Name" xml:space="preserve">
-    <value>cbFreshrate</value>
-  </data>
-  <data name="chkAutoRun.Size" type="System.Drawing.Size, System.Drawing">
-    <value>246, 16</value>
-  </data>
-  <data name="&gt;&gt;label6.Parent" xml:space="preserve">
+  <data name="&gt;&gt;tabPage6.Name" xml:space="preserve">
     <value>tabPage6</value>
   </data>
-  <data name="&gt;&gt;label6.Name" xml:space="preserve">
-    <value>label6</value>
-  </data>
-  <data name="txtKcpmtu.Location" type="System.Drawing.Point, System.Drawing">
-    <value>111, 24</value>
-  </data>
-  <data name="&gt;&gt;btnOK.Parent" xml:space="preserve">
-    <value>panel2</value>
-  </data>
-  <data name="txtuserPacRule.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
-  </data>
-  <data name="&gt;&gt;label9.Name" xml:space="preserve">
-    <value>label9</value>
-  </data>
-  <data name="tabControl1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 10</value>
-  </data>
-  <data name="&gt;&gt;panel1.Name" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;label14.Name" xml:space="preserve">
-    <value>label14</value>
+  <data name="&gt;&gt;txtuserPacRule.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/v2rayN/v2rayN/Forms/OptionSettingForm.zh-Hans.resx
+++ b/v2rayN/v2rayN/Forms/OptionSettingForm.zh-Hans.resx
@@ -369,6 +369,57 @@
   <data name="label4.Text" xml:space="preserve">
     <value>*设置用户PAC规则，用逗号(,)隔开</value>
   </data>
+  <data name="tabPage10.Text" xml:space="preserve">
+    <value>  快捷键设置  </value>
+  </data>
+  <data name="chkRegHotkeyAtStartup.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkRegHotkeyAtStartup.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 160</value>
+  </data>
+  <data name="chkRegHotkeyAtStartup.Size" type="System.Drawing.Size, System.Drawing">
+    <value>144, 16</value>
+  </data>
+  <data name="chkRegHotkeyAtStartup.Text" xml:space="preserve">
+    <value>启动时注册所有快捷键</value>
+  </data>
+  <data name="txtHotkeyAddUserPAC.Location" type="System.Drawing.Point, System.Drawing">
+    <value>146, 121</value>
+  </data>
+  <data name="lblHotkeyAddUserPAC.Size" type="System.Drawing.Size, System.Drawing">
+    <value>95, 12</value>
+  </data>
+  <data name="lblHotkeyAddUserPAC.Text" xml:space="preserve">
+    <value>添加用户PAC记录</value>
+  </data>
+  <data name="txtHotkeyPACProxyMode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>146, 85</value>
+  </data>
+  <data name="lblHotkeyPACProxyMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>119, 12</value>
+  </data>
+  <data name="lblHotkeyPACProxyMode.Text" xml:space="preserve">
+    <value>开启使用PAC代理模式</value>
+  </data>
+  <data name="txtHotkeyGlobalProxyMode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>146, 50</value>
+  </data>
+  <data name="lblHotkeyGlobalProxyMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>125, 12</value>
+  </data>
+  <data name="lblHotkeyGlobalProxyMode.Text" xml:space="preserve">
+    <value>开启使用全局代理模式</value>
+  </data>
+  <data name="txtHotkeyStopProxy.Location" type="System.Drawing.Point, System.Drawing">
+    <value>146, 15</value>
+  </data>
+  <data name="lblHotkeyStopProxy.Size" type="System.Drawing.Size, System.Drawing">
+    <value>77, 12</value>
+  </data>
+  <data name="lblHotkeyStopProxy.Text" xml:space="preserve">
+    <value>关闭代理服务</value>
+  </data>
   <data name="btnOK.Text" xml:space="preserve">
     <value>确定(&amp;O)</value>
   </data>

--- a/v2rayN/v2rayN/Forms/QuicklyAddUserPACForm.Designer.cs
+++ b/v2rayN/v2rayN/Forms/QuicklyAddUserPACForm.Designer.cs
@@ -1,0 +1,89 @@
+﻿namespace v2rayN.Forms
+{
+    partial class QuicklyAddUserPACForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(QuicklyAddUserPACForm));
+            this.label6 = new System.Windows.Forms.Label();
+            this.txtUserPACRule = new System.Windows.Forms.TextBox();
+            this.btnClose = new System.Windows.Forms.Button();
+            this.btnOK = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // label6
+            // 
+            resources.ApplyResources(this.label6, "label6");
+            this.label6.Name = "label6";
+            // 
+            // txtUserPACRule
+            // 
+            resources.ApplyResources(this.txtUserPACRule, "txtUserPACRule");
+            this.txtUserPACRule.Name = "txtUserPACRule";
+            // 
+            // btnClose
+            // 
+            this.btnClose.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            resources.ApplyResources(this.btnClose, "btnClose");
+            this.btnClose.Name = "btnClose";
+            this.btnClose.UseVisualStyleBackColor = true;
+            this.btnClose.Click += new System.EventHandler(this.btnClose_Click);
+            // 
+            // btnOK
+            // 
+            this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
+            resources.ApplyResources(this.btnOK, "btnOK");
+            this.btnOK.Name = "btnOK";
+            this.btnOK.UseVisualStyleBackColor = true;
+            this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
+            // 
+            // QuicklyAddUserPACForm
+            // 
+            this.AcceptButton = this.btnOK;
+            resources.ApplyResources(this, "$this");
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.btnClose;
+            this.Controls.Add(this.btnClose);
+            this.Controls.Add(this.btnOK);
+            this.Controls.Add(this.txtUserPACRule);
+            this.Controls.Add(this.label6);         
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.Name = "QuicklyAddUserPACForm";
+            this.VisibleChanged += new System.EventHandler(this.QuicklyAddUserPACForm_VisibleChanged);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.TextBox txtUserPACRule;
+        private System.Windows.Forms.Button btnClose;
+        private System.Windows.Forms.Button btnOK;
+    }
+}

--- a/v2rayN/v2rayN/Forms/QuicklyAddUserPACForm.cs
+++ b/v2rayN/v2rayN/Forms/QuicklyAddUserPACForm.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using v2rayN.Base;
+
+namespace v2rayN.Forms
+{
+    public partial class QuicklyAddUserPACForm : BaseForm
+    {
+        public QuicklyAddUserPACForm()
+        {
+            InitializeComponent();            
+        }
+
+
+        private void btnOK_Click(object sender, EventArgs e)
+        {
+            string userPacRule=this.txtUserPACRule.Text.TrimEx().Replace("\"", "");
+            this.txtUserPACRule.Text = "";
+            if (!string.IsNullOrEmpty(userPacRule))
+            {
+                config.userPacRule.Insert(0, userPacRule);                
+                this.DialogResult = DialogResult.OK;
+            }
+            else
+            {
+                this.DialogResult = DialogResult.Cancel;
+            }
+        }
+
+        private void btnClose_Click(object sender, EventArgs e)
+        {
+            this.txtUserPACRule.Text = "";
+            this.DialogResult = DialogResult.Cancel;
+        }
+
+        private void QuicklyAddUserPACForm_VisibleChanged(object sender, EventArgs e)
+        {
+            //在主屏幕的左下角显示窗口
+            if (this.Visible == true)
+            {
+                int heightLocation = System.Windows.Forms.Screen.PrimaryScreen.WorkingArea.Size.Height - this.Size.Height - 10;
+                this.SetDesktopLocation(12, heightLocation);
+                this.Activate();
+            }
+            this.txtUserPACRule.Focus();
+        }
+
+    }
+}

--- a/v2rayN/v2rayN/Forms/QuicklyAddUserPACForm.resx
+++ b/v2rayN/v2rayN/Forms/QuicklyAddUserPACForm.resx
@@ -1,0 +1,249 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="label6.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="label6.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 12</value>
+  </data>
+  <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 12</value>
+  </data>
+  <data name="label6.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="label6.Text" xml:space="preserve">
+    <value>User PAC rule</value>
+  </data>
+  <data name="&gt;&gt;label6.Name" xml:space="preserve">
+    <value>label6</value>
+  </data>
+  <data name="&gt;&gt;label6.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label6.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="txtUserPACRule.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 37</value>
+  </data>
+  <data name="txtUserPACRule.Size" type="System.Drawing.Size, System.Drawing">
+    <value>341, 21</value>
+  </data>
+  <data name="txtUserPACRule.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;txtUserPACRule.Name" xml:space="preserve">
+    <value>txtUserPACRule</value>
+  </data>
+  <data name="&gt;&gt;txtUserPACRule.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtUserPACRule.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;txtUserPACRule.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="btnClose.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnClose.Location" type="System.Drawing.Point, System.Drawing">
+    <value>278, 72</value>
+  </data>
+  <data name="btnClose.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="btnClose.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="btnClose.Text" xml:space="preserve">
+    <value>&amp;Cancel</value>
+  </data>
+  <data name="&gt;&gt;btnClose.Name" xml:space="preserve">
+    <value>btnClose</value>
+  </data>
+  <data name="&gt;&gt;btnClose.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnClose.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnClose.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="btnOK.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="btnOK.Location" type="System.Drawing.Point, System.Drawing">
+    <value>195, 72</value>
+  </data>
+  <data name="btnOK.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="btnOK.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="btnOK.Text" xml:space="preserve">
+    <value>&amp;OK</value>
+  </data>
+  <data name="&gt;&gt;btnOK.Name" xml:space="preserve">
+    <value>btnOK</value>
+  </data>
+  <data name="&gt;&gt;btnOK.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnOK.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;btnOK.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="$this.Localizable" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 12</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>365, 106</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>Manual</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Quickly add user PAC rule</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>QuicklyAddUserPACForm</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>v2rayN.Forms.BaseForm, v2rayN, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+</root>

--- a/v2rayN/v2rayN/Forms/QuicklyAddUserPACForm.zh-Hans.resx
+++ b/v2rayN/v2rayN/Forms/QuicklyAddUserPACForm.zh-Hans.resx
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
+    <value>95, 12</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="label6.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="label6.Text" xml:space="preserve">
+    <value>用户PAC规则地址</value>
+  </data>
+  <data name="txtUserPACRule.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="btnClose.Text" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="btnOK.Text" xml:space="preserve">
+    <value>确定</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>快速添加用户PAC规则</value>
+  </data>
+</root>

--- a/v2rayN/v2rayN/Handler/ConfigHandler.cs
+++ b/v2rayN/v2rayN/Handler/ConfigHandler.cs
@@ -156,6 +156,10 @@ namespace v2rayN.Handler
             {
                 config.userPacRule = new List<string>();
             }
+            if (config.hotkeyConfig == null)
+            {
+                config.hotkeyConfig = new HotkeyConfig();
+            }
 
             if (config == null
                 || config.index < 0

--- a/v2rayN/v2rayN/Handler/Hotkey/HotkeyCallbacks.cs
+++ b/v2rayN/v2rayN/Handler/Hotkey/HotkeyCallbacks.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Reflection;
+
+
+namespace v2rayN.Handler.Hotkey
+{
+    public class HotkeyCallbacks
+    {
+
+        public static void InitInstance(V2rayHandler v2rayHandler)
+        {
+            if (Instance != null)
+            {
+                return;
+            }
+
+            Instance = new HotkeyCallbacks(v2rayHandler);
+        }
+
+        /// <summary>
+        /// Create hotkey callback handler delegate based on callback name
+        /// </summary>
+        /// <param name="methodname"></param>
+        /// <returns></returns>
+        public static Delegate GetCallback(string methodname)
+        {
+            if (string.IsNullOrEmpty(methodname)) throw new ArgumentException(nameof(methodname));
+            MethodInfo dynMethod = typeof(HotkeyCallbacks).GetMethod(methodname,
+                BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.IgnoreCase);
+            return dynMethod == null ? null : Delegate.CreateDelegate(typeof(Hotkeys.HotKeyCallBackHandler), Instance, dynMethod);
+        }
+
+        #region Singleton
+
+        private static HotkeyCallbacks Instance { get; set; }
+
+        private readonly V2rayHandler _v2rayHandler;        
+
+        private HotkeyCallbacks(V2rayHandler v2rayHandler)
+        {
+            _v2rayHandler = v2rayHandler;           
+        }
+
+        #endregion
+
+        #region Callbacks
+
+        /// <summary>
+        /// 停止系统代理服务
+        /// </summary>
+        private void StopProxyCallback()
+        {            
+            _v2rayHandler.StopProxy();
+        }
+
+        /// <summary>
+        /// 开启使用全局代理服务模式
+        /// </summary>
+        private void GlobalProxyModeCallback()
+        {
+            _v2rayHandler.StartUseGlobalProxyMode();
+        }
+
+        /// <summary>
+        /// 开启使用PAC代理服务模式
+        /// </summary>
+        private void PACProxyModeCallback()
+        {
+            _v2rayHandler.StartUsePACProxyMode(); 
+        }
+
+        /// <summary>
+        /// 快速添加用户PAC规则
+        /// </summary>
+        private void AddUserPACCallback()
+        {            
+            _v2rayHandler.ShowAddUserPACForm();            
+        }
+
+        #endregion
+    }
+}

--- a/v2rayN/v2rayN/Handler/Hotkey/HotkeyReg.cs
+++ b/v2rayN/v2rayN/Handler/Hotkey/HotkeyReg.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Windows.Forms;
+using v2rayN.Mode;
+
+namespace v2rayN.Handler.Hotkey
+{
+    public static class HotkeyReg
+    {        
+        public static void RegAllHotkeys(HotkeyConfig hotkeyConfig)
+        {
+            if (hotkeyConfig == null || !hotkeyConfig.regHotkeyAtStartup)
+                return;
+
+            // if any of the hotkey reg fail, undo everything
+            if (RegHotkeyFromString(hotkeyConfig.stopProxy, "StopProxyCallback")
+                && RegHotkeyFromString(hotkeyConfig.globalProxyMode, "GlobalProxyModeCallback")
+                && RegHotkeyFromString(hotkeyConfig.pacProxyMode, "PACProxyModeCallback")
+                && RegHotkeyFromString(hotkeyConfig.addUserPAC, "AddUserPACCallback")
+            )
+            {
+                // success
+            }
+            else
+            {
+                RegHotkeyFromString("", "StopProxyCallback");
+                RegHotkeyFromString("", "GlobalProxyModeCallback");
+                RegHotkeyFromString("", "PACProxyModeCallback");
+                RegHotkeyFromString("", "AddUserPACCallback");
+                UI.ShowWarning(UIRes.I18N("HotkeyRegFailed"));
+            }
+        }
+
+        public static bool RegHotkeyFromString(string hotkeyStr, string callbackName, Action<RegResult> onComplete = null)
+        {
+            var _callback = HotkeyCallbacks.GetCallback(callbackName);
+            if (_callback == null)
+            {
+                throw new Exception($"{callbackName} not found");
+            }
+
+            var callback = _callback as Hotkeys.HotKeyCallBackHandler;
+
+            if (string.IsNullOrEmpty(hotkeyStr))
+            {
+                Hotkeys.UnregExistingHotkey(callback);
+                onComplete?.Invoke(RegResult.UnregSuccess);
+                return true;
+            }
+            else
+            {
+                var hotkey = Hotkeys.Str2HotKey(hotkeyStr);
+                if (hotkey == null)
+                {                   
+                    onComplete?.Invoke(RegResult.ParseError);
+                    return false;
+                }
+                else
+                {
+                    bool regResult = (Hotkeys.RegHotkey(hotkey, callback));
+                    if (regResult)
+                    {
+                        onComplete?.Invoke(RegResult.RegSuccess);
+                    }
+                    else
+                    {
+                        onComplete?.Invoke(RegResult.RegFailure);
+                    }
+                    return regResult;
+                }
+            }
+        }
+
+        public enum RegResult
+        {
+            RegSuccess,
+            RegFailure,
+            ParseError,
+            UnregSuccess,
+            //UnregFailure
+        }
+    }
+}

--- a/v2rayN/v2rayN/Handler/Hotkey/Hotkeys.cs
+++ b/v2rayN/v2rayN/Handler/Hotkey/Hotkeys.cs
@@ -1,0 +1,175 @@
+﻿using GlobalHotKey;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Input;
+using v2rayN.Mode;
+
+namespace v2rayN.Handler.Hotkey
+{
+    public static class Hotkeys
+    {
+        private static HotKeyManager _hotKeyManager;
+
+        public delegate void HotKeyCallBackHandler();
+        // map key and corresponding handler function
+        private static Dictionary<HotKey, HotKeyCallBackHandler> _keymap = new Dictionary<HotKey, HotKeyCallBackHandler>();
+
+        public static void Init(V2rayHandler v2rayHandler)
+        {
+            _hotKeyManager = new HotKeyManager();
+            _hotKeyManager.KeyPressed += HotKeyManagerPressed;
+
+            HotkeyCallbacks.InitInstance(v2rayHandler);
+        }
+
+        public static void Destroy()
+        {
+            _hotKeyManager.KeyPressed -= HotKeyManagerPressed;
+            _hotKeyManager.Dispose();
+        }
+
+        private static void HotKeyManagerPressed(object sender, KeyPressedEventArgs e)
+        {
+            var hotkey = e.HotKey;
+            HotKeyCallBackHandler callback;
+            if (_keymap.TryGetValue(hotkey, out callback))
+                callback();
+        }
+
+        public static bool RegHotkey(HotKey hotkey, HotKeyCallBackHandler callback)
+        {
+            UnregExistingHotkey(callback);
+            return Register(hotkey, callback);
+        }
+
+        public static bool UnregExistingHotkey(Hotkeys.HotKeyCallBackHandler cb)
+        {
+            HotKey existingHotKey;
+            if (IsCallbackExists(cb, out existingHotKey))
+            {
+                // unregister existing one
+                Unregister(existingHotKey);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static bool IsHotkeyExists(HotKey hotKey)
+        {
+            if (hotKey == null) throw new ArgumentNullException(nameof(hotKey));
+            return _keymap.Any(v => v.Key.Equals(hotKey));
+        }
+
+        public static bool IsCallbackExists(HotKeyCallBackHandler cb, out HotKey hotkey)
+        {
+            if (cb == null) throw new ArgumentNullException(nameof(cb));
+            if (_keymap.Any(v => v.Value == cb))
+            {
+                hotkey = _keymap.First(v => v.Value == cb).Key;
+                return true;
+            }
+            else
+            {
+                hotkey = null;
+                return false;
+            }
+        }
+
+        #region Converters
+
+        public static string HotKey2Str(HotKey key)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
+            return HotKey2Str(key.Key, key.Modifiers);
+        }
+
+        public static string HotKey2Str(Key key, ModifierKeys modifier)
+        {
+            if (!Enum.IsDefined(typeof(Key), key))
+                throw new InvalidEnumArgumentException(nameof(key), (int)key, typeof(Key));
+            try
+            {
+                ModifierKeysConverter mkc = new ModifierKeysConverter();
+                var keyStr = Enum.GetName(typeof(Key), key);
+                var modifierStr = mkc.ConvertToInvariantString(modifier);
+
+                return $"{modifierStr}+{keyStr}";
+            }
+            catch (NotSupportedException)
+            {
+                // converter exception
+                return null;
+            }
+        }
+
+        public static HotKey Str2HotKey(string s)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(s)) return null;
+                int offset = s.LastIndexOf("+", StringComparison.OrdinalIgnoreCase);
+                if (offset <= 0) return null;
+                string modifierStr = s.Substring(0, offset).Trim();
+                string keyStr = s.Substring(offset + 1).Trim();
+
+                KeyConverter kc = new KeyConverter();
+                ModifierKeysConverter mkc = new ModifierKeysConverter();
+                Key key = (Key)kc.ConvertFrom(keyStr.ToUpper());
+                ModifierKeys modifier = (ModifierKeys)mkc.ConvertFrom(modifierStr.ToUpper());
+
+                return new HotKey(key, modifier);
+            }
+            catch (NotSupportedException)
+            {
+                // converter exception
+                return null;
+            }
+            catch (NullReferenceException)
+            {
+                return null;
+            }
+        }
+
+        #endregion
+
+        private static bool Register(HotKey key, HotKeyCallBackHandler callBack)
+        {
+            if (key == null)
+                throw new ArgumentNullException(nameof(key));
+            if (callBack == null)
+                throw new ArgumentNullException(nameof(callBack));
+            try
+            {
+                _hotKeyManager.Register(key);
+                _keymap[key] = callBack;
+                return true;
+            }
+            catch (ArgumentException)
+            {
+                // already called this method with the specific hotkey
+                // return success silently
+                return true;
+            }
+            catch (Win32Exception)
+            {
+                // this hotkey already registered by other programs
+                // notify user to change key
+                return false;
+            }
+        }
+
+        private static void Unregister(HotKey key)
+        {
+            if (key == null)
+                throw new ArgumentNullException(nameof(key));
+            _hotKeyManager.Unregister(key);
+            if (_keymap.ContainsKey(key))
+                _keymap.Remove(key);
+        }
+    }
+}

--- a/v2rayN/v2rayN/Handler/V2rayHandler.cs
+++ b/v2rayN/v2rayN/Handler/V2rayHandler.cs
@@ -18,11 +18,17 @@ namespace v2rayN.Handler
     /// <summary>
     /// v2ray进程处理类
     /// </summary>
-    class V2rayHandler
+    public class V2rayHandler
     {
         private static string v2rayConfigRes = Global.v2rayConfigFileName;
         private List<string> lstV2ray;
         public event ProcessDelegate ProcessEvent;
+        
+        public event EventHandler StopProxyEvent;
+        public event EventHandler StartGlobalProxyModeEvent;
+        public event EventHandler StartPACProxyModeEvent;
+        public event EventHandler ShowAddUserPACEvent;
+
         //private int processId = 0;
         private Process _process;
 
@@ -299,6 +305,23 @@ namespace v2rayN.Handler
         private void ShowMsg(bool updateToTrayTooltip, string msg)
         {
             ProcessEvent?.Invoke(updateToTrayTooltip, msg);
+        }
+                
+        public void StopProxy()
+        {
+            StopProxyEvent?.Invoke(null, null);
+        }
+        public void StartUseGlobalProxyMode()
+        {
+            StartGlobalProxyModeEvent?.Invoke(null, null);
+        }
+        public void StartUsePACProxyMode()
+        {
+            StartPACProxyModeEvent?.Invoke(null, null);
+        }
+        public void ShowAddUserPACForm()
+        {
+            ShowAddUserPACEvent?.Invoke(null, null);
         }
 
         private void KillProcess(Process p)

--- a/v2rayN/v2rayN/Mode/Config.cs
+++ b/v2rayN/v2rayN/Mode/Config.cs
@@ -207,6 +207,14 @@ namespace v2rayN.Mode
             get; set;
         }
 
+        /// <summary>
+        /// 快捷键设置
+        /// </summary>
+        public HotkeyConfig hotkeyConfig
+        {
+            get; set;
+        }
+
         #region 函数
 
         public string address()
@@ -714,6 +722,40 @@ namespace v2rayN.Mode
         public Dictionary<string, int> mainLvColWidth
         {
             get; set;
+        }
+    }
+
+    [Serializable]
+    public class HotkeyConfig
+    {
+        /// <summary>
+        /// 停止代理服务的快捷键
+        /// </summary>
+        public string stopProxy { get; set; }
+        /// <summary>
+        /// 开启使用全局代理服务的快捷键
+        /// </summary>
+        public string globalProxyMode { get; set; }
+        /// <summary>
+        /// 开启使用PAC代理模式的快捷键
+        /// </summary>
+        public string pacProxyMode { get; set; }
+        /// <summary>
+        /// 打开添加一条用户PAC规则窗口的快捷键
+        /// </summary>
+        public string addUserPAC { get; set; }
+        /// <summary>
+        /// 是否在程序启动时注册所有的快捷键
+        /// </summary>
+        public bool regHotkeyAtStartup { get; set; }
+
+        public HotkeyConfig()
+        {
+            stopProxy = "";
+            globalProxyMode = "";
+            pacProxyMode = "";
+            addUserPAC = "";
+            regHotkeyAtStartup = false;
         }
     }
 }

--- a/v2rayN/v2rayN/Properties/AssemblyInfo.cs
+++ b/v2rayN/v2rayN/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // 方法是按如下所示使用“*”:
 //[assembly: AssemblyVersion("1.0.*")]
 //[assembly: AssemblyVersion("1.0.0")]
-[assembly: AssemblyFileVersion("3.19")]
+[assembly: AssemblyFileVersion("3.20")]

--- a/v2rayN/v2rayN/Resx/ResUI.Designer.cs
+++ b/v2rayN/v2rayN/Resx/ResUI.Designer.cs
@@ -241,6 +241,24 @@ namespace v2rayN.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Cannot parse hotkey: {0} 的本地化字符串。
+        /// </summary>
+        internal static string HotkeyParseFailed {
+            get {
+                return ResourceManager.GetString("HotkeyParseFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Register hotkey failed 的本地化字符串。
+        /// </summary>
+        internal static string HotkeyRegFailed {
+            get {
+                return ResourceManager.GetString("HotkeyRegFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似  is not the correct client configuration file, please check 的本地化字符串。
         /// </summary>
         internal static string IncorrectClientConfiguration {

--- a/v2rayN/v2rayN/Resx/ResUI.resx
+++ b/v2rayN/v2rayN/Resx/ResUI.resx
@@ -177,6 +177,12 @@
   <data name="FillUUID" xml:space="preserve">
     <value>Please fill in the user ID</value>
   </data>
+  <data name="HotkeyParseFailed" xml:space="preserve">
+    <value>Cannot parse hotkey: {0}</value>
+  </data>
+  <data name="HotkeyRegFailed" xml:space="preserve">
+    <value>Register hotkey failed</value>
+  </data>
   <data name="IncorrectClientConfiguration" xml:space="preserve">
     <value> is not the correct client configuration file, please check</value>
   </data>

--- a/v2rayN/v2rayN/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/v2rayN/Resx/ResUI.zh-Hans.resx
@@ -177,6 +177,12 @@
   <data name="FillUUID" xml:space="preserve">
     <value>请填写用户ID</value>
   </data>
+  <data name="HotkeyParseFailed" xml:space="preserve">
+    <value>无法识别的快捷键: {0}</value>
+  </data>
+  <data name="HotkeyRegFailed" xml:space="preserve">
+    <value>注册快捷键失败，请检查冲突或修改快捷键重试</value>
+  </data>
   <data name="IncorrectClientConfiguration" xml:space="preserve">
     <value>不是正确的客户端配置文件，请检查</value>
   </data>

--- a/v2rayN/v2rayN/v2rayN.csproj
+++ b/v2rayN/v2rayN/v2rayN.csproj
@@ -112,6 +112,12 @@
     <Compile Include="Forms\MainForm.Designer.cs">
       <DependentUpon>MainForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="Forms\QuicklyAddUserPACForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Forms\QuicklyAddUserPACForm.Designer.cs">
+      <DependentUpon>QuicklyAddUserPACForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="Forms\SubSettingForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -142,6 +148,8 @@
     <Compile Include="Forms\SubSettingControl.Designer.cs">
       <DependentUpon>SubSettingControl.cs</DependentUpon>
     </Compile>
+    <Compile Include="Handler\Hotkey\HotkeyCallbacks.cs" />
+    <Compile Include="Handler\Hotkey\Hotkeys.cs" />
     <Compile Include="Handler\MainFormHandler.cs" />
     <Compile Include="Handler\SpeedtestHandler.cs" />
     <Compile Include="Handler\StatisticsHandler.cs" />
@@ -208,6 +216,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Tool\FileManager.cs" />
+    <Compile Include="Handler\Hotkey\HotkeyReg.cs" />
     <Compile Include="Tool\Job.cs" />
     <Compile Include="Tool\QueryableExtension.cs" />
     <Compile Include="Tool\UIRes.cs" />
@@ -244,10 +253,17 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\OptionSettingForm.zh-Hans.resx">
       <DependentUpon>OptionSettingForm.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\QRCodeControl.zh-Hans.resx">
       <DependentUpon>QRCodeControl.cs</DependentUpon>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Forms\QuicklyAddUserPACForm.resx">
+      <DependentUpon>QuicklyAddUserPACForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Forms\QuicklyAddUserPACForm.zh-Hans.resx">
+      <DependentUpon>QuicklyAddUserPACForm.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\SubSettingControl.resx">
       <DependentUpon>SubSettingControl.cs</DependentUpon>
@@ -382,6 +398,9 @@
     <Content Include="Resources\privoxy_conf.txt" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="GlobalHotKey">
+      <Version>1.1.0</Version>
+    </PackageReference>
     <PackageReference Include="Google.Protobuf">
       <Version>3.11.4</Version>
     </PackageReference>


### PR DESCRIPTION
1、从shadowsocks-windows客户端中移植了快捷键设置的功能代码。在程序设置面板中可以设置4个快捷键。分别为：**停用代理、开启全局代理、开启PAC代理、添加UserPAC规则** ，**默认值均为空**。以及一个checkbox设置项--**在程序启动时注册快捷键**。**默认为False**。设置项均保存在guiNConfig.json本地配置文件中。
2、增加了一个通知区域图标菜单项--**添加用户PAC规则**，可以该选项打开一个添加窗体来添加**一条**User PAC规则。