### PR TITLE
External routing rules templates + regional presets support

### DIFF
--- a/v2rayN/ServiceLib/Enums/EPresetType.cs
+++ b/v2rayN/ServiceLib/Enums/EPresetType.cs
@@ -1,0 +1,8 @@
+﻿namespace ServiceLib.Enums
+{
+    public enum EPresetType
+    {
+        Default = 0,
+        Russia = 1,
+    }
+}

--- a/v2rayN/ServiceLib/Global.cs
+++ b/v2rayN/ServiceLib/Global.cs
@@ -124,6 +124,11 @@
             @"https://raw.githubusercontent.com/runetfreedom/russia-v2ray-rules-dat/refs/heads/release/sing-box/rule-set-{0}/{1}.srs",
         };
 
+        public static readonly List<string> RoutingRulesSources = new() {
+            "", //Default
+            @"https://raw.githubusercontent.com/runetfreedom/russia-v2ray-custom-routing-list/refs/heads/main/template.json",
+        };
+
         public static readonly Dictionary<string, string> UserAgentTexts = new()
         {
             {"chrome","Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36" },

--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -1788,5 +1788,31 @@ namespace ServiceLib.Handler
         }
 
         #endregion DNS
+
+        #region Presets
+
+        public static bool ApplyPreset(Config config, EPresetType type) 
+        {
+            switch (type)
+            {
+                case EPresetType.Default:
+                    config.constItem.geoSourceUrl = "";
+                    config.constItem.srsSourceUrl = "";
+                    config.constItem.routeRulesTemplateSourceUrl = "";
+
+                    return true;
+
+                case EPresetType.Russia:
+                    config.constItem.geoSourceUrl = Global.GeoFilesSources[1];
+                    config.constItem.srsSourceUrl = Global.SingboxRulesetSources[1];
+                    config.constItem.routeRulesTemplateSourceUrl = Global.RoutingRulesSources[1];
+
+                    return true;
+            }
+
+            return false;
+        }
+
+        #endregion
     }
 }

--- a/v2rayN/ServiceLib/Models/ConfigItems.cs
+++ b/v2rayN/ServiceLib/Models/ConfigItems.cs
@@ -142,6 +142,7 @@
         public string subConvertUrl { get; set; } = string.Empty;
         public string? geoSourceUrl { get; set; }
         public string? srsSourceUrl { get; set; }
+        public string? routeRulesTemplateSourceUrl { get; set; }
     }
 
     [Serializable]

