### PR TITLE
enable delay before deleting tun

### DIFF
--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -554,11 +554,11 @@ namespace ServiceLib.ViewModels
         {
             await Task.Run(() =>
             {
-                //if (_config.tunModeItem.enableTun)
-                //{
-                //    Task.Delay(1000).Wait();
-                //    WindowsUtils.RemoveTunDevice();
-                //}
+                if (_config.tunModeItem.enableTun)
+                {
+                    Task.Delay(1000).Wait();
+                    WindowsUtils.RemoveTunDevice();
+                }
 
                 var node = ConfigHandler.GetDefaultServer(_config);
                 CoreHandler.Instance.LoadCore(node);


### PR DESCRIPTION
[Starting from version 6.56](https://github.com/2dust/v2rayN/blame/50449df08dd453ed615283cc9af7d76f6677bc05/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs#L557) sometimes enabling the Tun mode with sing-box kernel throws an error:


```
+0300 2024-10-20 00:56:53 WARN inbound/tun[tun-in]: open tun interface take too much time to finish!
FATAL[0015] start service: initialize inbound/tun[tun-in]: configure tun interface: Cannot create a file when that file already exists.
```

I think it is a good idea to enable back a little delay for to solve this. 
Using the sing-box kernel manually (without v2rayN) does not cause such error.