### PR TITLE
解决窗口尺寸大于屏幕尺寸的问题

### DIFF
--- a/v2rayN/v2rayN/Views/AddServer2Window.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddServer2Window.xaml.cs
@@ -11,6 +11,10 @@ namespace v2rayN.Views
         public AddServer2Window(ProfileItem profileItem)
         {
             InitializeComponent();
+
+            this.MaxWidth = SystemParameters.WorkArea.Width;
+            this.MaxHeight = SystemParameters.WorkArea.Height;
+
             this.Owner = Application.Current.MainWindow;
             this.Loaded += Window_Loaded;
             ViewModel = new AddServer2ViewModel(profileItem, this);

--- a/v2rayN/v2rayN/Views/AddServer2Window.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddServer2Window.xaml.cs
@@ -12,8 +12,15 @@ namespace v2rayN.Views
         {
             InitializeComponent();
 
-            this.MaxWidth = SystemParameters.WorkArea.Width;
-            this.MaxHeight = SystemParameters.WorkArea.Height;
+            // 设置窗口的尺寸不大于屏幕的尺寸
+            if (this.Width > SystemParameters.WorkArea.Width)
+            {
+                this.Width = SystemParameters.WorkArea.Width;
+            }
+            if (this.Height > SystemParameters.WorkArea.Height)
+            {
+                this.Height = SystemParameters.WorkArea.Height;
+            }
 
             this.Owner = Application.Current.MainWindow;
             this.Loaded += Window_Loaded;

--- a/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using ReactiveUI;
+using System.Net.Security;
 using System.Reactive.Disposables;
 using System.Windows;
 using System.Windows.Controls;
@@ -15,6 +16,10 @@ namespace v2rayN.Views
         public AddServerWindow(ProfileItem profileItem)
         {
             InitializeComponent();
+
+            this.MaxWidth = SystemParameters.WorkArea.Width;
+            this.MaxHeight = SystemParameters.WorkArea.Height;
+
             this.Owner = Application.Current.MainWindow;
             this.Loaded += Window_Loaded;
             cmbNetwork.SelectionChanged += CmbNetwork_SelectionChanged;

--- a/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using ReactiveUI;
-using System.Net.Security;
 using System.Reactive.Disposables;
 using System.Windows;
 using System.Windows.Controls;

--- a/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
@@ -16,8 +16,15 @@ namespace v2rayN.Views
         {
             InitializeComponent();
 
-            this.MaxWidth = SystemParameters.WorkArea.Width;
-            this.MaxHeight = SystemParameters.WorkArea.Height;
+            // 设置窗口的尺寸不大于屏幕的尺寸
+            if (this.Width > SystemParameters.WorkArea.Width)
+            {
+                this.Width = SystemParameters.WorkArea.Width;
+            }
+            if (this.Height > SystemParameters.WorkArea.Height)
+            {
+                this.Height = SystemParameters.WorkArea.Height;
+            }
 
             this.Owner = Application.Current.MainWindow;
             this.Loaded += Window_Loaded;

--- a/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using ReactiveUI;
+using System.Net.Security;
 using System.Reactive.Disposables;
 using System.Windows;
 using System.Windows.Controls;

--- a/v2rayN/v2rayN/Views/DNSSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/DNSSettingWindow.xaml.cs
@@ -15,8 +15,15 @@ namespace v2rayN.Views
         {
             InitializeComponent();
 
-            this.MaxWidth = SystemParameters.WorkArea.Width;
-            this.MaxHeight = SystemParameters.WorkArea.Height;
+            // 设置窗口的尺寸不大于屏幕的尺寸
+            if (this.Width > SystemParameters.WorkArea.Width)
+            {
+                this.Width = SystemParameters.WorkArea.Width;
+            }
+            if (this.Height > SystemParameters.WorkArea.Height)
+            {
+                this.Height = SystemParameters.WorkArea.Height;
+            }
 
             this.Owner = Application.Current.MainWindow;
             _config = LazyConfig.Instance.GetConfig();

--- a/v2rayN/v2rayN/Views/DNSSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/DNSSettingWindow.xaml.cs
@@ -14,6 +14,10 @@ namespace v2rayN.Views
         public DNSSettingWindow()
         {
             InitializeComponent();
+
+            this.MaxWidth = SystemParameters.WorkArea.Width;
+            this.MaxHeight = SystemParameters.WorkArea.Height;
+
             this.Owner = Application.Current.MainWindow;
             _config = LazyConfig.Instance.GetConfig();
 

--- a/v2rayN/v2rayN/Views/GlobalHotkeySettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/GlobalHotkeySettingWindow.xaml.cs
@@ -17,8 +17,15 @@ namespace v2rayN.Views
         {
             InitializeComponent();
 
-            this.MaxWidth = SystemParameters.WorkArea.Width;
-            this.MaxHeight = SystemParameters.WorkArea.Height;
+            // 设置窗口的尺寸不大于屏幕的尺寸
+            if (this.Width > SystemParameters.WorkArea.Width)
+            {
+                this.Width = SystemParameters.WorkArea.Width;
+            }
+            if (this.Height > SystemParameters.WorkArea.Height)
+            {
+                this.Height = SystemParameters.WorkArea.Height;
+            }
 
             this.Owner = Application.Current.MainWindow;
             _config = LazyConfig.Instance.GetConfig();

--- a/v2rayN/v2rayN/Views/GlobalHotkeySettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/GlobalHotkeySettingWindow.xaml.cs
@@ -16,6 +16,10 @@ namespace v2rayN.Views
         public GlobalHotkeySettingWindow()
         {
             InitializeComponent();
+
+            this.MaxWidth = SystemParameters.WorkArea.Width;
+            this.MaxHeight = SystemParameters.WorkArea.Height;
+
             this.Owner = Application.Current.MainWindow;
             _config = LazyConfig.Instance.GetConfig();
             _config.globalHotkeys ??= new List<KeyEventItem>();

--- a/v2rayN/v2rayN/Views/MainWindow.xaml
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml
@@ -15,8 +15,6 @@
     Title="v2rayN"
     Width="900"
     Height="700"
-    MinWidth="900"
-    MinHeight="700"
     x:TypeArguments="vms:MainWindowViewModel"
     Background="{DynamicResource MaterialDesignPaper}"
     FontFamily="{x:Static conv:MaterialDesignFonts.MyFont}"

--- a/v2rayN/v2rayN/Views/MainWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml.cs
@@ -26,8 +26,15 @@ namespace v2rayN.Views
         {
             InitializeComponent();
 
-            this.MaxWidth = SystemParameters.WorkArea.Width;
-            this.MaxHeight = SystemParameters.WorkArea.Height;
+            // 设置窗口的尺寸不大于屏幕的尺寸
+            if (this.Width > SystemParameters.WorkArea.Width)
+            {
+                this.Width = SystemParameters.WorkArea.Width;
+            }
+            if (this.Height > SystemParameters.WorkArea.Height)
+            {
+                this.Height = SystemParameters.WorkArea.Height;
+            }
 
             _config = LazyConfig.Instance.GetConfig();
 

--- a/v2rayN/v2rayN/Views/MainWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml.cs
@@ -25,6 +25,10 @@ namespace v2rayN.Views
         public MainWindow()
         {
             InitializeComponent();
+
+            this.MaxWidth = SystemParameters.WorkArea.Width;
+            this.MaxHeight = SystemParameters.WorkArea.Height;
+
             _config = LazyConfig.Instance.GetConfig();
 
             App.Current.SessionEnding += Current_SessionEnding;

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
@@ -18,6 +18,10 @@ namespace v2rayN.Views
         public OptionSettingWindow()
         {
             InitializeComponent();
+
+            this.MaxWidth = SystemParameters.WorkArea.Width;
+            this.MaxHeight = SystemParameters.WorkArea.Height;
+
             this.Owner = Application.Current.MainWindow;
             _config = LazyConfig.Instance.GetConfig();
 

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
@@ -19,8 +19,15 @@ namespace v2rayN.Views
         {
             InitializeComponent();
 
-            this.MaxWidth = SystemParameters.WorkArea.Width;
-            this.MaxHeight = SystemParameters.WorkArea.Height;
+            // 设置窗口的尺寸不大于屏幕的尺寸
+            if (this.Width > SystemParameters.WorkArea.Width)
+            {
+                this.Width = SystemParameters.WorkArea.Width;
+            }
+            if (this.Height > SystemParameters.WorkArea.Height)
+            {
+                this.Height = SystemParameters.WorkArea.Height;
+            }
 
             this.Owner = Application.Current.MainWindow;
             _config = LazyConfig.Instance.GetConfig();

--- a/v2rayN/v2rayN/Views/RoutingRuleDetailsWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/RoutingRuleDetailsWindow.xaml.cs
@@ -12,6 +12,10 @@ namespace v2rayN.Views
         public RoutingRuleDetailsWindow(RulesItem rulesItem)
         {
             InitializeComponent();
+
+            this.MaxWidth = SystemParameters.WorkArea.Width;
+            this.MaxHeight = SystemParameters.WorkArea.Height;
+
             this.Owner = Application.Current.MainWindow;
             this.Loaded += Window_Loaded;
             clbProtocol.SelectionChanged += ClbProtocol_SelectionChanged;

--- a/v2rayN/v2rayN/Views/RoutingRuleDetailsWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/RoutingRuleDetailsWindow.xaml.cs
@@ -13,8 +13,15 @@ namespace v2rayN.Views
         {
             InitializeComponent();
 
-            this.MaxWidth = SystemParameters.WorkArea.Width;
-            this.MaxHeight = SystemParameters.WorkArea.Height;
+            // 设置窗口的尺寸不大于屏幕的尺寸
+            if (this.Width > SystemParameters.WorkArea.Width)
+            {
+                this.Width = SystemParameters.WorkArea.Width;
+            }
+            if (this.Height > SystemParameters.WorkArea.Height)
+            {
+                this.Height = SystemParameters.WorkArea.Height;
+            }
 
             this.Owner = Application.Current.MainWindow;
             this.Loaded += Window_Loaded;

--- a/v2rayN/v2rayN/Views/RoutingRuleSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/RoutingRuleSettingWindow.xaml.cs
@@ -13,6 +13,10 @@ namespace v2rayN.Views
         public RoutingRuleSettingWindow(RoutingItem routingItem)
         {
             InitializeComponent();
+
+            this.MaxWidth = SystemParameters.WorkArea.Width;
+            this.MaxHeight = SystemParameters.WorkArea.Height;
+
             this.Owner = Application.Current.MainWindow;
             this.Loaded += Window_Loaded;
             this.PreviewKeyDown += RoutingRuleSettingWindow_PreviewKeyDown;

--- a/v2rayN/v2rayN/Views/RoutingRuleSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/RoutingRuleSettingWindow.xaml.cs
@@ -14,8 +14,15 @@ namespace v2rayN.Views
         {
             InitializeComponent();
 
-            this.MaxWidth = SystemParameters.WorkArea.Width;
-            this.MaxHeight = SystemParameters.WorkArea.Height;
+            // 设置窗口的尺寸不大于屏幕的尺寸
+            if (this.Width > SystemParameters.WorkArea.Width)
+            {
+                this.Width = SystemParameters.WorkArea.Width;
+            }
+            if (this.Height > SystemParameters.WorkArea.Height)
+            {
+                this.Height = SystemParameters.WorkArea.Height;
+            }
 
             this.Owner = Application.Current.MainWindow;
             this.Loaded += Window_Loaded;

--- a/v2rayN/v2rayN/Views/RoutingSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/RoutingSettingWindow.xaml.cs
@@ -12,6 +12,10 @@ namespace v2rayN.Views
         public RoutingSettingWindow()
         {
             InitializeComponent();
+
+            this.MaxWidth = SystemParameters.WorkArea.Width;
+            this.MaxHeight = SystemParameters.WorkArea.Height;
+
             this.Owner = Application.Current.MainWindow;
             this.Closing += RoutingSettingWindow_Closing;
             this.PreviewKeyDown += RoutingSettingWindow_PreviewKeyDown;

--- a/v2rayN/v2rayN/Views/RoutingSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/RoutingSettingWindow.xaml.cs
@@ -13,8 +13,15 @@ namespace v2rayN.Views
         {
             InitializeComponent();
 
-            this.MaxWidth = SystemParameters.WorkArea.Width;
-            this.MaxHeight = SystemParameters.WorkArea.Height;
+            // 设置窗口的尺寸不大于屏幕的尺寸
+            if (this.Width > SystemParameters.WorkArea.Width)
+            {
+                this.Width = SystemParameters.WorkArea.Width;
+            }
+            if (this.Height > SystemParameters.WorkArea.Height)
+            {
+                this.Height = SystemParameters.WorkArea.Height;
+            }
 
             this.Owner = Application.Current.MainWindow;
             this.Closing += RoutingSettingWindow_Closing;

--- a/v2rayN/v2rayN/Views/SubEditWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/SubEditWindow.xaml.cs
@@ -11,6 +11,10 @@ namespace v2rayN.Views
         public SubEditWindow(SubItem subItem)
         {
             InitializeComponent();
+
+            this.MaxWidth = SystemParameters.WorkArea.Width;
+            this.MaxHeight = SystemParameters.WorkArea.Height;
+
             this.Owner = Application.Current.MainWindow;
             this.Loaded += Window_Loaded;
 

--- a/v2rayN/v2rayN/Views/SubEditWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/SubEditWindow.xaml.cs
@@ -12,8 +12,15 @@ namespace v2rayN.Views
         {
             InitializeComponent();
 
-            this.MaxWidth = SystemParameters.WorkArea.Width;
-            this.MaxHeight = SystemParameters.WorkArea.Height;
+            // 设置窗口的尺寸不大于屏幕的尺寸
+            if (this.Width > SystemParameters.WorkArea.Width)
+            {
+                this.Width = SystemParameters.WorkArea.Width;
+            }
+            if (this.Height > SystemParameters.WorkArea.Height)
+            {
+                this.Height = SystemParameters.WorkArea.Height;
+            }
 
             this.Owner = Application.Current.MainWindow;
             this.Loaded += Window_Loaded;

--- a/v2rayN/v2rayN/Views/SubSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/SubSettingWindow.xaml.cs
@@ -13,6 +13,10 @@ namespace v2rayN.Views
         public SubSettingWindow()
         {
             InitializeComponent();
+
+            this.MaxWidth = SystemParameters.WorkArea.Width;
+            this.MaxHeight = SystemParameters.WorkArea.Height;
+
             this.Owner = Application.Current.MainWindow;
 
             ViewModel = new SubSettingViewModel(this);

--- a/v2rayN/v2rayN/Views/SubSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/SubSettingWindow.xaml.cs
@@ -14,8 +14,15 @@ namespace v2rayN.Views
         {
             InitializeComponent();
 
-            this.MaxWidth = SystemParameters.WorkArea.Width;
-            this.MaxHeight = SystemParameters.WorkArea.Height;
+            // 设置窗口的尺寸不大于屏幕的尺寸
+            if (this.Width > SystemParameters.WorkArea.Width)
+            {
+                this.Width = SystemParameters.WorkArea.Width;
+            }
+            if (this.Height > SystemParameters.WorkArea.Height)
+            {
+                this.Height = SystemParameters.WorkArea.Height;
+            }
 
             this.Owner = Application.Current.MainWindow;
 


### PR DESCRIPTION
1080p的笔记本, 屏幕13寸, 把缩放开到175%, 会出现窗口的高大于屏幕的高的情况.
显示不完全, 使用体验不好.
<img width="349" alt="Telegram_2023-07-01_03-21-26" src="https://github.com/2dust/v2rayN/assets/665889/f9f04d97-4e83-4b0d-a6a5-67c80f3486af">

修改说明:
在窗口初始化时, 
```
this.MaxWidth = SystemParameters.WorkArea.Width;
this.MaxHeight = SystemParameters.WorkArea.Height;
```
主窗口的最小尺寸设置值去掉.
```
MinWidth="900"
MinHeight="700"
```
https://zelikk.blogspot.com/2023/07/v2rayn-systemparameters-workarea-width-height.html