### PR TITLE
Update SysProxyHandle.cs

### DIFF
--- a/v2rayN/v2rayN/Handler/SysProxyHandle.cs
+++ b/v2rayN/v2rayN/Handler/SysProxyHandle.cs
@@ -72,7 +72,7 @@ namespace v2rayN.Handler
                     var strProxy = string.Empty;
                     if (Utils.IsNullOrEmpty(config.systemProxyAdvancedProtocol))
                     {
-                        strProxy = $"{Global.Loopback}:{port}";
+                        strProxy = $"http=http://{Global.Loopback}:{port};https=http://{Global.Loopback}:{port}";
                     }
                     else
                     {


### PR DESCRIPTION
直接导出ip和端口号，其它程序获取代理时，会自动补全协议，从而导致代理异常。

例如，如果只导出ip和端口号，127.0.0.1:10809 会被解析成 http和https分别走http://127.0.0.1:10809和https://127.0.0.1:10809。甚至ftp也走ftp://127.0.0.1:10809，这显然是有问题的，V2rayN也无法处理这些协议。

而V2rayN预期效果是http和https均走http://127.0.0.1:10809。

加入协议头后，可以使windows上的更多程序正常运行，也更符合代理规范。