### PR TITLE
与最新的在线默认规则保持一致

### DIFF
--- a/v2rayN/v2rayN/Sample/custom_routing_block
+++ b/v2rayN/v2rayN/Sample/custom_routing_block
@@ -1,1 +1,1 @@
-geosite:category-ads,
+geosite:category-ads-all,


### PR DESCRIPTION
category-ads-all包含category-ads，并增添了提供广告的域名。
详见https://github.com/v2fly/domain-list-community/blob/master/data/category-ads-all