### PR TITLE
SetIEProxy : add prefix `http://`

### DIFF
--- a/v2rayN/v2rayN/HttpProxyHandler/HttpProxyHandle.cs
+++ b/v2rayN/v2rayN/HttpProxyHandler/HttpProxyHandle.cs
@@ -41,7 +41,7 @@ namespace v2rayN.HttpProxyHandler
                     if (type == ListenerType.GlobalHttp)
                     {
                         //ProxySetting.SetProxy($"{Global.Loopback}:{port}", Global.IEProxyExceptions, 2);
-                        SysProxyHandle.SetIEProxy(true, true, $"{Global.Loopback}:{port}");
+                        SysProxyHandle.SetIEProxy(true, true, $"{Global.httpProtocol}{Global.Loopback}:{port}");
                     }
                     else if (type == ListenerType.HttpOpenAndClear)
                     {
@@ -166,7 +166,7 @@ namespace v2rayN.HttpProxyHandler
                 }
                 if (type == ESysProxyType.ForcedChange)
                 {
-                    SysProxyHandle.SetIEProxy(true, true, $"{Global.Loopback}:{port}");
+                    SysProxyHandle.SetIEProxy(true, true, $"{Global.httpProtocol}{Global.Loopback}:{port}");
                 }
                 else if (type == ESysProxyType.ForcedClear)
                 {


### PR DESCRIPTION
虽然不知道为什么

`v2ray_win_temp` 下的 `sysproxy.exe` 设置全局代理时加上http前缀后pip就能正常使用了

#1408   #1384

`.\sysproxy.exe global 127.0.0.1:10880`
`pip install xxx`

`.\sysproxy.exe global http://127.0.0.1:10880`
`pip install xxx`