### PR TITLE
build(ci): bump actions/upload-artifact from v3 to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,13 +36,12 @@ jobs:
     #     7z a -mx9 ..\v2rayN.7z $env:Wap_Project_Directory
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: v2rayN
-        path: 
+        path: |
           .\v2rayN\v2rayN.zip
 
-      
     # - name: Release
     #   uses: softprops/action-gh-release@v1
     #   env:


### PR DESCRIPTION
bump actions/upload-artifact from v3 to v4, as [actions/upload-artifact@v3 is running on Node.js v16](https://github.com/actions/upload-artifact/blob/a8a3f3ad30e3422c9c7b888a15615d19a852ae32/action.yml#L27), [which is going to be deprecated in GitHub Actions runner](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/). Using [actions/upload-artifact@v4](https://github.com/actions/upload-artifact/blob/cf8714cfeaba5687a442b9bcb85b29e23f468dfa/action.yml#L45) (which is running on Node.js v20) could resolve this.
