### PR TITLE
保存自定义路由信息时先排序后输出

### DIFF
--- a/v2rayN/v2rayN/Forms/RoutingRuleSettingDetailsForm.cs
+++ b/v2rayN/v2rayN/Forms/RoutingRuleSettingDetailsForm.cs
@@ -48,8 +48,8 @@ namespace v2rayN.Forms
                 }
                 rulesItem.inboundTag = inboundTag;
                 rulesItem.outboundTag = cmbOutboundTag.Text;
-                rulesItem.domain = Utils.String2List(txtDomain.Text);
-                rulesItem.ip = Utils.String2List(txtIP.Text);
+                rulesItem.domain = Utils.String2ListSorted(txtDomain.Text);
+                rulesItem.ip = Utils.String2ListSorted(txtIP.Text);
 
                 var protocol = new List<string>();
                 for (int i = 0; i < clbProtocol.Items.Count; i++)

--- a/v2rayN/v2rayN/Tool/Utils.cs
+++ b/v2rayN/v2rayN/Tool/Utils.cs
@@ -220,6 +220,26 @@ namespace v2rayN
         }
 
         /// <summary>
+        /// 逗号分隔的字符串,先排序后转List<string>
+        /// </summary>
+        /// <param name="str"></param>
+        /// <returns></returns>
+        public static List<string> String2ListSorted(string str)
+        {
+            try
+            {
+                str = str.Replace(Environment.NewLine, "");
+                List<string> list = new List<string>(str.Split(new string[] { "," }, StringSplitOptions.RemoveEmptyEntries));
+                return list.OrderBy(x => x).ToList();
+            }
+            catch (Exception ex)
+            {
+                SaveLog(ex.Message, ex);
+                return new List<string>();
+            }
+        }
+
+        /// <summary>
         /// Base64编码
         /// </summary>
         /// <param name="plainText"></param>


### PR DESCRIPTION
自定义规则列表默认会比较混乱。
![image](https://user-images.githubusercontent.com/36562931/161200504-cc9c1e45-5989-40be-a2f6-df9ba5aeda50.png)
修改后每次保存会自动对内容进行排序，这样有时可以快速核对有无重复域名，提高列表的规律性。
![image](https://user-images.githubusercontent.com/36562931/161200959-63dc261c-016c-42eb-bf4c-abd553c5a47c.png)
