### PR TITLE
Change language in runtime without restart application

### DIFF
--- a/v2rayN/v2rayN/App.xaml
+++ b/v2rayN/v2rayN/App.xaml
@@ -5,8 +5,7 @@
     xmlns:conv="clr-namespace:v2rayN.Converters"
     xmlns:local="clr-namespace:v2rayN"
     xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
-    ShutdownMode="OnExplicitShutdown"
-    StartupUri="Views/MainWindow.xaml">
+    ShutdownMode="OnExplicitShutdown">
     <Application.Resources>
         <ResourceDictionary xmlns:system="clr-namespace:System;assembly=mscorlib">
             <ResourceDictionary.MergedDictionaries>

--- a/v2rayN/v2rayN/App.xaml.cs
+++ b/v2rayN/v2rayN/App.xaml.cs
@@ -1,9 +1,11 @@
-﻿using System.Runtime.InteropServices;
+﻿using ProtosLib.Statistics;
+using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Threading;
 using v2rayN.Handler;
-using v2rayN.Mode;
 using v2rayN.Tool;
+using v2rayN.Views;
 
 namespace v2rayN
 {
@@ -13,8 +15,8 @@ namespace v2rayN
     public partial class App : Application
     {
         public static EventWaitHandle ProgramStarted;
-        private static Config _config;
-
+        private static v2rayN.Mode.Config _config;
+        public static bool ignoreClosing { get; set; } = true;
         public App()
         {
             // Locator.CurrentMutable.RegisterViewsForViewModels(Assembly.GetCallingAssembly());
@@ -53,6 +55,8 @@ namespace v2rayN
             Thread.CurrentThread.CurrentUICulture = new(_config.uiItem.currentLanguage);
 
             base.OnStartup(e);
+            Current.MainWindow = new MainWindow();
+            Current.MainWindow.Show();
         }
 
 
@@ -87,6 +91,23 @@ namespace v2rayN
         private void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
         {
             Utils.SaveLog("TaskScheduler_UnobservedTaskException", e.Exception);
+        }
+
+        public static void ChangeCulture(CultureInfo newCulture)
+        {
+            if (newCulture != null)
+            {
+                Thread.CurrentThread.CurrentCulture = newCulture;
+                Thread.CurrentThread.CurrentUICulture = newCulture;
+                _config.uiItem.currentLanguage = newCulture.Name;
+                var oldWindow = Current.MainWindow;
+                ignoreClosing = false;
+                Current.MainWindow = new MainWindow();
+                oldWindow.Close();
+                ignoreClosing = true;
+                Current.MainWindow.Show();
+
+            }
         }
     }
 }

--- a/v2rayN/v2rayN/Global.cs
+++ b/v2rayN/v2rayN/Global.cs
@@ -111,7 +111,7 @@
         };
         public static readonly List<string> allowInsecures = new() { "true", "false", "" };
         public static readonly List<string> domainStrategy4Freedoms = new() { "AsIs", "UseIP", "UseIPv4", "UseIPv6", "" };
-        public static readonly List<string> Languages = new() { "zh-Hans", "en", "fa-Ir", "ru" };
+        public static readonly List<string> Languages = new() { "zh-Hans", "en", "fa-IR", "ru" };
         public static readonly List<string> alpns = new() { "h2", "http/1.1", "h2,http/1.1", "" };
         public static readonly List<string> LogLevel = new() { "debug", "info", "warning", "error", "none" };
         public static readonly List<string> InboundTags = new() { "socks", "http", "socks2", "http2" };
@@ -129,7 +129,7 @@
         public static Job processJob { get; set; }
         public static bool ShowInTaskbar { get; set; }
         public static string ExePathKey { get; set; }
-
+       
         #endregion
 
     }

--- a/v2rayN/v2rayN/Views/MainWindow.xaml
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml
@@ -355,6 +355,7 @@
                                         Width="100"
                                         Margin="8"
                                         materialDesign:HintAssist.Hint="Language"
+                                        SelectionChanged="cmbCurrentLanguage_SelectionChanged"
                                         Style="{StaticResource DefComboBox}" />
 
                                 </Grid>

--- a/v2rayN/v2rayN/Views/MainWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using ReactiveUI;
 using Splat;
 using System.ComponentModel;
+using System.Globalization;
 using System.Reactive.Disposables;
 using System.Windows;
 using System.Windows.Controls;
@@ -225,8 +226,11 @@ namespace v2rayN.Views
 
         private void MainWindow_Closing(object? sender, CancelEventArgs e)
         {
-            e.Cancel = true;
-            ViewModel?.ShowHideWindow(false);
+            if (App.ignoreClosing)
+            {
+                e.Cancel = true;
+                ViewModel?.ShowHideWindow(false);
+            }
         }
 
         private void menuExit_Click(object sender, RoutedEventArgs e)
@@ -605,8 +609,13 @@ namespace v2rayN.Views
             }
         }
 
+
         #endregion
+        private void cmbCurrentLanguage_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (e.AddedItems.Count != 0 && e.RemovedItems.Count != 0)
+                App.ChangeCulture(new CultureInfo(e.AddedItems[0].ToString()));
 
-
+        }
     }
 }


### PR DESCRIPTION
After changing language application need to restart to changing language.
this fix change it in runtime and user don't need to restart application