### PR TITLE
Update to support v2fly core v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ A V2Ray client for Windows, support [Xray core](https://github.com/XTLS/Xray-cor
 
 ### Requirements  
 - Microsoft [.NET Framework 4.8 Runtime](https://dotnet.microsoft.com/zh-cn/download/dotnet-framework/thank-you/net48-offline-installer)
-- v2fly core [https://github.com/v2fly/v2ray-core/releases](https://github.com/v2fly/v2ray-core/releases)
+- Latest v2fly core [https://github.com/v2fly/v2ray-core/releases/latest](https://github.com/v2fly/v2ray-core/releases/latest)
 - Xray core [https://github.com/XTLS/Xray-core/releases](https://github.com/XTLS/Xray-core/releases)

--- a/v2rayN/v2rayN/Handler/LazyConfig.cs
+++ b/v2rayN/v2rayN/Handler/LazyConfig.cs
@@ -80,14 +80,14 @@ namespace v2rayN.Handler
             coreInfos.Add(new CoreInfo
             {
                 coreType = ECoreType.v2fly,
-                coreExes = new List<string> { "wv2ray", "v2ray" },
-                arguments = "",
+                coreExes = new List<string> { "v2ray" },
+                arguments = "run",
                 coreUrl = Global.v2flyCoreUrl,
                 coreReleaseApiUrl = Global.v2flyCoreUrl.Replace(@"https://github.com", @"https://api.github.com/repos"),
                 coreDownloadUrl32 = Global.v2flyCoreUrl + "/download/{0}/v2ray-windows-{1}.zip",
                 coreDownloadUrl64 = Global.v2flyCoreUrl + "/download/{0}/v2ray-windows-{1}.zip",
                 match = "V2Ray",
-                versionArg = "-version"
+                versionArg = "version"
             });
 
             coreInfos.Add(new CoreInfo


### PR DESCRIPTION
The commit did two things:

1. Update lazyconfig.cs to support v2fly core v5, as it has been marked stable now.
2. Ask users to use v2fly core v5 as the change breaks v2fly v4 core support.