### PR TITLE
修正 juicity 启动参数少了 run

### DIFF
--- a/v2rayN/v2rayN/Handler/LazyConfig.cs
+++ b/v2rayN/v2rayN/Handler/LazyConfig.cs
@@ -358,7 +358,7 @@ namespace v2rayN.Handler
             {
                 coreType = ECoreType.juicity,
                 coreExes = new List<string> { "juicity-client", "juicity" },
-                arguments = "-c config.json",
+                arguments = "run -c config.json",
                 coreUrl = Global.juicityCoreUrl
             });
         }


### PR DESCRIPTION
它的客户端启动参数是 `./juicity-client run -c config.json`

文档链接 https://github.com/juicity/juicity/blob/main/cmd/client/README.md#run