### PR TITLE
修复分享为已经带[]的IPv6地址添加[]的问题

### DIFF
--- a/v2rayN/v2rayN/Handler/ShareHandler.cs
+++ b/v2rayN/v2rayN/Handler/ShareHandler.cs
@@ -264,7 +264,7 @@ namespace v2rayN.Handler
 
         private static string GetIpv6(string address)
         {
-            return Utils.IsIpv6(address) ? $"[{address}]" : address;
+            return Utils.IsIpv6(address) ? address.Contains("[") ? address : $"[{address}]" : address;
         }
 
         private static int GetStdTransport(ProfileItem item, string? securityDef, ref Dictionary<string, string> dicQuery)


### PR DESCRIPTION
当节点地址为带[]格式的IPv6地址时，节点可以正常使用
但在分享时由于**IsIpv6**方法会对该格式的IPv6地址返回`true`
加上**GetIpv6**方法的逻辑问题(`Utils.IsIpv6(address) ? $"[{address}]" : address;`)
使其依旧会对address添加[]导致分享的链接/二维码无法正常使用
需要再增加一个条件以判断该IPv6地址是否需要额外加[]