### PR TITLE
Add Update CoreTypeName

### DIFF
--- a/v2rayN/v2rayN/Handler/UpdateHandle.cs
+++ b/v2rayN/v2rayN/Handler/UpdateHandle.cs
@@ -427,7 +427,7 @@ namespace v2rayN.Handler
                     case ECoreType.v2fly_v5:
                         {
                             curVersion = getCoreVersion(type);
-                            message = string.Format(ResUI.IsLatestCore, curVersion.ToVersionString("v"));
+                            message = string.Format(ResUI.IsLatestCore, type, curVersion.ToVersionString("v"));
                             string osBit = "64";
                             switch (RuntimeInformation.ProcessArchitecture)
                             {
@@ -451,7 +451,7 @@ namespace v2rayN.Handler
                     case ECoreType.clash_meta:
                         {
                             curVersion = getCoreVersion(type);
-                            message = string.Format(ResUI.IsLatestCore, curVersion);
+                            message = string.Format(ResUI.IsLatestCore, type, curVersion);
                             switch (RuntimeInformation.ProcessArchitecture)
                             {
                                 case Architecture.Arm64:
@@ -472,7 +472,7 @@ namespace v2rayN.Handler
                     case ECoreType.sing_box:
                         {
                             curVersion = getCoreVersion(type);
-                            message = string.Format(ResUI.IsLatestCore, curVersion.ToVersionString("v"));
+                            message = string.Format(ResUI.IsLatestCore, type, curVersion.ToVersionString("v"));
                             switch (RuntimeInformation.ProcessArchitecture)
                             {
                                 case Architecture.Arm64:
@@ -493,7 +493,7 @@ namespace v2rayN.Handler
                     case ECoreType.v2rayN:
                         {
                             curVersion = new SemanticVersion(FileVersionInfo.GetVersionInfo(Utils.GetExePath()).FileVersion.ToString());
-                            message = string.Format(ResUI.IsLatestN, curVersion);
+                            message = string.Format(ResUI.IsLatestN, type, curVersion);
                             switch (RuntimeInformation.ProcessArchitecture)
                             {
                                 case Architecture.Arm64:

--- a/v2rayN/v2rayN/Resx/ResUI.fa-Ir.resx
+++ b/v2rayN/v2rayN/Resx/ResUI.fa-Ir.resx
@@ -187,10 +187,10 @@
     <value>پیکربندی اولیه</value>
   </data>
   <data name="IsLatestCore" xml:space="preserve">
-    <value>{0} در حال حاضر به روز است.</value>
+    <value>{0} {1} در حال حاضر به روز است.</value>
   </data>
   <data name="IsLatestN" xml:space="preserve">
-    <value>{0} در حال حاضر به روز است.</value>
+    <value>{0} {1} در حال حاضر به روز است.</value>
   </data>
   <data name="LvAddress" xml:space="preserve">
     <value>آدرس</value>

--- a/v2rayN/v2rayN/Resx/ResUI.resx
+++ b/v2rayN/v2rayN/Resx/ResUI.resx
@@ -187,10 +187,10 @@
     <value>Initial Configuration</value>
   </data>
   <data name="IsLatestCore" xml:space="preserve">
-    <value>{0} already up to date.</value>
+    <value>{0} {1} already up to date.</value>
   </data>
   <data name="IsLatestN" xml:space="preserve">
-    <value>{0} already up to date.</value>
+    <value>{0} {1} already up to date.</value>
   </data>
   <data name="LvAddress" xml:space="preserve">
     <value>Address</value>

--- a/v2rayN/v2rayN/Resx/ResUI.ru.resx
+++ b/v2rayN/v2rayN/Resx/ResUI.ru.resx
@@ -187,10 +187,10 @@
     <value>Исходная конфигурация</value>
   </data>
   <data name="IsLatestCore" xml:space="preserve">
-    <value>{0} является последней версией.</value>
+    <value>{0} {1} является последней версией.</value>
   </data>
   <data name="IsLatestN" xml:space="preserve">
-    <value>{0} является последней версией.</value>
+    <value>{0} {1} является последней версией.</value>
   </data>
   <data name="LvAddress" xml:space="preserve">
     <value>Адрес</value>

--- a/v2rayN/v2rayN/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/v2rayN/Resx/ResUI.zh-Hans.resx
@@ -187,10 +187,10 @@
     <value>初始化配置</value>
   </data>
   <data name="IsLatestCore" xml:space="preserve">
-    <value>{0} 已是最新版本。</value>
+    <value>{0} {1} 已是最新版本。</value>
   </data>
   <data name="IsLatestN" xml:space="preserve">
-    <value>{0} 已是最新版本。</value>
+    <value>{0} {1} 已是最新版本。</value>
   </data>
   <data name="LvAddress" xml:space="preserve">
     <value>地址</value>

--- a/v2rayN/v2rayN/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/v2rayN/Resx/ResUI.zh-Hant.resx
@@ -187,10 +187,10 @@
     <value>初始化配置</value>
   </data>
   <data name="IsLatestCore" xml:space="preserve">
-    <value>{0} 已是最新版本。</value>
+    <value>{0} {1} 已是最新版本。</value>
   </data>
   <data name="IsLatestN" xml:space="preserve">
-    <value>{0} 已是最新版本。</value>
+    <value>{0} {1} 已是最新版本。</value>
   </data>
   <data name="LvAddress" xml:space="preserve">
     <value>位址</value>


### PR DESCRIPTION
在检查更新菜单中依次连续点击每个更新项的时候，会连续监测每个项目的更新，并在信息窗口做出提示，但是没有告知是哪个选项的版本号已经是最新版本，有时候以为没有点那个选项进行更新。
![image](https://github.com/2dust/v2rayN/assets/11498170/c0ff184f-46a1-42f4-9348-03919101a14a)
简单检查代码发现只需要输出信息的地方添加一个Type就可以显示，没有多少改动。
![image](https://github.com/2dust/v2rayN/assets/11498170/606f159b-bb3d-4fa7-9313-ebc35d69a90a)

_可能只是我个人的习惯问题。_