### PR TITLE
fix sysproxy execute argument

### DIFF
--- a/v2rayN/v2rayN/HttpProxyHandler/HttpProxyHandle.cs
+++ b/v2rayN/v2rayN/HttpProxyHandler/HttpProxyHandle.cs
@@ -41,7 +41,9 @@ namespace v2rayN.HttpProxyHandler
                     if (type == ListenerType.GlobalHttp)
                     {
                         //ProxySetting.SetProxy($"{Global.Loopback}:{port}", Global.IEProxyExceptions, 2);
-                        SysProxyHandle.SetIEProxy(true, true, $"{Global.Loopback}:{port}");
+                        string strHttpProxy = $"{Global.httpProtocol}{Global.Loopback}:{port}";
+                        SysProxyHandle.SetIEProxy(true, $"http={strHttpProxy};https={strHttpProxy};ftp={strHttpProxy}",
+                            config.systemProxyExceptions);
                     }
                     else if (type == ListenerType.HttpOpenAndClear)
                     {
@@ -166,7 +168,9 @@ namespace v2rayN.HttpProxyHandler
                 }
                 if (type == ESysProxyType.ForcedChange)
                 {
-                    SysProxyHandle.SetIEProxy(true, $"{Global.Loopback}:{port}", config.systemProxyExceptions);
+                    string strHttpProxy = $"{Global.httpProtocol}{Global.Loopback}:{port}";
+                    SysProxyHandle.SetIEProxy(true, $"http={strHttpProxy};https={strHttpProxy};ftp={strHttpProxy}",
+                        config.systemProxyExceptions);
                 }
                 else if (type == ESysProxyType.ForcedClear)
                 {


### PR DESCRIPTION
individual config of each protocols can avoid the proxy error of some programs like pip,npm when using https proxy.

<del>`.\sysproxy.exe global 127.0.0.1:10881`</del>

`.\sysproxy.exe global http=http://127.0.0.1:10881";"https=http://127.0.0.1:10881";"ftp=http://127.0.0.1:10881`