### PR TITLE
Fix the state ports conflicts when multiple `v2rayN` instances start in a short period.

### DIFF
--- a/v2rayN/v2rayN/Handler/LazyConfig.cs
+++ b/v2rayN/v2rayN/Handler/LazyConfig.cs
@@ -11,14 +11,24 @@ namespace v2rayN.Handler
 
         public static LazyConfig Instance => _instance.Value;
 
-        private int _statePort;
-        public int StatePort { get => _statePort; }
-        private Job _processJob  = new();
+        private int? _statePort;
+        public int StatePort
+        {
+            get
+            {
+                if (_statePort is null)
+                {
+                    _statePort = Utils.GetFreePort();
+                }
+
+                return _statePort.Value;
+            }
+        }
+
+        private Job _processJob = new();
 
         public LazyConfig()
         {
-            _statePort = Utils.GetFreePort();
-
             SqliteHelper.Instance.CreateTable<SubItem>();
             SqliteHelper.Instance.CreateTable<ProfileItem>();
             SqliteHelper.Instance.CreateTable<ServerStatItem>();
@@ -68,7 +78,7 @@ namespace v2rayN.Handler
             }
             return localPort;
         }
-        
+
         public void AddProcess(IntPtr processHandle)
         {
             _processJob.AddProcess(processHandle);


### PR DESCRIPTION
If the `v2rayN` starts and the core does not start the state port will be the value resolved during the `v2rayN` initialization, which may be the same and cause confilct with the other consequent `v2rayN` instances.

The PR postpones when to resolve `StatePort` from the `v2rayN` initialization to the first time the statistics component calls the property.