### PR TITLE
fix: 修复选中服务器->测速 后，当前服务器会丢失选中的情况

### DIFF
--- a/v2rayN/v2rayN/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/v2rayN/ViewModels/MainWindowViewModel.cs
@@ -556,8 +556,8 @@ namespace v2rayN.ViewModels
                     {
                         return;
                     }
-                    SpeedProxyDisplay = string.Format("{0}:{1}/s¡ü | {2}/s¡ý", Global.agentTag, Utils.HumanFy(update.proxyUp), Utils.HumanFy(update.proxyDown));
-                    SpeedDirectDisplay = string.Format("{0}:{1}/s¡ü | {2}/s¡ý", Global.directTag, Utils.HumanFy(update.directUp), Utils.HumanFy(update.directDown));
+                    SpeedProxyDisplay = string.Format("{0}:{1}/sÂ¡Ã¼ | {2}/sÂ¡Ã½", Global.agentTag, Utils.HumanFy(update.proxyUp), Utils.HumanFy(update.proxyDown));
+                    SpeedDirectDisplay = string.Format("{0}:{1}/sÂ¡Ã¼ | {2}/sÂ¡Ã½", Global.directTag, Utils.HumanFy(update.directUp), Utils.HumanFy(update.directDown));
 
                     if (update.proxyUp + update.proxyDown > 0)
                     {
@@ -621,6 +621,7 @@ namespace v2rayN.ViewModels
                     item.speedVal = $"{speed} {Global.SpeedUnit}";
                 }
                 _profileItems.Replace(item, Utils.DeepCopy(item));
+                SelectedProfile = item;
             }
         }
 


### PR DESCRIPTION
在客户端选中一个服务器->测速时，SelectedProfile会变为null，导致被视为没有选中服务器，会影响右键菜单以及快捷键的操作 例如ctrl+p后按enter，无法设置为活动服务器，反而会跳转到下一行

对于559-560行，似乎是因为编码问题导致的，提交时候会有现在这个commit的中的情况
![DZ P5KC0@5VLIMX40KGS99](https://user-images.githubusercontent.com/45081750/221391423-ca9e1ba3-30b4-44d7-aba3-1498eac8d41c.png)
取消之后在github中尝试直接改文件，也会显示有更改，希望可以赐教一下怎么解决~
