### PR TITLE
Fix broken TUN if custom geo file is selected

### DIFF
--- a/v2rayN/ServiceLib/Global.cs
+++ b/v2rayN/ServiceLib/Global.cs
@@ -114,9 +114,19 @@
             @"http://www.msftconnecttest.com/connecttest.txt",
         };
 
+        public static readonly List<string> GeoSourceNames = new() {
+            "", //Default
+            "Russia",
+        };
+
         public static readonly List<string> GeoFilesSources = new() {
             GeoUrl,
             @"https://github.com/runetfreedom/russia-v2ray-rules-dat/releases/latest/download/{0}.dat",
+        };
+
+        public static readonly List<string> SingboxRulesetSources = new() {
+            SingboxRulesetUrl,
+            @"https://raw.githubusercontent.com/runetfreedom/russia-v2ray-rules-dat/refs/heads/release/sing-box/rule-set-{0}/{1}.srs",
         };
 
         public static readonly Dictionary<string, string> UserAgentTexts = new()

--- a/v2rayN/ServiceLib/Models/ConfigItems.cs
+++ b/v2rayN/ServiceLib/Models/ConfigItems.cs
@@ -140,7 +140,7 @@
     {
         public string defIEProxyExceptions { get; set; }
         public string subConvertUrl { get; set; } = string.Empty;
-        public string? geoSourceUrl { get; set; }
+        public int geoSource { get; set; } = 0;
     }
 
     [Serializable]

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1367,12 +1367,16 @@ namespace ServiceLib.Services.CoreConfig
                     }
                     else
                     {
+                        var geoUrl = Global.SingboxRulesetSources.Count <= _config.constItem.geoSource
+                            ? Global.SingboxRulesetUrl
+                            : Global.SingboxRulesetSources[_config.constItem.geoSource];
+
                         customRuleset = new()
                         {
                             type = "remote",
                             format = "binary",
                             tag = item,
-                            url = string.Format(Global.SingboxRulesetUrl, item.StartsWith(geosite) ? geosite : geoip, item),
+                            url = string.Format(geoUrl, item.StartsWith(geosite) ? geosite : geoip, item),
                             download_detour = Global.ProxyTag
                         };
                     }

--- a/v2rayN/ServiceLib/Services/UpdateService.cs
+++ b/v2rayN/ServiceLib/Services/UpdateService.cs
@@ -451,10 +451,11 @@ namespace ServiceLib.Services
             _config = config;
             _updateFunc = updateFunc;
 
-            var geoUrl = string.IsNullOrEmpty(config?.constItem.geoSourceUrl)
+            var geoIndex = config?.constItem.geoSource ?? 0;
+            var geoUrl = Global.GeoFilesSources.Count <= geoIndex
                 ? Global.GeoUrl
-                : config.constItem.geoSourceUrl;
-            var url = string.Format(Global.GeoUrl, geoName);
+                : Global.GeoFilesSources[geoIndex];
+            var url = string.Format(geoUrl, geoName);
             var fileName = Utils.GetTempPath(Utils.GetGuid());
 
             DownloadService downloadHandle = new();

--- a/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
@@ -65,7 +65,7 @@ namespace ServiceLib.ViewModels
         [Reactive] public bool EnableHWA { get; set; }
         [Reactive] public string SubConvertUrl { get; set; }
         [Reactive] public int MainGirdOrientation { get; set; }
-        [Reactive] public string GeoFileSourceUrl { get; set; }
+        [Reactive] public int GeoFileSource { get; set; }
 
         #endregion UI
 
@@ -165,7 +165,7 @@ namespace ServiceLib.ViewModels
             EnableHWA = _config.guiItem.enableHWA;
             SubConvertUrl = _config.constItem.subConvertUrl;
             MainGirdOrientation = (int)_config.uiItem.mainGirdOrientation;
-            GeoFileSourceUrl = _config.constItem.geoSourceUrl;
+            GeoFileSource = _config.constItem.geoSource;
 
             #endregion UI
 
@@ -318,7 +318,7 @@ namespace ServiceLib.ViewModels
             _config.guiItem.enableHWA = EnableHWA;
             _config.constItem.subConvertUrl = SubConvertUrl;
             _config.uiItem.mainGirdOrientation = (EGirdOrientation)MainGirdOrientation;
-            _config.constItem.geoSourceUrl = GeoFileSourceUrl;
+            _config.constItem.geoSource = GeoFileSource;
 
             //systemProxy
             _config.systemProxyItem.systemProxyExceptions = systemProxyExceptions;

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
@@ -619,7 +619,7 @@
                             Classes="Margin8"
                             Text="{x:Static resx:ResUI.TbSettingsGeoFilesSource}" />
                         <ComboBox
