### PR TITLE
Update the H.NotifyIcon to show default system tooltip for sys tray icon.

### DIFF
--- a/v2rayN/v2rayN/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/v2rayN/ViewModels/MainWindowViewModel.cs
@@ -210,8 +210,8 @@ namespace v2rayN.ViewModels
         [Reactive]
         public string RunningServerDisplay { get; set; }
 
-        //[Reactive]
-        //public string RunningServerToolTipText { get; set; }
+        [Reactive]
+        public string RunningServerToolTipText { get; set; }
 
         [Reactive]
         public string RunningInfoDisplay { get; set; }
@@ -849,12 +849,12 @@ namespace v2rayN.ViewModels
                 {
                     var runningSummary = running.GetSummary();
                     RunningServerDisplay = $"{ResUI.menuServers}:{runningSummary}";
-                    //RunningServerToolTipText = runningSummary;
+                    RunningServerToolTipText = runningSummary;
                 }
                 else
                 {
                     RunningServerDisplay = ResUI.CheckServerSettings;
-                    //RunningServerToolTipText = ResUI.CheckServerSettings;
+                    RunningServerToolTipText = ResUI.CheckServerSettings;
                 }
             }));
         }

--- a/v2rayN/v2rayN/Views/MainWindow.xaml
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml
@@ -751,6 +751,7 @@
             <tb:TaskbarIcon
                 x:Name="tbNotify"
                 IconSource="/v2rayN.ico"
+                ToolTipText="v2rayN"
                 NoLeftClickDelay="True">
                 <tb:TaskbarIcon.ContextMenu>
                     <ContextMenu Style="{StaticResource DefContextMenu}">

--- a/v2rayN/v2rayN/Views/MainWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml.cs
@@ -174,7 +174,7 @@ namespace v2rayN.Views
                 this.BindCommand(ViewModel, vm => vm.SubUpdateViaProxyCmd, v => v.menuSubUpdateViaProxy2).DisposeWith(disposables);
 
                 this.OneWayBind(ViewModel, vm => vm.NotifyIcon, v => v.tbNotify.Icon).DisposeWith(disposables);
-                //this.OneWayBind(ViewModel, vm => vm.RunningServerToolTipText, v => v.tbNotify.ToolTipText).DisposeWith(disposables);
+                this.OneWayBind(ViewModel, vm => vm.RunningServerToolTipText, v => v.tbNotify.ToolTipText).DisposeWith(disposables);
                 this.OneWayBind(ViewModel, vm => vm.NotifyLeftClickCmd, v => v.tbNotify.LeftClickCommand).DisposeWith(disposables);
                 this.OneWayBind(ViewModel, vm => vm.AppIcon, v => v.Icon).DisposeWith(disposables);
                 //this.OneWayBind(ViewModel, vm => vm.BlShowTrayTip, v => v.borTrayToolTip.Visibility).DisposeWith(disposables);

--- a/v2rayN/v2rayN/v2rayN.csproj
+++ b/v2rayN/v2rayN/v2rayN.csproj
@@ -16,7 +16,7 @@
 	<ItemGroup>
 		<PackageReference Include="Downloader" Version="3.0.6" />		
 		<PackageReference Include="MaterialDesignThemes" Version="4.9.0" />
-		<PackageReference Include="H.NotifyIcon.Wpf" Version="2.0.117" />
+		<PackageReference Include="H.NotifyIcon.Wpf" Version="2.0.118" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="QRCoder.Xaml" Version="1.4.3" />
 		<PackageReference Include="sqlite-net-pcl" Version="1.8.116" />

--- a/v2rayN/v2rayN/v2rayN.csproj
+++ b/v2rayN/v2rayN/v2rayN.csproj
@@ -16,7 +16,7 @@
 	<ItemGroup>
 		<PackageReference Include="Downloader" Version="3.0.6" />		
 		<PackageReference Include="MaterialDesignThemes" Version="4.9.0" />
-		<PackageReference Include="H.NotifyIcon.Wpf" Version="2.0.108" />
+		<PackageReference Include="H.NotifyIcon.Wpf" Version="2.0.117" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="QRCoder.Xaml" Version="1.4.3" />
 		<PackageReference Include="sqlite-net-pcl" Version="1.8.116" />


### PR DESCRIPTION
The latest `H.NotifyIcon` update will use the default system tooltip when there is no custom tooltip control defined, thus resolving the issues for sys tray icon tooltip display on Win11.

Related issue for the package update:
https://github.com/HavenDV/H.NotifyIcon/issues/94

Tooltip display in this PR:
![image](https://github.com/2dust/v2rayN/assets/17916222/e414cf1f-4074-4628-adc3-dbbea4d85a89)
