### PR TITLE
Update schdtask related code

### DIFF
--- a/v2rayN/v2rayN/Common/Utile.cs
+++ b/v2rayN/v2rayN/Common/Utile.cs
@@ -1136,7 +1136,7 @@ namespace v2rayN
             task.Settings.ExecutionTimeLimit = TimeSpan.Zero;
             task.Triggers.Add(new LogonTrigger { UserId = logonUser, Delay = TimeSpan.FromSeconds(10) });
             task.Principal.RunLevel = TaskRunLevel.Highest;
-            task.Actions.Add(new ExecAction(deamonFileName));
+            task.Actions.Add(new ExecAction(deamonFileName, null, Path.GetDirectoryName(deamonFileName)));
 
             taskService.RootFolder.RegisterTaskDefinition(TaskName, task);
         }


### PR DESCRIPTION
设置计划任务开机启动的起始位置为程序储存目录

解决了
- 相对目录自定义图标无法显示
- 无法排序服务器
- 和其他