-                            x:Name="cmbGetFilesSourceUrl"
+                            x:Name="cmbGetFilesSource"
                             Grid.Row="22"
                             Grid.Column="1"
                             Width="300"

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
@@ -83,9 +83,9 @@ namespace v2rayN.Desktop.Views
             {
                 cmbSubConvertUrl.Items.Add(it);
             });
-            Global.GeoFilesSources.ForEach(it =>
+            Global.GeoSourceNames.ForEach(it =>
             {
-                cmbGetFilesSourceUrl.Items.Add(it);
+                cmbGetFilesSource.Items.Add(it);
             });
             foreach (EGirdOrientation it in Enum.GetValues(typeof(EGirdOrientation)))
             {
@@ -136,7 +136,7 @@ namespace v2rayN.Desktop.Views
                 this.Bind(ViewModel, vm => vm.SpeedPingTestUrl, v => v.cmbSpeedPingTestUrl.SelectedValue).DisposeWith(disposables);
                 this.Bind(ViewModel, vm => vm.SubConvertUrl, v => v.cmbSubConvertUrl.SelectedValue).DisposeWith(disposables);
                 this.Bind(ViewModel, vm => vm.MainGirdOrientation, v => v.cmbMainGirdOrientation.SelectedIndex).DisposeWith(disposables);
-                this.Bind(ViewModel, vm => vm.GeoFileSourceUrl, v => v.cmbGetFilesSourceUrl.SelectedValue).DisposeWith(disposables);
+                this.Bind(ViewModel, vm => vm.GeoFileSource, v => v.cmbGetFilesSource.SelectedIndex).DisposeWith(disposables);
 
                 this.Bind(ViewModel, vm => vm.notProxyLocalAddress, v => v.tognotProxyLocalAddress.IsChecked).DisposeWith(disposables);
                 this.Bind(ViewModel, vm => vm.systemProxyAdvancedProtocol, v => v.cmbsystemProxyAdvancedProtocol.SelectedValue).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
@@ -855,12 +855,12 @@
                             Style="{StaticResource ToolbarTextBlock}"
                             Text="{x:Static resx:ResUI.TbSettingsGeoFilesSource}" />
                         <ComboBox
-                            x:Name="cmbGetFilesSourceUrl"
+                            x:Name="cmbGetFilesSource"
                             Grid.Row="22"
                             Grid.Column="1"
                             Width="300"
                             Margin="{StaticResource Margin8}"
-                            IsEditable="True"
+                            IsEditable="False"
                             Style="{StaticResource DefComboBox}" />
                     </Grid>
                 </ScrollViewer>

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
@@ -85,9 +85,9 @@ namespace v2rayN.Views
             {
                 cmbSubConvertUrl.Items.Add(it);
             });
-            Global.GeoFilesSources.ForEach(it =>
+            Global.GeoSourceNames.ForEach(it =>
             {
-                cmbGetFilesSourceUrl.Items.Add(it);
+                cmbGetFilesSource.Items.Add(it);
             });
             foreach (EGirdOrientation it in Enum.GetValues(typeof(EGirdOrientation)))
             {
@@ -149,7 +149,7 @@ namespace v2rayN.Views
                 this.Bind(ViewModel, vm => vm.EnableHWA, v => v.togEnableHWA.IsChecked).DisposeWith(disposables);
                 this.Bind(ViewModel, vm => vm.SubConvertUrl, v => v.cmbSubConvertUrl.Text).DisposeWith(disposables);
                 this.Bind(ViewModel, vm => vm.MainGirdOrientation, v => v.cmbMainGirdOrientation.SelectedIndex).DisposeWith(disposables);
-                this.Bind(ViewModel, vm => vm.GeoFileSourceUrl, v => v.cmbGetFilesSourceUrl.Text).DisposeWith(disposables);
+                this.Bind(ViewModel, vm => vm.GeoFileSource, v => v.cmbGetFilesSource.SelectedIndex).DisposeWith(disposables);
 
                 this.Bind(ViewModel, vm => vm.notProxyLocalAddress, v => v.tognotProxyLocalAddress.IsChecked).DisposeWith(disposables);
                 this.Bind(ViewModel, vm => vm.systemProxyAdvancedProtocol, v => v.cmbsystemProxyAdvancedProtocol.Text).DisposeWith(disposables);


### PR DESCRIPTION
Hello!

While doing #5829, I did not take into account that a sing-box is started for TUN mode. Since the previous implementation does not support srs files, TUN mode was broken if categories that are not in the main repository were used.

Since it doesn't seem to make sense to specify geo and srs sources separately, I converted the checkbox to a list of source types (empty by default).

I thought about leaving the ability to specify geoUrl and srsUrl in the config via json, but no one seems to want that, although it brings additional code that will have to be maintained.

I apologize for having to ask you to review this again