### PR TITLE
fix: 当关闭"是否跟随系统主题"时，无法应用"暗黑模式"的设置

### DIFF
--- a/v2rayN/v2rayN/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/v2rayN/ViewModels/MainWindowViewModel.cs
@@ -1726,6 +1726,10 @@ namespace v2rayN.ViewModels
                             {
                                 ModifyTheme(!Utils.IsLightTheme());
                             }
+                            else
+                            {
+                                ModifyTheme(ColorModeDark);
+                            }
                         }
                     });
 


### PR DESCRIPTION
当系统主题为`Light`，开启`暗黑模式`时，当前主题切换为`Dark`
开启`是否跟随系统主题`，当前主题切换为`Light`
关闭`是否跟随系统主题`，当前主题仍为`Light`，但预期应该是`Dark`