### PR TITLE
Auto-update subscription without proxy

### DIFF
--- a/v2rayN/v2rayN/Handler/MainFormHandler.cs
+++ b/v2rayN/v2rayN/Handler/MainFormHandler.cs
@@ -299,6 +299,13 @@ namespace v2rayN.Handler
                             update(success, msg);
                             if (success)
                                 Utils.SaveLog("subscription" + msg);
+                            else
+                                updateHandle.UpdateSubscriptionProcess(config, "", false, (bool success, string msg) =>
+                                {
+                                    update(success, msg);
+                                    if (success)
+                                        Utils.SaveLog("subscription" + msg);
+                                });
                         });
                         autoUpdateSubTime = dtNow;
                     }


### PR DESCRIPTION
Sometimes the subscription can only be updated without proxy. If the auto-updating process with proxy fails, try to update without proxy.
The original PR is #2874 which is closed now. I checked the code of the commit https://github.com/2dust/v2rayN/commit/020df117c48f67bc86f8f396895a1bc2170f67ee. I think this fix can be applied to the latest v6.x.