### PR TITLE
Fix autorun

### DIFF
--- a/v2rayN/v2rayN/Tool/Utils.cs
+++ b/v2rayN/v2rayN/Tool/Utils.cs
@@ -536,7 +536,7 @@ namespace v2rayN
             try
             {
                 string exePath = GetExePath();
-                RegWriteValue(autoRunRegPath, autoRunName, run ? exePath : "");
+                RegWriteValue(autoRunRegPath, autoRunName, run ? ("\"" + exePath + "\"") : "");
             }
             catch
             {
@@ -553,7 +553,7 @@ namespace v2rayN
             {
                 string value = RegReadValue(autoRunRegPath, autoRunName, "");
                 string exePath = GetExePath();
-                if (value?.Equals(exePath) == true)
+                if (value?.Equals(exePath) == true || value?.Equals("\"" + exePath + "\"") == true)
                 {
                     return true;
                 }


### PR DESCRIPTION
我的安装路径在`D:\Program Files\v2rayN\`
设置开机启动，经常会在开机时候，弹出启动了``D:\Program`这个文件，导致 v2rayN 启动不了
目前不清楚是什么软件导致的，尝试在注册表的路径加上双引号后，就不再出现了