### PR TITLE
添加geoip cn的dns分流

### DIFF
--- a/v2rayN/v2rayN/Sample/dns_singbox_normal
+++ b/v2rayN/v2rayN/Sample/dns_singbox_normal
@@ -23,6 +23,12 @@
       "server": "local"
     },
     {
+      "source_geoip": [
+        "cn"
+      ],
+      "server": "local"
+    },
+    {
       "geosite": [
         "category-ads-all"
       ],

--- a/v2rayN/v2rayN/Sample/tun_singbox_dns
+++ b/v2rayN/v2rayN/Sample/tun_singbox_dns
@@ -24,6 +24,13 @@
       "disable_cache": true
     },
     {
+      "source_geoip": [
+        "cn"
+      ],
+      "server": "local",
+      "disable_cache": true
+    },
+    {
       "geosite": [
         "category-ads-all"
       ],


### PR DESCRIPTION
添加geoip cn的dns分流,防止类似microsoft.com这样的网站dns通过8.8.8.8解析到境外导致无法访问