### PR TITLE
asynchronous font reading and rectified the previous issue.

### DIFF
--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
@@ -91,6 +91,7 @@ namespace v2rayN.Views
             });
 
             LoadFontsAsync();  //If there are many font files, opening the OptionSettingWindow will noticeably lag. The font loading logic can be changed to execute asynchronously.
+            cmbcurrentFontFamily.Items.Add(string.Empty);
 
             this.WhenActivated(disposables =>
             {


### PR DESCRIPTION
I restored this line of code: 
cmbCurrentFontFamily.Items.Add(string.Empty); 
This allowed the OptionSettingViewModel to successfully bind events.