### PR TITLE
添加简单的分流功能；修改修改非管理员模式下tun模式启动逻辑

### DIFF
--- a/v2rayN/v2rayN/Mode/RulesItem.cs
+++ b/v2rayN/v2rayN/Mode/RulesItem.cs
@@ -12,6 +12,9 @@
 
         public string outboundTag { get; set; }
 
+        // 分流修改
+        public string bingServerIndexId { get; set; }
+
         public List<string> ip { get; set; }
 
         public List<string> domain { get; set; }

--- a/v2rayN/v2rayN/Sample/tun_singbox_rules
+++ b/v2rayN/v2rayN/Sample/tun_singbox_rules
@@ -1,9 +1,5 @@
 [
   {
-    "protocol": [ "dns" ],
-    "outbound": "dns_out"
-  },
-  {
     "network": "udp",
     "port": [
       135,
@@ -16,13 +12,6 @@
   },
   {
     "ip_cidr": [
-      "224.0.0.0/3",
-      "ff00::/8"
-    ],
-    "outbound": "block"
-  },
-  {
-    "source_ip_cidr": [
       "224.0.0.0/3",
       "ff00::/8"
     ],

--- a/v2rayN/v2rayN/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/v2rayN/ViewModels/MainWindowViewModel.cs
@@ -1621,6 +1621,12 @@ namespace v2rayN.ViewModels
             if (_config.tunModeItem.enableTun != EnableTun)
             {
                 _config.tunModeItem.enableTun = EnableTun;
+                // 非管理员运行时tun模式开启逻辑修改
+                if (!Utils.IsAdministrator())
+                {
+                    RebootAsAdmin();
+                    return;
+                }
                 Reload();
             }
         }
@@ -1839,7 +1845,7 @@ namespace v2rayN.ViewModels
             if (_config.uiItem.autoHideStartup)
             {
                 Observable.Range(1, 1)
-                 .Delay(TimeSpan.FromSeconds(2))
+                 .Delay(TimeSpan.FromSeconds(0.5)) // 隐藏时间修改
                  .Subscribe(x =>
                  {
                      Application.Current.Dispatcher.Invoke(() =>

--- a/v2rayN/v2rayN/Views/MainWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml.cs
@@ -212,7 +212,8 @@ namespace v2rayN.Views
             var IsAdministrator = Utils.IsAdministrator();
             this.Title = $"{Utils.GetVersion()} - {(IsAdministrator ? ResUI.RunAsAdmin : ResUI.NotRunAsAdmin)}";
 
-            spEnableTun.Visibility = IsAdministrator ? Visibility.Visible : Visibility.Collapsed;
+            // 非管理员运行时tun模式开启逻辑修改
+            // spEnableTun.Visibility = IsAdministrator ? Visibility.Visible : Visibility.Collapsed;
 
             //if (_config.uiItem.autoHideStartup)
             //{

--- a/v2rayN/v2rayN/Views/RoutingRuleDetailsWindow.xaml
+++ b/v2rayN/v2rayN/Views/RoutingRuleDetailsWindow.xaml
@@ -52,7 +52,22 @@
                 Margin="4"
                 MaxDropDownHeight="1000"
                 Style="{StaticResource DefComboBox}" />
-
+            
+            <TextBlock
+                Grid.Column="1"
+                Margin="230,0,186,0"
+                VerticalAlignment="Center"
+                Style="{StaticResource ToolbarTextBlock}"
+                Text="outboundIndexId" />
+                        <ComboBox
+                x:Name="cmbOutboundIndexId"
+                Grid.Column="1"
+                Width="200"
+                Margin="354,4,0,5"
+                HorizontalAlignment="Left"
+                Style="{StaticResource DefComboBox}"
+                IsEnabled="False" />
+            
             <TextBlock
                 Grid.Row="1"
                 Grid.Column="0"


### PR DESCRIPTION
 ### 1.添加了简单的分流功能，效果如下：
![image](https://github.com/2dust/v2rayN/assets/35186451/639f85c1-a90e-4524-ac3b-501df689e1ce)
![image](https://github.com/2dust/v2rayN/assets/35186451/3e7dffd5-4e90-47db-96a5-95abff98642e)
![image](https://github.com/2dust/v2rayN/assets/35186451/bd805d2f-1fb8-421e-98dc-0b3df5d2b5ba)
### 2.非管理员身份运行时正常显示"启用tun模式"按钮，开启时软件自动以管理员身份重启并打开tun模式
![image](https://github.com/2dust/v2rayN/assets/35186451/eec9cbcc-ec6c-48fa-adaf-33ee0c3f6cc8)
![image](https://github.com/2dust/v2rayN/assets/35186451/73ef7cec-e4b2-4529-bab7-538832dbd3fa)
### 3.缩短自动隐藏时间为0.5秒（想改成像老版本那样直接隐藏，但是不了解c# /(ㄒoㄒ)/~~暂时没时间研究，求助！）