### PR TITLE
加载节点列表时, 去除重复节点

### DIFF
--- a/v2rayN/v2rayN/Handler/ConfigHandler.cs
+++ b/v2rayN/v2rayN/Handler/ConfigHandler.cs
@@ -889,7 +889,7 @@ namespace v2rayN.Handler
             return 0;
         }
 
-        private static bool CompareProfileItem(ProfileItem o, ProfileItem n, bool remarks)
+        public static bool CompareProfileItem(ProfileItem o, ProfileItem n, bool remarks)
         {
             if (o == null || n == null)
             {
@@ -909,6 +909,12 @@ namespace v2rayN.Handler
                 && (o.configType == EConfigType.Trojan || o.streamSecurity == n.streamSecurity)
                 && o.flow == n.flow
                 && o.sni == n.sni
+                && o.alpn == n.alpn
+                && o.allowInsecure == n.allowInsecure
+                && o.fingerprint == n.fingerprint
+                && o.publicKey == n.publicKey
+                && o.shortId == n.shortId
+                && o.spiderX == n.spiderX
                 && (!remarks || o.remarks == n.remarks);
         }
 

--- a/v2rayN/v2rayN/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/v2rayN/ViewModels/MainWindowViewModel.cs
@@ -765,7 +765,23 @@ namespace v2rayN.ViewModels
             _subId = SelectedSub?.id;
             _config.subIndexId = _subId;
 
-            RefreshServers();
+            // RefreshServers();
+
+            // 读取节点列表 lstModel
+            List<ProfileItemModel> lstModel = LoadProfilelist();
+
+            // lstModel 节点去重 不修改底层保存的节点数据
+            List<ProfileItemModel> lstKeep = new();
+            foreach (ProfileItemModel item in lstModel)
+            {
+                if (!lstKeep.Exists(i => ConfigHandler.CompareProfileItem(i, item, false)))
+                {
+                    lstKeep.Add(item);
+                }
+            }
+
+            // 向界面显示节点列表 lstModel
+            DisplayProfilelist(lstKeep);
 
             _updateView(EViewAction.ProfilesFocus);
         }
@@ -785,8 +801,20 @@ namespace v2rayN.ViewModels
 
         public void RefreshServers()
         {
+            List<ProfileItemModel> lstModel = LoadProfilelist();
+
+            DisplayProfilelist(lstModel);
+        }
+
+        private List<ProfileItemModel> LoadProfilelist()
+        {
             List<ProfileItemModel> lstModel = LazyConfig.Instance.ProfileItems(_subId, _serverFilter);
 
+            return lstModel;
+        }
+
+        private void DisplayProfilelist(List<ProfileItemModel> lstModel)
+        {
             ConfigHandler.SetDefaultServer(_config, lstModel);
 
             List<ServerStatItem> lstServerStat = new();


### PR DESCRIPTION
这个去重不会修改底层保存的节点数据, 只是在界面显示之前去重.
不影响现在的 菜单中的去重操作. (菜单中的去重操作是会修改底层保存的节点数据的)

修改思路:
https://zelikk.blogspot.com/2023/09/v2rayn-subselectedchanged-removeduplicateserver.html
https://zelikk.blogspot.com/2023/09/v2rayn-compareprofileitem.html