### PR TITLE
Setting subs-group name from the optional `remarks` query parameter in the pasted subs url

### DIFF
--- a/v2rayN/v2rayN/Handler/ConfigHandler.cs
+++ b/v2rayN/v2rayN/Handler/ConfigHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.Data;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Web;
 using v2rayN.Enums;
 using v2rayN.Handler.Fmt;
 using v2rayN.Models;
@@ -1355,15 +1356,19 @@ namespace v2rayN.Handler
         public static int AddSubItem(Config config, string url)
         {
             //already exists
-            if (SQLiteHelper.Instance.Table<SubItem>().Where(e => e.url == url).Count() > 0)
+            if (SQLiteHelper.Instance.Table<SubItem>().Any(e => e.url == url))
             {
                 return 0;
             }
 
+            var uri = new Uri(url);
+            var queryVars = HttpUtility.ParseQueryString(uri.Query);
+            string remarks = queryVars["remarks"] ?? "import_sub";
+
             SubItem subItem = new()
             {
                 id = string.Empty,
-                remarks = "import_sub",
+                remarks = remarks,
                 url = url
             };
 


### PR DESCRIPTION
This PR adds support for setting the subs-group `remarks ` property (group's name) from the optional `remarks` query parameter in the pasted subs url. 

If no query parameter is supplied in the subs url then, subs group's `remarks ` property is set to the default/old value of `import_sub` (to make it  fully compatible with the old behavior).

For example, if the url  `http://example.com/subs/example-id?remarks=BestVpn`  is pasted in v2rayN, then will show as: 


![2024_06_22_13_43_53_v2rayN_V6 45_2024_06_22_Not_run_as_Admin](https://github.com/2dust/v2rayN/assets/114700833/2c2b8ef6-ae04-42db-a853-151788550910)



