### PR TITLE
Add custom routing rule blacklist & change notify icon

### DIFF
--- a/v2rayN/v2rayN/Handler/ConfigHandler.cs
+++ b/v2rayN/v2rayN/Handler/ConfigHandler.cs
@@ -1185,6 +1185,15 @@ namespace v2rayN.Handler
                 AddBatchRoutingRules(ref item2, result2);
                 config.routings.Add(item2);
 
+                //Blacklist
+                var item3 = new RoutingItem();
+                item3.remarks = "黑名单(Blacklist)";
+                item3.url = string.Empty;
+                item3.rules = new List<RulesItem>();
+                string result3 = Utils.GetEmbedText(Global.CustomRoutingFileName + "black");
+                AddBatchRoutingRules(ref item3, result3);
+                config.routings.Add(item3);
+
                 config.routingIndex = 0;
             }
 

--- a/v2rayN/v2rayN/Handler/MainFormHandler.cs
+++ b/v2rayN/v2rayN/Handler/MainFormHandler.cs
@@ -37,7 +37,7 @@ namespace v2rayN.Handler
                 int index = (int)config.sysProxyType;
                 if (index > 0)
                 {
-                    color = (new Color[] { Color.Red, Color.Purple, Color.DarkGreen, Color.Orange, Color.DarkSlateBlue, Color.RoyalBlue })[index - 1];
+                    color = (new Color[] { Color.Purple, Color.DarkSlateBlue, Color.DarkGreen, Color.Red, Color.Orange, Color.RoyalBlue })[index - 1];
                     //color = ColorTranslator.FromHtml(new string[] { "#CC0066", "#CC6600", "#99CC99", "#666699" }[index - 1]);
                 }
 

--- a/v2rayN/v2rayN/Sample/custom_routing_black
+++ b/v2rayN/v2rayN/Sample/custom_routing_black
@@ -1,0 +1,23 @@
+﻿[
+  {
+    "outboundTag": "block",
+    "domain": [
+      "geosite:category-ads-all"
+    ]
+  },
+  {
+    "outboundTag": "Proxy",
+    "domain": [
+      "geosite:tld-!cn",
+      "geosite:gfw",
+      "geosite:greatfire"
+    ],
+    "ip": [
+      "geoip:telegram"
+    ]
+  },
+  {
+    "port": "0-65535",
+    "outboundTag": "direct"
+  }
+]

--- a/v2rayN/v2rayN/v2rayN.csproj
+++ b/v2rayN/v2rayN/v2rayN.csproj
@@ -402,6 +402,7 @@
     <EmbeddedResource Include="Sample\custom_routing_white" />
     <EmbeddedResource Include="Sample\custom_routing_global" />
     <EmbeddedResource Include="Sample\custom_routing_locked" />
+    <EmbeddedResource Include="Sample\custom_routing_black" />
     <Protobuf Include="Protos\Statistics.proto" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
1.  默认路由规则添加了黑名单
2. PAC取消后将自动配置系统代理设置为紫色图标比较符合之前的使用习惯

![blacklist](https://user-images.githubusercontent.com/51202308/119355646-1b2fb000-bcd8-11eb-8c33-715f14e1b93d.png)

![custom_rule](https://user-images.githubusercontent.com/51202308/119355654-1d920a00-bcd8-11eb-81cc-0e253a50b7e7.png)
