### PR TITLE
Update OptionSettingWindow.xaml

### DIFF
--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
@@ -10,7 +10,7 @@
     xmlns:resx="clr-namespace:v2rayN.Resx"
     xmlns:vms="clr-namespace:v2rayN.ViewModels"
     Title="{x:Static resx:ResUI.menuSetting}"
-    Width="900"
+    Width="1100"
     Height="700"
     x:TypeArguments="vms:OptionSettingViewModel"
     Background="{DynamicResource MaterialDesignPaper}"
@@ -485,7 +485,7 @@
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
 
                         <TextBlock
@@ -507,7 +507,8 @@
                             Margin="{StaticResource ServerItemMargin}"
                             VerticalAlignment="Center"
                             Style="{StaticResource ToolbarTextBlock}"
-                            Text="{x:Static resx:ResUI.TbSettingsStartBootTip}" />
+                            Text="{x:Static resx:ResUI.TbSettingsStartBootTip}"
+                            TextWrapping="Wrap" />
 
                         <TextBlock
                             Grid.Row="2"
@@ -719,7 +720,8 @@
                             Margin="{StaticResource ServerItemMargin}"
                             VerticalAlignment="Center"
                             Style="{StaticResource ToolbarTextBlock}"
-                            Text="{x:Static resx:ResUI.TbSettingsCurrentFontFamilyTip}" />
+                            Text="{x:Static resx:ResUI.TbSettingsCurrentFontFamilyTip}"
+                            TextWrapping="Wrap" />
 
                         <TextBlock
                             Grid.Row="16"


### PR DESCRIPTION
当客户端语言不为中文时，文字过长，使后面的元素无法完全显示。
https://github.com/2dust/v2rayN/issues/3338

- 修改前
![](https://user-images.githubusercontent.com/45081750/221113577-a0d4fda3-5d92-4b0f-9b60-738bbac01e6e.png)
- 修改后
![](https://user-images.githubusercontent.com/45081750/221113666-f8866f44-cab9-4ef4-9937-318619e6b3e4.png)
