### PR TITLE
Adjust singbox DNS server and rule position

### DIFF
--- a/v2rayN/v2rayN/Handler/CoreConfig/CoreConfigSingbox.cs
+++ b/v2rayN/v2rayN/Handler/CoreConfig/CoreConfigSingbox.cs
@@ -841,13 +841,13 @@ namespace v2rayN.Handler.CoreConfig
             if (lstDomain != null && lstDomain.Count > 0)
             {
                 var tag = "local_local";
-                dns4Sbox.servers.Insert(0, new()
+                dns4Sbox.servers.Add(new()
                 {
                     tag = tag,
                     address = "223.5.5.5",
                     detour = Global.DirectTag,
                 });
-                dns4Sbox.rules.Insert(0, new()
+                dns4Sbox.rules.Add(new()
                 {
                     server = tag,
                     domain = lstDomain


### PR DESCRIPTION
对使用自定DNS的人来说，之前生成DNS的server和rule位置可能和他们所需要自定义DNS希望的行为不一致，添加的兜底的server和rule应该是为了保证server的域名能够正常解析，所以希望能够把他们后移