### PR TITLE
Removed Main Toolbar `<Separator>`s

### DIFF
--- a/v2rayN/v2rayN/Views/MainWindow.xaml
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml
@@ -94,7 +94,6 @@
                                     Header="{x:Static resx:ResUI.menuAddServerViaScan}" />
                             </MenuItem>
                         </Menu>
-                        <Separator />
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
                             <MenuItem Padding="8,0">
                                 <MenuItem.Header>
@@ -129,7 +128,6 @@
                                     Header="{x:Static resx:ResUI.menuSubGroupUpdateViaProxy}" />
                             </MenuItem>
                         </Menu>
-                        <Separator />
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
                             <MenuItem Padding="8,0">
                                 <MenuItem.Header>
@@ -178,7 +176,6 @@
                                     Header="{x:Static resx:ResUI.menuImportOldGuiConfig}" />
                             </MenuItem>
                         </Menu>
-                        <Separator />
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
                             <MenuItem x:Name="menuReload" Padding="8,0">
                                 <MenuItem.Header>
@@ -192,7 +189,6 @@
                                 </MenuItem.Header>
                             </MenuItem>
                         </Menu>
-                        <Separator />
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
                             <MenuItem Padding="8,0">
                                 <MenuItem.Header>
@@ -241,7 +237,6 @@
                                     Header="Geo files" />
                             </MenuItem>
                         </Menu>
-                        <Separator />
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
                             <MenuItem x:Name="menuHelp" Padding="8,0">
                                 <MenuItem.Header>
@@ -255,7 +250,6 @@
                                 </MenuItem.Header>
                             </MenuItem>
                         </Menu>
-                        <Separator />
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
                             <MenuItem
                                 x:Name="menuPromotion"
@@ -272,7 +266,6 @@
                                 </MenuItem.Header>
                             </MenuItem>
                         </Menu>
-                        <Separator />
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
                             <MenuItem
                                 x:Name="menuClose"

--- a/v2rayN/v2rayN/Views/MainWindow.xaml
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml
@@ -48,7 +48,7 @@
                         ClipToBounds="True"
                         Style="{StaticResource MaterialDesignToolBar}">
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
-                            <MenuItem Padding="8,0">
+                            <MenuItem Padding="12,0,16,0">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <materialDesign:PackIcon
@@ -95,7 +95,7 @@
                             </MenuItem>
                         </Menu>
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
-                            <MenuItem Padding="8,0">
+                            <MenuItem Padding="12,0,16,0">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <materialDesign:PackIcon
@@ -129,7 +129,7 @@
                             </MenuItem>
                         </Menu>
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
-                            <MenuItem Padding="8,0">
+                            <MenuItem Padding="12,0,16,0">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <materialDesign:PackIcon
@@ -177,7 +177,7 @@
                             </MenuItem>
                         </Menu>
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
-                            <MenuItem x:Name="menuReload" Padding="8,0">
+                            <MenuItem x:Name="menuReload" Padding="12,0,16,0">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <materialDesign:PackIcon
@@ -190,7 +190,7 @@
                             </MenuItem>
                         </Menu>
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
-                            <MenuItem Padding="8,0">
+                            <MenuItem Padding="12,0,16,0">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <materialDesign:PackIcon
@@ -238,7 +238,7 @@
                             </MenuItem>
                         </Menu>
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
-                            <MenuItem x:Name="menuHelp" Padding="8,0">
+                            <MenuItem x:Name="menuHelp" Padding="12,0,16,0">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <materialDesign:PackIcon
@@ -253,7 +253,7 @@
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
                             <MenuItem
                                 x:Name="menuPromotion"
-                                Padding="8,0"
+                                Padding="12,0,16,0"
                                 Click="menuPromotion_Click">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
@@ -269,7 +269,7 @@
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
                             <MenuItem
                                 x:Name="menuClose"
-                                Padding="8,0"
+                                Padding="12,0,16,0"
                                 Click="menuClose_Click">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
@@ -284,7 +284,7 @@
                         </Menu>
 
                         <materialDesign:PopupBox
-                            Padding="8,0"
+                            Padding="12,0,16,0"
                             HorizontalAlignment="Right"
                             StaysOpen="True"
                             Style="{StaticResource MaterialDesignToolForegroundPopupBox}">

--- a/v2rayN/v2rayN/Views/RoutingSettingWindow.xaml
+++ b/v2rayN/v2rayN/Views/RoutingSettingWindow.xaml
@@ -36,7 +36,7 @@
                 ClipToBounds="True"
                 Style="{StaticResource MaterialDesignToolBar}">
                 <Menu Margin="0,8" Style="{StaticResource ToolbarMenu}">
-                    <MenuItem x:Name="menuRoutingBasic" Padding="8,0">
+                    <MenuItem x:Name="menuRoutingBasic" Padding="12,0,16,0">
                         <MenuItem.Header>
                             <StackPanel Orientation="Horizontal">
                                 <materialDesign:PackIcon
@@ -53,7 +53,7 @@
                     </MenuItem>
                 </Menu>
                 <Menu Margin="0,8" Style="{StaticResource ToolbarMenu}">
-                    <MenuItem x:Name="menuRoutingAdvanced" Padding="8,0">
+                    <MenuItem x:Name="menuRoutingAdvanced" Padding="12,0,16,0">
                         <MenuItem.Header>
                             <StackPanel Orientation="Horizontal">
                                 <materialDesign:PackIcon


### PR DESCRIPTION
Hi

The top one is the new one (it looks cleaner):

![Screenshot 2023-09-26 230003](https://github.com/2dust/v2rayN/assets/44144724/f4c67749-6fa9-4f31-8af7-805f00f9f966)

https://github.com/2dust/v2rayN/assets/44144724/a3964585-64b5-4bcc-be06-c72b3531f128
