### PR TITLE
bypass proxy for intranet address

### DIFF
--- a/v2rayN/v2rayN/Global.cs
+++ b/v2rayN/v2rayN/Global.cs
@@ -189,7 +189,7 @@ namespace v2rayN
         }
         public const string StatisticLogOverall = "StatisticLogOverall.json";
 
-        public const string IEProxyExceptions = "localhost;127.*;10.*;172.16.*;172.17.*;172.18.*;172.19.*;172.20.*;172.21.*;172.22.*;172.23.*;172.24.*;172.25.*;172.26.*;172.27.*;172.28.*;172.29.*;172.30.*;172.31.*;192.168.*";
+        public const string IEProxyExceptions = "localhost;127.*;10.*;172.16.*;172.17.*;172.18.*;172.19.*;172.20.*;172.21.*;172.22.*;172.23.*;172.24.*;172.25.*;172.26.*;172.27.*;172.28.*;172.29.*;172.30.*;172.31.*;192.168.*;<local>";
 
         public const string RoutingRuleComma = "<COMMA>";
 


### PR DESCRIPTION
Update for  #1708 
Tested on Win10 Pro 21H1 x64 and Win7 Ent sp1 x64.