### PR TITLE
Extend stats reporting to support custom load-balanced configs with several outbounds

### DIFF
--- a/v2rayN/v2rayN/Handler/StatisticsV2ray.cs
+++ b/v2rayN/v2rayN/Handler/StatisticsV2ray.cs
@@ -87,6 +87,8 @@ namespace v2rayN.Handler
         private void ParseOutput(Google.Protobuf.Collections.RepeatedField<Stat> source, out ServerSpeedItem server)
         {
             server = new();
+            long aggregateProxyUp = 0;
+            long aggregateProxyDown = 0;
             try
             {
                 foreach (Stat stat in source)
@@ -101,15 +103,15 @@ namespace v2rayN.Handler
                     name = nStr[1];
                     type = nStr[3];
 
-                    if (name == Global.ProxyTag)
+                    if (name.StartsWith(Global.ProxyTag))
                     {
                         if (type == "uplink")
                         {
-                            server.proxyUp = value;
+                            aggregateProxyUp += value;
                         }
                         else if (type == "downlink")
                         {
-                            server.proxyDown = value;
+                            aggregateProxyDown += value;
                         }
                     }
                     else if (name == Global.DirectTag)
@@ -124,6 +126,8 @@ namespace v2rayN.Handler
                         }
                     }
                 }
+                server.proxyUp = aggregateProxyUp;
+                server.proxyDown = aggregateProxyDown;
             }
             catch
             {


### PR DESCRIPTION
Hello
This pull request makes simple modifications (to a single file) to allow correct stats reporting and display for custom (json) configs with several outbounds (matches any outbound tags starting with `proxy` instead of exact match). 

Custom (json) configs with several outbounds are used in load-balanced configs. Because now there are several outbounds, a single `proxy `tag will not suffice and the outbounds might have to be be tagged as `proxy1`, `proxy2`, `proxy_1`, `proxy_2`, etc. The current v2rayN version cannot handle these cases and reports nothing for their traffic. 

This pull request remedies the situation by simply aggregating traffic for all such matching outbounds (separately, of course, for uplink and down-link). It was tested and confirmed to work with existing normal configs, custom configs and new load-balanced (multi-outbound) configs.


Thank you.