### PR TITLE
Fix misleading "Cannot mix synchronous and asynchronous operation on process stream." logs.

### DIFF
--- a/v2rayN/v2rayN/Handler/CoreHandler.cs
+++ b/v2rayN/v2rayN/Handler/CoreHandler.cs
@@ -147,7 +147,7 @@ namespace v2rayN.Handler
             }
         }
 
-        private string CoreFindexe(CoreInfo coreInfo)
+        private string CoreFindExe(CoreInfo coreInfo)
         {
             string fileName = string.Empty;
             foreach (string name in coreInfo.coreExes)
@@ -225,7 +225,7 @@ namespace v2rayN.Handler
             try
             {
                 var coreInfo = LazyConfig.Instance.GetCoreInfo(ECoreType.Xray);
-                string fileName = CoreFindexe(coreInfo);
+                string fileName = CoreFindExe(coreInfo);
                 if (fileName == "") return -1;
 
                 Process p = new()
@@ -269,6 +269,7 @@ namespace v2rayN.Handler
 
                 if (p.WaitForExit(1000))
                 {
+                    p.CancelErrorRead();
                     throw new Exception(p.StandardError.ReadToEnd());
                 }
 
@@ -295,7 +296,7 @@ namespace v2rayN.Handler
         {
             try
             {
-                string fileName = CoreFindexe(coreInfo);
+                string fileName = CoreFindExe(coreInfo);
                 if (Utils.IsNullOrEmpty(fileName))
                 {
                     return null;
@@ -343,6 +344,7 @@ namespace v2rayN.Handler
 
                 if (proc.WaitForExit(1000))
                 {
+                    proc.CancelErrorRead();
                     throw new Exception(displayLog ? proc.StandardError.ReadToEnd() : "启动进程失败并退出 (Failed to start the process and exited)");
                 }
 


### PR DESCRIPTION
By searching via Google with the following keywords: *cannot mix synchronous and asynchronous operation on process stream. site:github.com*, there are many results in the repo that showing misleading logs to the users and maintainers, since the log is originated from the `proc.StandardError.ReadToEnd()` calls not from the core the user wished to start.

According to the [doc](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.standardoutput?view=net-8.0), it is not able to start both synchronous and asynchronous redirections on the same process stream object. `v2rayN` starts the asynchronous redirection of `stderr` and `stdout`, and when the core fails to start, `v2rayN` starts the synchronous redirection of `stderr`, which triggers the exception in the PR title.