### PR TITLE
更正下载 GeoFile 之后的日志信息

### DIFF
--- a/v2rayN/v2rayN/Handler/UpdateHandle.cs
+++ b/v2rayN/v2rayN/Handler/UpdateHandle.cs
@@ -245,7 +245,7 @@ namespace v2rayN.Handler
                 {
                     if (args.Success)
                     {
-                        _updateFunc(false, UIRes.I18N("MsgDownloadV2rayCoreSuccessfully"));
+                        _updateFunc(false, string.Format(UIRes.I18N("MsgDownloadGeoFileSuccessfully"), geoName));
 
                         try
                         {

--- a/v2rayN/v2rayN/Resx/ResUI.Designer.cs
+++ b/v2rayN/v2rayN/Resx/ResUI.Designer.cs
@@ -457,6 +457,15 @@ namespace v2rayN.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Download GeoFile: {0} successfully 的本地化字符串。
+        /// </summary>
+        internal static string MsgDownloadGeoFileSuccessfully {
+            get {
+                return ResourceManager.GetString("MsgDownloadGeoFileSuccessfully", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Download Core successfully 的本地化字符串。
         /// </summary>
         internal static string MsgDownloadV2rayCoreSuccessfully {

--- a/v2rayN/v2rayN/Resx/ResUI.resx
+++ b/v2rayN/v2rayN/Resx/ResUI.resx
@@ -388,4 +388,7 @@
   <data name="AddBatchRoutingRulesYesNo" xml:space="preserve">
     <value>Do you want to append rules? Choose yes to append, choose otherwise to replace</value>
   </data>
+  <data name="MsgDownloadGeoFileSuccessfully" xml:space="preserve">
+    <value>Download GeoFile: {0} successfully</value>
+  </data>
 </root>

--- a/v2rayN/v2rayN/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/v2rayN/Resx/ResUI.zh-Hans.resx
@@ -388,4 +388,7 @@
   <data name="AddBatchRoutingRulesYesNo" xml:space="preserve">
     <value>是否追加规则?选择是则追加,选择否则替换</value>
   </data>
+  <data name="MsgDownloadGeoFileSuccessfully" xml:space="preserve">
+    <value>下载 GeoFile: {0} 成功</value>
+  </data>
 </root>


### PR DESCRIPTION
你好。

这是一个关于日志的修改，不影响具体的业务逻辑。

修改前后的对比如下：

<table>
    <thead>
      <tr>
        <th colspan="2"></th>
        <th>GeoSite</th>
        <th>GeoIP</th>
      </tr>
    </thead>
    <tbody>
      <tr>
        <td rowspan="2">Before</td>
        <td>en-us</td>
        <td colspan="2">
            <pre>
Downloading...
...0%
...
...100%
Download Core successfully</pre>
        </td>
      </tr>
      <tr>
        <td>zh-Hans</td>
        <td colspan="2">
            <pre>
下载开始...
...0%
...
...100%
下载Core成功</pre>
        </td>
      </tr>
      <tr>
        <td rowspan="2">After</td>
        <td>en-us</td>
        <td>
            <pre>
Downloading...
...0%
...
...100%
Download GeoFile: geosite successfully</pre>
        </td>
        <td>
            <pre>
Downloading...
...0%
...
...100%
Download GeoFile: geoip successfully</pre>
        </td>
      </tr>
      <tr>
        <td>zh-Hans</td>
        <td>
            <pre>
下载开始...
...0%
...
...100%
下载 GeoFile: geosite 成功</pre>
        </td>
        <td>
            <pre>
下载开始...
...0%
...
...100%
下载 GeoFile: geoip 成功</pre>
        </td>
      </tr>
    </tbody>
</table>
