### PR TITLE
Update LazyConfig.cs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # v2rayN
-A V2Ray client for Windows, support [Xray core](https://github.com/XTLS/Xray-core) and [v2fly core](https://github.com/v2fly/v2ray-core)
+A V2Ray client for Windows, support [Xray core](https://github.com/XTLS/Xray-core) and [v2fly core](https://github.com/v2fly/v2ray-core).
 
 
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/2dust/v2rayN)](https://github.com/2dust/v2rayN/commits/master)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # v2rayN
-A V2Ray client for Windows, support [Xray core](https://github.com/XTLS/Xray-core) and [v2fly core](https://github.com/v2fly/v2ray-core).
+A V2Ray client for Windows, support [Xray core](https://github.com/XTLS/Xray-core) and [v2fly core](https://github.com/v2fly/v2ray-core)
 
 
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/2dust/v2rayN)](https://github.com/2dust/v2rayN/commits/master)

--- a/v2rayN/v2rayN/Handler/LazyConfig.cs
+++ b/v2rayN/v2rayN/Handler/LazyConfig.cs
@@ -80,14 +80,14 @@ namespace v2rayN.Handler
             coreInfos.Add(new CoreInfo
             {
                 coreType = ECoreType.v2fly,
-                coreExes = new List<string> { "wv2ray", "v2ray" },
-                arguments = "",
+                coreExes = new List<string> { "v2ray" },
+                arguments = "run",
                 coreUrl = Global.v2flyCoreUrl,
                 coreReleaseApiUrl = Global.v2flyCoreUrl.Replace(@"https://github.com", @"https://api.github.com/repos"),
                 coreDownloadUrl32 = Global.v2flyCoreUrl + "/download/{0}/v2ray-windows-{1}.zip",
                 coreDownloadUrl64 = Global.v2flyCoreUrl + "/download/{0}/v2ray-windows-{1}.zip",
                 match = "V2Ray",
-                versionArg = "-version"
+                versionArg = "version"
             });
 
             coreInfos.Add(new CoreInfo


### PR DESCRIPTION
For v2fly core v5, will fix #2596 

大概看了下，现在sagernet core的调用参数和程序名与v2fly core v5的相同（实测core类型选sagernet core然后把v2fly v5 core的文件盖上去能完美使用），理论上这么改应该能满足v2fly core v5的使用。但显然这个改法会破坏v4core的使用。因此我先把pr开成草稿，等啥时候v5 core变成stable了再转正。