### PR TITLE
恢复使用pnputil的方式清除sing-tun可能残留下的wintun设备驱动

### DIFF
--- a/v2rayN/v2rayN/Common/Utils.cs
+++ b/v2rayN/v2rayN/Common/Utils.cs
@@ -1186,6 +1186,7 @@ namespace v2rayN
                 if (success && size == instanceIdSize && instanceId.ToString() == deviceInstanceId)
                 {
                     isRemoved = SetupAPI.SetupDiRemoveDevice(devs, ref devInfo);
+                    break;
                 }
             }
             SetupAPI.SetupDiDestroyDeviceInfoList(devs);

--- a/v2rayN/v2rayN/Common/Utils.cs
+++ b/v2rayN/v2rayN/Common/Utils.cs
@@ -22,7 +22,6 @@ using ZXing;
 using ZXing.Common;
 using ZXing.QrCode;
 using ZXing.Windows.Compatibility;
-using Vanara.PInvoke;
 
 namespace v2rayN
 {
@@ -1142,12 +1141,12 @@ namespace v2rayN
             taskService.RootFolder.RegisterTaskDefinition(TaskName, task);
         }
 
-        public static void RemoveTunDevice()
+        public static void RemoveDeviceForPnputil(string removeArg)
         {
             try
             {
                 string pnputilPath = @"C:\Windows\System32\pnputil.exe";
-                string arg = $" /remove-device /deviceid \"wintun\"";
+                string arg = $" /remove-device " + removeArg;
 
                 // Try to remove the device
                 Process proc = new()
@@ -1169,29 +1168,6 @@ namespace v2rayN
             catch
             {
             }
-        }
-
-        public static bool RemoveDeviceByDevIstId(string deviceInstanceId)
-        {
-            var isRemoved = false;
-            var devs = SetupAPI.SetupDiGetClassDevs(SetupAPI.GUID_DEVCLASS_NET, null, HWND.NULL, SetupAPI.DIGCF.DIGCF_PROFILE);
-            var instanceIdSize = deviceInstanceId.Length + 1;
-            var devInfo = new SetupAPI.SP_DEVINFO_DATA() { cbSize = (uint)Marshal.SizeOf<SetupAPI.SP_DEVINFO_DATA>() };
-            var instanceId = new StringBuilder(instanceIdSize);
-            uint index = 0;
-
-            while (SetupAPI.SetupDiEnumDeviceInfo(devs, index++, ref devInfo))
-            {
-                var success = SetupAPI.SetupDiGetDeviceInstanceId(devs, devInfo, instanceId, (uint)instanceIdSize, out uint size);
-                if (success && size == instanceIdSize && instanceId.ToString() == deviceInstanceId)
-                {
-                    isRemoved = SetupAPI.SetupDiRemoveDevice(devs, ref devInfo);
-                    break;
-                }
-            }
-            SetupAPI.SetupDiDestroyDeviceInfoList(devs);
-
-            return isRemoved;
         }
 
         public static string GetSingboxTunDeviceInstanceId(string deviceName)

--- a/v2rayN/v2rayN/Global.cs
+++ b/v2rayN/v2rayN/Global.cs
@@ -43,6 +43,7 @@ namespace v2rayN
         public const string DNSV2rayNormalFileName = "v2rayN.Sample.dns_v2ray_normal";
         public const string DNSSingboxNormalFileName = "v2rayN.Sample.dns_singbox_normal";
 
+        public const string DefaultSingboxTunDeviceName = "tun_singbox";
         public const string DefaultSecurity = "auto";
         public const string DefaultNetwork = "tcp";
         public const string TcpHeaderHttp = "http";

--- a/v2rayN/v2rayN/Handler/CoreHandler.cs
+++ b/v2rayN/v2rayN/Handler/CoreHandler.cs
@@ -54,7 +54,7 @@ namespace v2rayN.Handler
             {
                 ShowMsg(true, $"{node!.GetSummary()}");
                 CoreStop();
-                Utils.RemoveTunDevice();
+                Utils.RemoveDeviceByDevIstId(Utils.GetSingboxTunDeviceInstanceId(Global.DefaultSingboxTunDeviceName));
                 CoreStart(node);
             }
             executingResetEvents.ForEach(result => result.Set());

--- a/v2rayN/v2rayN/Handler/CoreHandler.cs
+++ b/v2rayN/v2rayN/Handler/CoreHandler.cs
@@ -54,7 +54,7 @@ namespace v2rayN.Handler
             {
                 ShowMsg(true, $"{node!.GetSummary()}");
                 CoreStop();
-                Utils.RemoveDeviceByDevIstId(Utils.GetSingboxTunDeviceInstanceId(Global.DefaultSingboxTunDeviceName));
+                Utils.RemoveDeviceForPnputil(Utils.GetSingboxTunDeviceInstanceId(Global.DefaultSingboxTunDeviceName));
                 CoreStart(node);
             }
             executingResetEvents.ForEach(result => result.Set());

--- a/v2rayN/v2rayN/v2rayN.csproj
+++ b/v2rayN/v2rayN/v2rayN.csproj
@@ -20,8 +20,7 @@
 		<PackageReference Include="H.NotifyIcon.Wpf" Version="2.0.124" />
 		<PackageReference Include="QRCoder.Xaml" Version="1.4.3" />
 		<PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
-		<PackageReference Include="TaskScheduler" Version="2.10.1" />
-		<PackageReference Include="Vanara.PInvoke.SetupAPI" Version="4.0.0" /> 
+		<PackageReference Include="TaskScheduler" Version="2.10.1" /> 
 		<PackageReference Include="ZXing.Net.Bindings.Windows.Compatibility" Version="0.16.12" />
 		<PackageReference Include="ReactiveUI.Fody" Version="19.5.41" />
 		<PackageReference Include="ReactiveUI.Validation" Version="3.1.7" />

--- a/v2rayN/v2rayN/v2rayN.csproj
+++ b/v2rayN/v2rayN/v2rayN.csproj
@@ -20,7 +20,8 @@
 		<PackageReference Include="H.NotifyIcon.Wpf" Version="2.0.124" />
 		<PackageReference Include="QRCoder.Xaml" Version="1.4.3" />
 		<PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
-		<PackageReference Include="TaskScheduler" Version="2.10.1" /> 
+		<PackageReference Include="TaskScheduler" Version="2.10.1" />
+		<PackageReference Include="Vanara.PInvoke.SetupAPI" Version="4.0.0" /> 
 		<PackageReference Include="ZXing.Net.Bindings.Windows.Compatibility" Version="0.16.12" />
 		<PackageReference Include="ReactiveUI.Fody" Version="19.5.41" />
 		<PackageReference Include="ReactiveUI.Validation" Version="3.1.7" />


### PR DESCRIPTION
如果只是不希望引入第三方库的话，那使用pnputil传入instance ID参数也能实现精准匹配并删除本程序启动的singbox残留下的wintun设备驱动。原来是通过匹配deviceid的方式清除设备驱动，个人觉得这样有点一刀切了，因为这样会清除所有使用Wintun API创建的tun设备，而不管是不是本程序启动的singbox创建的。
还有就是我打算添加全局热键开启和关闭Tun mode的功能，所以加固了一下在比较频繁执行LoadCore方法的情况下的稳定性。