### PR TITLE
Remove the wildcard match to `proxy` outbound in `custom_routing_white`

### DIFF
--- a/v2rayN/ServiceLib/Sample/custom_routing_white
+++ b/v2rayN/ServiceLib/Sample/custom_routing_white
@@ -99,10 +99,5 @@
     "domain": [
       "geosite:cn"
     ]
-  },
-  {
-    "remarks": "最终代理",
-    "port": "0-65535",
-    "outboundTag": "proxy"
   }
 ]


### PR DESCRIPTION
根据 Xray-core 文档对于[域名解析策略](https://xtls.github.io/config/routing.html#routingobject)的说明以及 Xray-core 代码中函数 [pickRouteInternal](https://github.com/XTLS/Xray-core/blob/7d0a80b501d430542ae851043de3da4d68335325/app/router/router.go#L184) 的实现，原来的实现逻辑会导致在使用 `IPIfNonMatch` 匹配域名时基于 IP 的匹配规则无效。

具体而言，当加入这条通配规则以后，当域名结果没有命中任何一条域名相关的规则时，会命中此规则。这样就不会将这个未命中任何域名规则的域名解析成 IP 以后，再匹配路由规则中的 IP 规则。显然，这与  `IPIfNonMatch`  解析策略的期望行为不符。

在删掉此规则以后，就会将未命中任何域名规则的域名解析成 IP 以后，再匹配路由规则中的 IP 规则。如果没有命中任何 IP 规则，按照设计语义，会走第一个 `outbound` 出站。根据我对 v2rayN 生成配置文件的观察，这其实就是走 `proxy` 出战，符合预期。

希望您能尽快修复这一错误，谢谢！