### PR TITLE
修正不改变系统代理时的退出行为

### DIFF
--- a/v2rayN/v2rayN/Forms/MainForm.cs
+++ b/v2rayN/v2rayN/Forms/MainForm.cs
@@ -36,6 +36,7 @@ namespace v2rayN.Forms
                 v2rayHandler.V2rayStop();
 
                 //HttpProxyHandle.CloseHttpAgent(config);
+                // 第二个bool参数指示此次UpdateSysProxy是否为退出
                 HttpProxyHandle.UpdateSysProxy(config, true);
 
                 ConfigHandler.SaveConfig(ref config);

--- a/v2rayN/v2rayN/HttpProxyHandler/HttpProxyHandle.cs
+++ b/v2rayN/v2rayN/HttpProxyHandler/HttpProxyHandle.cs
@@ -147,11 +147,12 @@ namespace v2rayN.HttpProxyHandler
             Update(config, false);
         }
 
-        public static bool UpdateSysProxy(Config config, bool forceDisable)
+        public static bool UpdateSysProxy(Config config, bool isExit)
         {
             var type = config.sysProxyType;
 
-            if (forceDisable)
+            // 如果是程序退出那么自动配置系统代理的更新行为应当是清除
+            if (isExit && type == ESysProxyType.ForcedChange)
             {
                 type = ESysProxyType.ForcedClear;
             }
@@ -170,6 +171,7 @@ namespace v2rayN.HttpProxyHandler
                 }
                 else if (type == ESysProxyType.ForcedClear)
                 {
+                    // 系统关机时这里无法复位成功，需要改
                     SysProxyHandle.ResetIEProxy();
                 }
                 else if (type == ESysProxyType.Unchanged)


### PR DESCRIPTION
原来的v2rayN，必然会在退出时去复位系统代理，不受“不改变系统代理”控制
行为和说好的不一样

HttpProxyHandle.cs里只有UpdateSysProxy一个方法还在用，其他都没有引用了（没动）

SysProxyHandle.ResetIEProxy();无法在关机时复位系统代理
这一点没有改，加了一行注释。ResetIEProxy方法改好了记得移除

更新：如果原定行为就是关闭复位系统代理的话，还请直接关闭pr。