### PR TITLE
Correct listen address in status bar when allowLANConn is on

### DIFF
--- a/v2rayN/v2rayN/Forms/MainForm.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.cs
@@ -347,11 +347,12 @@ namespace v2rayN.Forms
             toolSslHttpPort.Text =
             toolSslPacPort.Text = "OFF";
 
-            toolSslSocksPort.Text = $"{Global.Loopback}:{config.inbound[0].localPort}";
+            var listen = config.allowLANConn ? "0.0.0.0" : Global.Loopback;
+            toolSslSocksPort.Text = $"{listen}:{config.inbound[0].localPort}";
 
             if (config.listenerType != (int)ListenerType.noHttpProxy)
             {
-                toolSslHttpPort.Text = $"{Global.Loopback}:{Global.httpPort}";
+                toolSslHttpPort.Text = $"{listen}:{Global.httpPort}";
                 if (config.listenerType == ListenerType.GlobalPac ||
                     config.listenerType == ListenerType.PacOpenAndClear ||
                     config.listenerType == ListenerType.PacOpenOnly)


### PR DESCRIPTION
Previously, all addresses in the status bar use loopback as host even when `allowLANConn` is on, which is rather confusing. This commit changes 127.0.0.1 to 0.0.0.0 when allowLANConn is on, reflecting the fact that v2ray is listening on all interfaces.