### PR TITLE
Ability to specify sources of geo files in settings.

### DIFF
--- a/v2rayN/ServiceLib/Global.cs
+++ b/v2rayN/ServiceLib/Global.cs
@@ -114,6 +114,11 @@
             @"http://www.msftconnecttest.com/connecttest.txt",
         };
 
+        public static readonly List<string> GeoFilesSources = new() {
+            GeoUrl,
+            @"https://github.com/runetfreedom/russia-v2ray-rules-dat/releases/latest/download/{0}.dat",
+        };
+
         public static readonly Dictionary<string, string> UserAgentTexts = new()
         {
             {"chrome","Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36" },

--- a/v2rayN/ServiceLib/Models/ConfigItems.cs
+++ b/v2rayN/ServiceLib/Models/ConfigItems.cs
@@ -103,6 +103,8 @@
         public int trayMenuServersLimit { get; set; } = 20;
 
         public bool enableHWA { get; set; } = false;
+
+        public string geoSourceUrl { get; set; }
     }
 
     [Serializable]

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -3003,7 +3003,18 @@ namespace ServiceLib.Resx {
                 return ResourceManager.GetString("TbSettingsFontSize", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Get Geo files source.
+        /// </summary>
+        public static string TbSettingsGeoFilesSource
+        {
+            get
+            {
+                return ResourceManager.GetString("TbSettingsGeoFilesSource", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   查找类似 HTTP Port 的本地化字符串。
         /// </summary>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1322,9 +1322,12 @@
     <value>Host filter</value>
   </data>
   <data name="TipActiveServer" xml:space="preserve">
-    <value>Active</value>    
+    <value>Active</value>
   </data>
   <data name="menuStorageUI" xml:space="preserve">
     <value>Save Interface Layout</value>
+  </data>
+  <data name="TbSettingsGeoFilesSource" xml:space="preserve">
+    <value>Geo files source</value>
   </data>
 </root>

--- a/v2rayN/ServiceLib/Services/UpdateService.cs
+++ b/v2rayN/ServiceLib/Services/UpdateService.cs
@@ -255,8 +255,8 @@ namespace ServiceLib.Services
 
         public async Task UpdateGeoFileAll(Config config, Action<bool, string> updateFunc)
         {
-            await UpdateGeoFile("geosite", _config, updateFunc);
-            await UpdateGeoFile("geoip", _config, updateFunc);
+            await UpdateGeoFile("geosite", config, updateFunc);
+            await UpdateGeoFile("geoip", config, updateFunc);
             _updateFunc?.Invoke(true, string.Format(ResUI.MsgDownloadGeoFileSuccessfully, "geo"));
         }
 
@@ -450,7 +450,8 @@ namespace ServiceLib.Services
         {
             _config = config;
             _updateFunc = updateFunc;
-            var url = string.Format(Global.GeoUrl, geoName);
+            var geoUrl = !String.IsNullOrEmpty(config?.guiItem.geoSourceUrl) ? config.guiItem.geoSourceUrl : Global.GeoUrl;
+            var url = string.Format(geoUrl, geoName);
             var fileName = Utils.GetTempPath(Utils.GetGUID());
 
             DownloadService downloadHandle = new();

--- a/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
@@ -65,6 +65,7 @@ namespace ServiceLib.ViewModels
         [Reactive] public bool EnableHWA { get; set; }
         [Reactive] public string SubConvertUrl { get; set; }
         [Reactive] public int MainGirdOrientation { get; set; }
+        [Reactive] public string GeoFileSourceUrl { get; set; }
 
         #endregion UI
 
@@ -164,6 +165,7 @@ namespace ServiceLib.ViewModels
             EnableHWA = _config.guiItem.enableHWA;
             SubConvertUrl = _config.constItem.subConvertUrl;
             MainGirdOrientation = (int)_config.uiItem.mainGirdOrientation;
+            GeoFileSourceUrl = _config.guiItem.geoSourceUrl;
 
             #endregion UI
 
@@ -316,6 +318,7 @@ namespace ServiceLib.ViewModels
             _config.guiItem.enableHWA = EnableHWA;
             _config.constItem.subConvertUrl = SubConvertUrl;
             _config.uiItem.mainGirdOrientation = (EGirdOrientation)MainGirdOrientation;
+            _config.guiItem.geoSourceUrl = GeoFileSourceUrl;
 
             //systemProxy
             _config.systemProxyItem.systemProxyExceptions = systemProxyExceptions;

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
@@ -364,6 +364,7 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
@@ -607,6 +608,19 @@
                         <ComboBox
                             x:Name="cmbMainGirdOrientation"
                             Grid.Row="21"
+                            Grid.Column="1"
+                            Width="300"
+                            Classes="Margin8" />
+
+                        <TextBlock
+                            Grid.Row="22"
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Classes="Margin8"
+                            Text="{x:Static resx:ResUI.TbSettingsGeoFilesSource}" />
+                        <ComboBox
+                            x:Name="cmbGetFilesSourceUrl"
+                            Grid.Row="22"
                             Grid.Column="1"
                             Width="300"
                             Classes="Margin8" />

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
@@ -83,6 +83,10 @@ namespace v2rayN.Desktop.Views
             {
                 cmbSubConvertUrl.Items.Add(it);
             });
+            Global.GeoFilesSources.ForEach(it =>
+            {
+                cmbGetFilesSourceUrl.Items.Add(it);
+            });
             foreach (EGirdOrientation it in Enum.GetValues(typeof(EGirdOrientation)))
             {
                 cmbMainGirdOrientation.Items.Add(it.ToString());
@@ -132,6 +136,7 @@ namespace v2rayN.Desktop.Views
                 this.Bind(ViewModel, vm => vm.SpeedPingTestUrl, v => v.cmbSpeedPingTestUrl.SelectedValue).DisposeWith(disposables);
                 this.Bind(ViewModel, vm => vm.SubConvertUrl, v => v.cmbSubConvertUrl.SelectedValue).DisposeWith(disposables);
                 this.Bind(ViewModel, vm => vm.MainGirdOrientation, v => v.cmbMainGirdOrientation.SelectedIndex).DisposeWith(disposables);
+                this.Bind(ViewModel, vm => vm.GeoFileSourceUrl, v => v.cmbGetFilesSourceUrl.SelectedValue).DisposeWith(disposables);
 
                 this.Bind(ViewModel, vm => vm.notProxyLocalAddress, v => v.tognotProxyLocalAddress.IsChecked).DisposeWith(disposables);
                 this.Bind(ViewModel, vm => vm.systemProxyAdvancedProtocol, v => v.cmbsystemProxyAdvancedProtocol.SelectedValue).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
@@ -528,6 +528,7 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
@@ -844,6 +845,23 @@
                             Grid.Column="1"
                             Width="300"
                             Margin="{StaticResource SettingItemMargin}"
+                            Style="{StaticResource DefComboBox}" />
+
+
+                        <TextBlock
+                            Grid.Row="22"
+                            Grid.Column="0"
+                            Margin="{StaticResource SettingItemMargin}"
+                            VerticalAlignment="Center"
+                            Style="{StaticResource ToolbarTextBlock}"
+                            Text="{x:Static resx:ResUI.TbSettingsGeoFilesSource}" />
+                        <ComboBox
+                            x:Name="cmbGetFilesSourceUrl"
+                            Grid.Row="22"
+                            Grid.Column="1"
+                            Width="300"
+                            Margin="{StaticResource SettingItemMargin}"
+                            IsEditable="True"
                             Style="{StaticResource DefComboBox}" />
                     </Grid>
                 </ScrollViewer>

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
@@ -85,6 +85,10 @@ namespace v2rayN.Views
             {
                 cmbSubConvertUrl.Items.Add(it);
             });
+            Global.GeoFilesSources.ForEach(it =>
+            {
+                cmbGetFilesSourceUrl.Items.Add(it);
+            });
             foreach (EGirdOrientation it in Enum.GetValues(typeof(EGirdOrientation)))
             {
                 cmbMainGirdOrientation.Items.Add(it.ToString());
@@ -145,6 +149,7 @@ namespace v2rayN.Views
                 this.Bind(ViewModel, vm => vm.EnableHWA, v => v.togEnableHWA.IsChecked).DisposeWith(disposables);
                 this.Bind(ViewModel, vm => vm.SubConvertUrl, v => v.cmbSubConvertUrl.Text).DisposeWith(disposables);
                 this.Bind(ViewModel, vm => vm.MainGirdOrientation, v => v.cmbMainGirdOrientation.SelectedIndex).DisposeWith(disposables);
+                this.Bind(ViewModel, vm => vm.GeoFileSourceUrl, v => v.cmbGetFilesSourceUrl.Text).DisposeWith(disposables);
 
                 this.Bind(ViewModel, vm => vm.notProxyLocalAddress, v => v.tognotProxyLocalAddress.IsChecked).DisposeWith(disposables);
                 this.Bind(ViewModel, vm => vm.systemProxyAdvancedProtocol, v => v.cmbsystemProxyAdvancedProtocol.Text).DisposeWith(disposables);


### PR DESCRIPTION
Hello! 

In Russia many people use v2rayN, but we have a global problem - now v2rayN is primarily focused on China, I mean routing rules and geo files. 

Current geo files do not allow us to fully create our own rules, as they do not contain anything related to our reality.

In this PR I propose to allow setting the sources of geo files in the settings, and I propose my own repository that generates geo files on the same way as [@loyalsoldier/v2ray-rules-dat](https://github.com/Loyalsoldier/v2ray-rules-dat), but with lists of domains and subnets blocked in Russia.

Thank you!