### PR TITLE
Update Clash.Meta coreExes

### DIFF
--- a/v2rayN/v2rayN/Handler/LazyConfig.cs
+++ b/v2rayN/v2rayN/Handler/LazyConfig.cs
@@ -112,7 +112,7 @@ namespace v2rayN.Handler
             coreInfos.Add(new CoreInfo
             {
                 coreType = ECoreType.clash_meta,
-                coreExes = new List<string> { "Clash.Meta-windows-amd64v1", "Clash.Meta-windows-amd64", "Clash.Meta-windows-386", "Clash.Meta", "clash" },
+                coreExes = new List<string> { "Clash.Meta-windows-amd64v1", "Clash.Meta-windows-amd64", "Clash.Meta-windows-amd64-compatible", "Clash.Meta-windows-386", "Clash.Meta", "clash" },
                 arguments = "-f config.json",
                 coreUrl = Global.clashMetaCoreUrl,
                 coreLatestUrl = Global.clashMetaCoreUrl + "/latest",


### PR DESCRIPTION
修复 x64 平台下，通过 Update Clash.Meta Core 下载核心后，启动仍然提示找不到核心的问题。
```
启动服务(2022/7/4 14:03:27)...
找不到Core，下载地址: https://github.com/MetaCubeX/Clash.Meta/releases
```