### PR TITLE
Fix that editing the basic routing settings will trigger unexpected error messages.

### DIFF
--- a/v2rayN/v2rayN/Views/RoutingSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/RoutingSettingWindow.xaml.cs
@@ -88,6 +88,11 @@ namespace v2rayN.Views
 
         private void RoutingSettingWindow_PreviewKeyDown(object sender, KeyEventArgs e)
         {
+            if (ViewModel?.enableRoutingBasic ?? false)
+            {
+                return;
+            }
+
             if (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl))
             {
                 if (e.Key == Key.A)


### PR DESCRIPTION
Looks like the key down handler is useless when the user is interacting with basic routing settings window, and the handler will trigger unexpected error messages during the editing process. The current behavior makes the basic routing editing experience very unpleasant.

Current behavior:
The following error message will appear when press editing (Enter, Delete, Ctrl + A) keys in the basic routing settings window.
<img width="740" alt="image" src="https://github.com/2dust/v2rayN/assets/17916222/7b03b8f1-4013-47e1-aa6d-f51ba945c9b7">

This PR:
The handler will ignore the editing key presses fired from the basic routing settings window.