### PR TITLE
Add a control to simulate system tool tip.

### DIFF
--- a/v2rayN/v2rayN/Views/MainWindow.xaml
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml
@@ -831,6 +831,21 @@
                             Header="{x:Static resx:ResUI.menuExit}" />
                     </ContextMenu>
                 </tb:TaskbarIcon.ContextMenu>
+                <tb:TaskbarIcon.TrayToolTip>
+                    <Border
+                        Background="White"
+                        BorderBrush="Black"
+                        BorderThickness="2"
+                        CornerRadius="2"
+                        Width="auto"
+                        Height="auto">
+                        <TextBlock
+                            Margin="2"
+                            Text="{Binding Mode=OneWay, Path=ToolTipText}"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center" />
+                    </Border>
+                </tb:TaskbarIcon.TrayToolTip>
             </tb:TaskbarIcon>
             <materialDesign:Snackbar x:Name="MainSnackbar" MessageQueue="{materialDesign:MessageQueue}" />
         </Grid>

--- a/v2rayN/v2rayN/Views/MainWindow.xaml
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml
@@ -837,8 +837,8 @@
                         BorderBrush="Black"
                         BorderThickness="2"
                         CornerRadius="2"
-                        Width="auto"
-                        Height="auto">
+                        Width="Auto"
+                        Height="Auto">
                         <TextBlock
                             Margin="2"
                             Text="{Binding Mode=OneWay, Path=ToolTipText}"


### PR DESCRIPTION
Follows #3370 

May fix #3408 

This is a temporary fix since the root cause is external.

The style of the control is adjusted to be similar to previous Windows versions.

Current:
<img width="335" alt="image" src="https://user-images.githubusercontent.com/17916222/222944353-6264ff6f-e402-4c70-96be-f62b4fdc656a.png">

This PR:
<img width="312" alt="image" src="https://user-images.githubusercontent.com/17916222/222944365-b53c9a9c-84b9-4447-b158-845c909fb659.png">

It looks OK to me on current WIndows 11 version 22621.1344.
I do not have other Windows versions to test.