### PR TITLE
Add support: custom outbound

### DIFF
--- a/v2rayN/v2rayN/Tool/Utils.cs
+++ b/v2rayN/v2rayN/Tool/Utils.cs
@@ -40,6 +40,12 @@ namespace v2rayN
 
             try
             {
+                //支持自定义文件覆盖默认配置
+                string path = GetPath(res);
+                if (File.Exists(path))
+                {
+                    return LoadResource(path);
+                }
                 Assembly assembly = Assembly.GetExecutingAssembly();
                 using (Stream stream = assembly.GetManifestResourceStream(res))
                 using (StreamReader reader = new StreamReader(stream))
@@ -171,6 +177,7 @@ namespace v2rayN
         /// <returns></returns>
         public static string List2String(List<string> lst, bool wrap = false)
         {
+            if (lst == null) return string.Empty;
             try
             {
                 if (wrap)


### PR DESCRIPTION
#1303

feature：

支持在启动目录下使用自定义的 v2rayN.Sample.SampleClientConfig.txt、v2rayN.Sample.SampleServerConfig.txt 等文件覆盖默认配置

示例：

假如需要转发baidu.com到本地的8899端口，供whistle代理控制，可按照以下步骤完成

1. 在运行目录下新建 [v2rayN.Sample.SampleClientConfig.txt](https://github.com/2dust/v2rayN/blob/master/v2rayN/v2rayN/Sample/SampleClientConfig.txt) 文件，并在 outbounds 里面添加下面的配置项，此项工作须在启动v2rayN前完成！

`{
	"protocol": "http",
	"tag": "whistle",
	"settings": {
		"servers": [
			{
				"address": "127.0.0.1",
				"port": 8899
			}
		]
	}
}`

2. 添加路由规则，仅支持高级路由！在 guiNConfig.json 中 routings.rules 里面添加路由规则

`{
          "type": null,
          "port": null,
          "inboundTag": null,
          "outboundTag": "whistle",
          "ip": null,
          "domain": [
            "domain:baidu.com"
          ],
          "protocol": null
        }`

图形界面这一块暂时没什么好的解决思路，不过目前这样用起来也不错。添加规则只需要在配置文件中编辑一次，之后也可以利用自带的图形界面编辑。