### PR TITLE
External dns configs support + ru translation 

### DIFF
--- a/v2rayN/ServiceLib/Common/SqliteHelper.cs
+++ b/v2rayN/ServiceLib/Common/SqliteHelper.cs
@@ -105,6 +105,11 @@ namespace ServiceLib.Common
             return _db.Execute(sql);
         }
 
+        public int DeleteAll<T>()
+        {
+            return _db.DeleteAll<T>();
+        }
+
         public async Task<int> ExecuteAsync(string sql)
         {
             return await _dbAsync.ExecuteAsync(sql);

--- a/v2rayN/ServiceLib/Global.cs
+++ b/v2rayN/ServiceLib/Global.cs
@@ -121,12 +121,17 @@
 
         public static readonly List<string> SingboxRulesetSources = new() {
             "",
-            @"https://raw.githubusercontent.com/runetfreedom/russia-v2ray-rules-dat/refs/heads/release/sing-box/rule-set-{0}/{1}.srs",
+            @"https://cdn.jsdelivr.net/gh/runetfreedom/russia-v2ray-rules-dat@release/sing-box/rule-set-{0}/{1}.srs",
         };
 
         public static readonly List<string> RoutingRulesSources = new() {
             "",
-            @"https://raw.githubusercontent.com/runetfreedom/russia-v2ray-custom-routing-list/refs/heads/main/template.json",
+            @"https://cdn.jsdelivr.net/gh/runetfreedom/russia-v2ray-custom-routing-list@main/template.json",
+        };
+
+        public static readonly List<string> DNSTemplateSources = new() {
+            "",
+            @"https://cdn.jsdelivr.net/gh/runetfreedom/russia-v2ray-custom-routing-list@main/",
         };
 
         public static readonly Dictionary<string, string> UserAgentTexts = new()

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1027,4 +1027,25 @@
   <data name="TbSettingsSpeedTestUrl" xml:space="preserve">
     <value>URL спидтеста</value>
   </data>
+  <data name="TbSettingsGeoFilesSource" xml:space="preserve">
+    <value>Источник geo файлов</value>
+  </data>
+  <data name="TbSettingsSrsFilesSource" xml:space="preserve">
+    <value>Источник sing-box srs файлов</value>
+  </data>
+  <data name="TbSettingsRoutingRulesSource" xml:space="preserve">
+    <value>Источник правил маршрутизации</value>
+  </data>
+  <data name="menuRegionalPresets" xml:space="preserve">
+    <value>Региональные пресеты</value>
+  </data>
+  <data name="menuRegionalPresetsDefault" xml:space="preserve">
+    <value>По умолчанию (Китай)</value>
+  </data>
+  <data name="menuRegionalPresetsRussia" xml:space="preserve">
+    <value>Россия</value>
+  </data>
+  <data name="TbSettingsChinaUserTip" xml:space="preserve">
+    <value>Используйте Настройки -> Региональные пресеты вместо изменения этого поля</value>
+  </data>
 </root>


### PR DESCRIPTION
Hello!

It seems the current default dns settings do not allow sign-box to download external srs files on startup. It would also be nice to use our local dns server instead of alidns.

RU translation for #5829, #5835, #5840