### PR TITLE
内存优化 #3632 图形化时内存占用100+，后台运行时内存占用10+

### DIFF
--- a/v2rayN/v2rayN/App.xaml.cs
+++ b/v2rayN/v2rayN/App.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using Lierda.WPFHelper;
+using System.Windows;
 using System.Windows.Threading;
 using v2rayN.Handler;
 using v2rayN.Mode;
@@ -13,6 +14,7 @@ namespace v2rayN
     {
         public static EventWaitHandle ProgramStarted;
         private static Config _config;
+        LierdaCracker lierdaCracker=new LierdaCracker();
 
         public App()
         {
@@ -28,6 +30,7 @@ namespace v2rayN
         /// <param name="e"></param>
         protected override void OnStartup(StartupEventArgs e)
         {
+            lierdaCracker.Cracker(30); //内存回收，每30秒回收一次
             Global.ExePathKey = Utils.GetMD5(Utils.GetExePath());
 
             var rebootas = (e.Args ?? new string[] { }).Any(t => t == Global.RebootAs);

--- a/v2rayN/v2rayN/v2rayN.csproj
+++ b/v2rayN/v2rayN/v2rayN.csproj
@@ -14,7 +14,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Downloader" Version="3.0.4" />		
+		<PackageReference Include="Downloader" Version="3.0.4" />
+		<PackageReference Include="Lierda.WPFHelper" Version="1.0.3" />		
 		<PackageReference Include="MaterialDesignThemes" Version="4.7.1" />
 		<PackageReference Include="H.NotifyIcon.Wpf" Version="2.0.108" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
下图是后台时无代理状态内存占用，有代理时大概20左右

![Snipaste_2023-04-07_20-18-32](https://user-images.githubusercontent.com/8471565/230608890-421be4b1-64c6-464b-a437-95e26f8a5331.jpg)