--- a/v2rayN/ServiceLib/Models/RoutingTemplate.cs
+++ b/v2rayN/ServiceLib/Models/RoutingTemplate.cs
@@ -1,0 +1,9 @@
+﻿namespace ServiceLib.Models
+{
+    [Serializable]
+    public class RoutingTemplate
+    {
+        public string version { get; set; }
+        public RoutingItem[] routingItems { get; set; }
+    }
+}

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -1114,6 +1114,33 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Regional presets 的本地化字符串。
+        /// </summary>
+        public static string menuPresets {
+            get {
+                return ResourceManager.GetString("menuPresets", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Default 的本地化字符串。
+        /// </summary>
+        public static string menuPresetsDefault {
+            get {
+                return ResourceManager.GetString("menuPresetsDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Russia 的本地化字符串。
+        /// </summary>
+        public static string menuPresetsRussia {
+            get {
+                return ResourceManager.GetString("menuPresetsRussia", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Auto column width adjustment 的本地化字符串。
         /// </summary>
         public static string menuProfileAutofitColumnWidth {

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -3014,6 +3014,17 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Routing rules source (optional) 的本地化字符串。
+        /// </summary>
+        public static string TbSettingsRoutingRulesSource
+        {
+            get
+            {
+                return ResourceManager.GetString("TbSettingsRoutingRulesSource", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   查找类似 HTTP Port 的本地化字符串。
         /// </summary>
         public static string TbSettingsHttpPort {

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1336,4 +1336,7 @@
   <data name="UpgradeAppNotExistTip" xml:space="preserve">
     <value>UpgradeApp does not exist</value>
   </data>
+  <data name="TbSettingsRoutingRulesSource" xml:space="preserve">
+    <value>Routing rules source (optional)</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1339,4 +1339,13 @@
   <data name="TbSettingsRoutingRulesSource" xml:space="preserve">
     <value>Routing rules source (optional)</value>
   </data>
+  <data name="menuPresets" xml:space="preserve">
+    <value>Regional presets</value>
+  </data>
+  <data name="menuPresetsDefault" xml:space="preserve">
+    <value>Default</value>
+  </data>
+  <data name="menuPresetsRussia" xml:space="preserve">
+    <value>Russia</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Services/UpdateService.cs
+++ b/v2rayN/ServiceLib/Services/UpdateService.cs
@@ -253,6 +253,23 @@ namespace ServiceLib.Services
             });
         }
 
+        public async Task<bool> VerifyGeoFilesRepo(Config config, Action<bool, string> updateFunc)
+        {
+            var repoPath = Utils.GetBinPath("geo.repo");
+            var repo = File.Exists(repoPath) ? File.ReadAllText(repoPath) : "";
+
+            if (repo != (config.constItem.geoSourceUrl ?? ""))
+            {
+                await UpdateGeoFileAll(config, updateFunc);
+
+                File.WriteAllText(repoPath, repo);
+
+                return false;
+            }
+
+            return true;
+        }
+
         public async Task UpdateGeoFileAll(Config config, Action<bool, string> updateFunc)
         {
             await UpdateGeoFile("geosite", config, updateFunc);

--- a/v2rayN/ServiceLib/Services/UpdateService.cs
+++ b/v2rayN/ServiceLib/Services/UpdateService.cs
@@ -253,23 +253,6 @@ namespace ServiceLib.Services
             });
         }
 
-        public async Task<bool> VerifyGeoFilesRepo(Config config, Action<bool, string> updateFunc)
-        {
-            var repoPath = Utils.GetBinPath("geo.repo");
-            var repo = File.Exists(repoPath) ? File.ReadAllText(repoPath) : "";
-
-            if (repo != (config.constItem.geoSourceUrl ?? ""))
-            {
-                await UpdateGeoFileAll(config, updateFunc);
-
-                File.WriteAllText(repoPath, repo);
-
-                return false;
-            }
-
-            return true;
-        }
-
         public async Task UpdateGeoFileAll(Config config, Action<bool, string> updateFunc)
         {
             await UpdateGeoFile("geosite", config, updateFunc);

--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -188,9 +188,10 @@ namespace ServiceLib.ViewModels
 
         private void Init()
         {
-            ConfigHandler.InitBuiltinRouting(_config);
+            ConfigHandler.InitRouting(_config);
             ConfigHandler.InitBuiltinDNS(_config);
             CoreHandler.Instance.Init(_config, UpdateHandler);
+            Task.Run(() => VerifyGeoFiles(true));
             TaskHandler.Instance.RegUpdateTask(_config, UpdateTaskHandler);
 
             if (_config.guiItem.enableStatistics)
@@ -421,6 +422,7 @@ namespace ServiceLib.ViewModels
             var ret = await _updateView?.Invoke(EViewAction.OptionSettingWindow, null);
             if (ret == true)
             {
+                await VerifyGeoFiles();
                 Locator.Current.GetService<StatusBarViewModel>()?.InboundDisplayStatus();
                 Reload();
             }
@@ -431,7 +433,7 @@ namespace ServiceLib.ViewModels
             var ret = await _updateView?.Invoke(EViewAction.RoutingSettingWindow, null);
             if (ret == true)
             {
-                ConfigHandler.InitBuiltinRouting(_config);
+                ConfigHandler.InitRouting(_config);
                 Locator.Current.GetService<StatusBarViewModel>()?.RefreshRoutingsMenu();
                 Reload();
             }
@@ -539,6 +541,14 @@ namespace ServiceLib.ViewModels
                         ShowHideWindow(false);
                     });
             }
+        }
+
+        public async Task VerifyGeoFiles(bool needReload = false)
+        {
+            var result = await new UpdateService().VerifyGeoFilesRepo(_config, UpdateHandler);
+
+            if (needReload && !result)
+                Reload();
         }
 
         #endregion core job

--- a/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
@@ -67,6 +67,7 @@ namespace ServiceLib.ViewModels
         [Reactive] public int MainGirdOrientation { get; set; }
         [Reactive] public string GeoFileSourceUrl { get; set; }
         [Reactive] public string SrsFileSourceUrl { get; set; }
+        [Reactive] public string RoutingRulesSourceUrl { get; set; }
 
         #endregion UI
 
@@ -168,6 +169,7 @@ namespace ServiceLib.ViewModels
             MainGirdOrientation = (int)_config.uiItem.mainGirdOrientation;
             GeoFileSourceUrl = _config.constItem.geoSourceUrl;
             SrsFileSourceUrl = _config.constItem.srsSourceUrl;
+            RoutingRulesSourceUrl = _config.constItem.routeRulesTemplateSourceUrl;
 
             #endregion UI
 
@@ -322,6 +324,7 @@ namespace ServiceLib.ViewModels
             _config.uiItem.mainGirdOrientation = (EGirdOrientation)MainGirdOrientation;
             _config.constItem.geoSourceUrl = GeoFileSourceUrl;
             _config.constItem.srsSourceUrl = SrsFileSourceUrl;
+            _config.constItem.routeRulesTemplateSourceUrl = RoutingRulesSourceUrl;
 
             //systemProxy
             _config.systemProxyItem.systemProxyExceptions = systemProxyExceptions;

--- a/v2rayN/ServiceLib/ViewModels/RoutingSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/RoutingSettingViewModel.cs
@@ -71,7 +71,7 @@ namespace ServiceLib.ViewModels
             _updateView = updateView;
             SelectedSource = new();
 
-            ConfigHandler.InitBuiltinRouting(_config);
+            ConfigHandler.InitRouting(_config);
 
             enableRoutingAdvanced = _config.routingBasicItem.enableRoutingAdvanced;
             domainStrategy = _config.routingBasicItem.domainStrategy;
@@ -286,7 +286,7 @@ namespace ServiceLib.ViewModels
 
         private async Task RoutingAdvancedImportRules()
         {
-            if (ConfigHandler.InitBuiltinRouting(_config, true) == 0)
+            if (ConfigHandler.InitRouting(_config, true) == 0)
             {
                 RefreshRoutingItems();
                 IsModified = true;

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml
@@ -74,6 +74,10 @@
                         <MenuItem x:Name="menuRoutingSetting" Header="{x:Static resx:ResUI.menuRoutingSetting}" />
                         <MenuItem x:Name="menuDNSSetting" Header="{x:Static resx:ResUI.menuDNSSetting}" />
                         <MenuItem x:Name="menuGlobalHotkeySetting" Header="{x:Static resx:ResUI.menuGlobalHotkeySetting}" />
+                        <MenuItem Header="{x:Static resx:ResUI.menuPresets}">
+                            <MenuItem x:Name="menuPresetsDefault" Header="{x:Static resx:ResUI.menuPresetsDefault}" />
+                            <MenuItem x:Name="menuPresetsRussia" Header="{x:Static resx:ResUI.menuPresetsRussia}" />
+                        </MenuItem>
                         <Separator />
                         <MenuItem x:Name="menuRebootAsAdmin" Header="{x:Static resx:ResUI.menuRebootAsAdmin}" />
                         <MenuItem x:Name="menuSettingsSetUWP" Header="{x:Static resx:ResUI.TbSettingsSetUWP}" />

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
@@ -76,6 +76,8 @@ namespace v2rayN.Desktop.Views
                 this.BindCommand(ViewModel, vm => vm.RebootAsAdminCmd, v => v.menuRebootAsAdmin).DisposeWith(disposables);
                 this.BindCommand(ViewModel, vm => vm.ClearServerStatisticsCmd, v => v.menuClearServerStatistics).DisposeWith(disposables);
                 this.BindCommand(ViewModel, vm => vm.OpenTheFileLocationCmd, v => v.menuOpenTheFileLocation).DisposeWith(disposables);
+                this.BindCommand(ViewModel, vm => vm.PresetDefaultCmd, v => v.menuPresetsDefault).DisposeWith(disposables);
+                this.BindCommand(ViewModel, vm => vm.PresetRussiaCmd, v => v.menuPresetsRussia).DisposeWith(disposables);
 
                 this.BindCommand(ViewModel, vm => vm.ReloadCmd, v => v.menuReload).DisposeWith(disposables);
                 this.OneWayBind(ViewModel, vm => vm.BlReloadEnabled, v => v.menuReload.IsEnabled).DisposeWith(disposables);

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
@@ -366,6 +366,7 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
@@ -635,6 +636,19 @@
                         <ComboBox
                             x:Name="cmbSrsFilesSourceUrl"
                             Grid.Row="23"
+                            Grid.Column="1"
+                            Width="300"
+                            Classes="Margin8" />
+
+                        <TextBlock
+                            Grid.Row="24"
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Classes="Margin8"
+                            Text="{x:Static resx:ResUI.TbSettingsRoutingRulesSource}" />
+                        <ComboBox
+                            x:Name="cmbRoutingRulesSourceUrl"
+                            Grid.Row="24"
                             Grid.Column="1"
                             Width="300"
                             Classes="Margin8" />

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
@@ -91,6 +91,10 @@ namespace v2rayN.Desktop.Views
             {
                 cmbSrsFilesSourceUrl.Items.Add(it);
             });
+            Global.RoutingRulesSources.ForEach(it =>
+            {
+                cmbRoutingRulesSourceUrl.Items.Add(it);
+            });
             foreach (EGirdOrientation it in Enum.GetValues(typeof(EGirdOrientation)))
             {
                 cmbMainGirdOrientation.Items.Add(it.ToString());
@@ -142,6 +146,7 @@ namespace v2rayN.Desktop.Views
                 this.Bind(ViewModel, vm => vm.MainGirdOrientation, v => v.cmbMainGirdOrientation.SelectedIndex).DisposeWith(disposables);
                 this.Bind(ViewModel, vm => vm.GeoFileSourceUrl, v => v.cmbGetFilesSourceUrl.SelectedValue).DisposeWith(disposables);
                 this.Bind(ViewModel, vm => vm.SrsFileSourceUrl, v => v.cmbSrsFilesSourceUrl.SelectedValue).DisposeWith(disposables);
+                this.Bind(ViewModel, vm => vm.RoutingRulesSourceUrl, v => v.cmbRoutingRulesSourceUrl.SelectedValue).DisposeWith(disposables);
 
                 this.Bind(ViewModel, vm => vm.notProxyLocalAddress, v => v.tognotProxyLocalAddress.IsChecked).DisposeWith(disposables);
                 this.Bind(ViewModel, vm => vm.systemProxyAdvancedProtocol, v => v.cmbsystemProxyAdvancedProtocol.SelectedValue).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/MainWindow.xaml
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml
@@ -171,6 +171,16 @@
                                     x:Name="menuGlobalHotkeySetting"
                                     Height="{StaticResource MenuItemHeight}"
                                     Header="{x:Static resx:ResUI.menuGlobalHotkeySetting}" />
+                                <MenuItem Height="{StaticResource MenuItemHeight}" Header="{x:Static resx:ResUI.menuPresets}">
+                                    <MenuItem
+                                        x:Name="menuPresetsDefault"
+                                        Height="{StaticResource MenuItemHeight}"
+                                        Header="{x:Static resx:ResUI.menuPresetsDefault}" />
+                                    <MenuItem
+                                        x:Name="menuPresetsRussia"
+                                        Height="{StaticResource MenuItemHeight}"
+                                        Header="{x:Static resx:ResUI.menuPresetsRussia}" />
+                                </MenuItem>
                                 <Separator Margin="-40,5" />
                                 <MenuItem
                                     x:Name="menuRebootAsAdmin"

--- a/v2rayN/v2rayN/Views/MainWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml.cs
@@ -98,6 +98,8 @@ namespace v2rayN.Views
                 this.BindCommand(ViewModel, vm => vm.RebootAsAdminCmd, v => v.menuRebootAsAdmin).DisposeWith(disposables);
                 this.BindCommand(ViewModel, vm => vm.ClearServerStatisticsCmd, v => v.menuClearServerStatistics).DisposeWith(disposables);
                 this.BindCommand(ViewModel, vm => vm.OpenTheFileLocationCmd, v => v.menuOpenTheFileLocation).DisposeWith(disposables);
+                this.BindCommand(ViewModel, vm => vm.PresetDefaultCmd, v => v.menuPresetsDefault).DisposeWith(disposables);
+                this.BindCommand(ViewModel, vm => vm.PresetRussiaCmd, v => v.menuPresetsRussia).DisposeWith(disposables);
 
                 this.BindCommand(ViewModel, vm => vm.ReloadCmd, v => v.menuReload).DisposeWith(disposables);
                 this.OneWayBind(ViewModel, vm => vm.BlReloadEnabled, v => v.menuReload.IsEnabled).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
@@ -530,6 +530,7 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
@@ -874,6 +875,22 @@
                         <ComboBox
                             x:Name="cmbSrsFilesSourceUrl"
                             Grid.Row="23"
+                            Grid.Column="1"
+                            Width="300"
+                            Margin="{StaticResource Margin8}"
+                            IsEditable="True"
+                            Style="{StaticResource DefComboBox}" />
+
+                        <TextBlock
+                            Grid.Row="24"
+                            Grid.Column="0"
+                            Margin="{StaticResource Margin8}"
+                            VerticalAlignment="Center"
+                            Style="{StaticResource ToolbarTextBlock}"
+                            Text="{x:Static resx:ResUI.TbSettingsRoutingRulesSource}" />
+                        <ComboBox
+                            x:Name="cmbRoutingRulesSourceUrl"
+                            Grid.Row="24"
                             Grid.Column="1"
                             Width="300"
                             Margin="{StaticResource Margin8}"

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
@@ -93,6 +93,10 @@ namespace v2rayN.Views
             {
                 cmbSrsFilesSourceUrl.Items.Add(it);
             });
+            Global.RoutingRulesSources.ForEach(it =>
+            {
+                cmbRoutingRulesSourceUrl.Items.Add(it);
+            });
             foreach (EGirdOrientation it in Enum.GetValues(typeof(EGirdOrientation)))
             {
                 cmbMainGirdOrientation.Items.Add(it.ToString());
@@ -155,6 +159,7 @@ namespace v2rayN.Views
                 this.Bind(ViewModel, vm => vm.MainGirdOrientation, v => v.cmbMainGirdOrientation.SelectedIndex).DisposeWith(disposables);
                 this.Bind(ViewModel, vm => vm.GeoFileSourceUrl, v => v.cmbGetFilesSourceUrl.Text).DisposeWith(disposables);
                 this.Bind(ViewModel, vm => vm.SrsFileSourceUrl, v => v.cmbSrsFilesSourceUrl.Text).DisposeWith(disposables);
+                this.Bind(ViewModel, vm => vm.RoutingRulesSourceUrl, v => v.cmbRoutingRulesSourceUrl.Text).DisposeWith(disposables);
 
                 this.Bind(ViewModel, vm => vm.notProxyLocalAddress, v => v.tognotProxyLocalAddress.IsChecked).DisposeWith(disposables);
                 this.Bind(ViewModel, vm => vm.systemProxyAdvancedProtocol, v => v.cmbsystemProxyAdvancedProtocol.Text).DisposeWith(disposables);


### PR DESCRIPTION
This PR allows users to specify routing rule template sources. A template is just a version + `RoutingItem` array encoded in json (same logic as for builtin rules). Rules inside the template can be passed in two ways - through `url` field (then the rules will be downloaded automatically if necessary) and through `ruleSet` field. 

Since we have to download this template quite often (including at program startup), I preferred the shorter version with the url field in my template.

As for automatic downloading of geo files - now they are downloaded after changing the url in the configuration file and gui settings. For the method we discussed in #5832 (`guiNConfig.json` distributing) the user needs to download the geo files on the first run, otherwise routing rules will be downloaded that will fail because they use categories that are not in the default geo files. This will result in xray and sing-box not being able to run. It also seems logical that if the user has changed the source of the geo files, he wants to use them, so the program needs to download them.

However, there was a problem - in order for startup to realize that we now have geo files from a different source and need to download new ones, I need to know what source we actually have the files from right now, so I decided to save the current source along with the geo files to the text file `bin/geo.repo`.

I'm not sure if this is the best place to this, maybe you have ideas how this would be improved?