### PR TITLE
Add full support for  (one-click) Iran regional preset by using Chocolate4U's github repos for iran routing rules

### DIFF
--- a/v2rayN/ServiceLib/Enums/EPresetType.cs
+++ b/v2rayN/ServiceLib/Enums/EPresetType.cs
@@ -4,5 +4,6 @@
     {
         Default = 0,
         Russia = 1,
+        Iran = 2,
     }
 }

--- a/v2rayN/ServiceLib/Global.cs
+++ b/v2rayN/ServiceLib/Global.cs
@@ -124,21 +124,25 @@
         public static readonly List<string> GeoFilesSources = new() {
             "",
             @"https://github.com/runetfreedom/russia-v2ray-rules-dat/releases/latest/download/{0}.dat",
+            @"https://cdn.jsdelivr.net/gh/chocolate4u/Iran-v2ray-rules@release/{0}.dat",
         };
 
         public static readonly List<string> SingboxRulesetSources = new() {
             "",
             @"https://cdn.jsdelivr.net/gh/runetfreedom/russia-v2ray-rules-dat@release/sing-box/rule-set-{0}/{1}.srs",
+            @"https://cdn.jsdelivr.net/gh/chocolate4u/Iran-sing-box-rules@rule-set/{1}.srs",
         };
 
         public static readonly List<string> RoutingRulesSources = new() {
             "",
             @"https://cdn.jsdelivr.net/gh/runetfreedom/russia-v2ray-custom-routing-list@main/v2rayN/template.json",
+            @"https://cdn.jsdelivr.net/gh/Chocolate4U/Iran-v2ray-rules@main/v2rayN/template.json",
         };
 
         public static readonly List<string> DNSTemplateSources = new() {
             "",
             @"https://cdn.jsdelivr.net/gh/runetfreedom/russia-v2ray-custom-routing-list@main/v2rayN/",
+            @"https://cdn.jsdelivr.net/gh/Chocolate4U/Iran-v2ray-rules@main/v2rayN/",
         };
 
         public static readonly Dictionary<string, string> UserAgentTexts = new()

--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -1869,6 +1869,16 @@ namespace ServiceLib.Handler
                     await SaveDNSItems(config, await GetExternalDNSItem(ECoreType.sing_box, Global.DNSTemplateSources[1] + "sing_box.json"));
 
                     return true;
+                
+                case EPresetType.Iran:
+                    config.ConstItem.GeoSourceUrl = Global.GeoFilesSources[2];
+                    config.ConstItem.SrsSourceUrl = Global.SingboxRulesetSources[2];
+                    config.ConstItem.RouteRulesTemplateSourceUrl = Global.RoutingRulesSources[2];
+
+                    await SaveDNSItems(config, await GetExternalDNSItem(ECoreType.Xray, Global.DNSTemplateSources[2] + "v2ray.json"));
+                    await SaveDNSItems(config, await GetExternalDNSItem(ECoreType.sing_box, Global.DNSTemplateSources[2] + "sing_box.json"));
+
+                    return true;
             }
 
             return false;

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -1258,6 +1258,15 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Iran 的本地化字符串。
+        /// </summary>
+        public static string menuRegionalPresetsIran {
+            get {
+                return ResourceManager.GetString("menuRegionalPresetsIran", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Reload 的本地化字符串。
         /// </summary>
         public static string menuReload {

--- a/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
@@ -1129,6 +1129,9 @@
   <data name="menuRegionalPresetsRussia" xml:space="preserve">
     <value>روسیه</value>
   </data>
+  <data name="menuRegionalPresetsIran" xml:space="preserve">
+    <value>ایران</value>
+  </data>
   <data name="TbSettingsChinaUserTip" xml:space="preserve">
     <value>کاربران در منطقه چین می توانند این مورد را نادیده بگیرند</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.hu.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.hu.resx
@@ -1342,6 +1342,9 @@
   <data name="menuRegionalPresetsRussia" xml:space="preserve">
     <value>Oroszország</value>
   </data>
+  <data name="menuRegionalPresetsIran" xml:space="preserve">
+    <value>Irán</value>
+  </data>
   <data name="TbSettingsChinaUserTip" xml:space="preserve">
     <value>A Kínában élő felhasználók figyelmen kívül hagyhatják ezt a tételt</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1342,6 +1342,9 @@
   <data name="menuRegionalPresetsRussia" xml:space="preserve">
     <value>Russia</value>
   </data>
+  <data name="menuRegionalPresetsIran" xml:space="preserve">
+    <value>Iran</value>
+  </data>
   <data name="TbSettingsChinaUserTip" xml:space="preserve">
     <value>Users in China region can ignore this item</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1039,6 +1039,9 @@
   <data name="menuRegionalPresetsRussia" xml:space="preserve">
     <value>Россия</value>
   </data>
+  <data name="menuRegionalPresetsIran" xml:space="preserve">
+    <value>Иран</value>
+  </data>
   <data name="TbSettingsChinaUserTip" xml:space="preserve">
     <value>Используйте Настройки -&gt; Региональные пресеты вместо изменения этого поля</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1342,6 +1342,9 @@
   <data name="menuRegionalPresetsRussia" xml:space="preserve">
     <value>俄罗斯</value>
   </data>
+  <data name="menuRegionalPresetsIran" xml:space="preserve">
+    <value>伊朗</value>
+  </data>
   <data name="menuAddServerViaImage" xml:space="preserve">
     <value>扫描图片中的二维码</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -1222,6 +1222,9 @@
   <data name="menuRegionalPresetsRussia" xml:space="preserve">
     <value>俄羅斯</value>
   </data>
+  <data name="menuRegionalPresetsIran" xml:space="preserve">
+    <value>伊朗</value>
+  </data>
   <data name="menuAddServerViaImage" xml:space="preserve">
     <value>掃描圖片中的二維碼</value>
   </data>

--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -50,6 +50,8 @@ namespace ServiceLib.ViewModels
 
         public ReactiveCommand<Unit, Unit> RegionalPresetRussiaCmd { get; }
 
+        public ReactiveCommand<Unit, Unit> RegionalPresetIranCmd { get; }
+
         public ReactiveCommand<Unit, Unit> ReloadCmd { get; }
 
         [Reactive]
@@ -195,6 +197,11 @@ namespace ServiceLib.ViewModels
             RegionalPresetRussiaCmd = ReactiveCommand.CreateFromTask(async () =>
             {
                 await ApplyRegionalPreset(EPresetType.Russia);
+            });
+
+            RegionalPresetIranCmd = ReactiveCommand.CreateFromTask(async () =>
+            {
+                await ApplyRegionalPreset(EPresetType.Iran);
             });
 
             #endregion WhenAnyValue && ReactiveCommand

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml
@@ -80,6 +80,7 @@
                         <MenuItem Header="{x:Static resx:ResUI.menuRegionalPresets}">
                             <MenuItem x:Name="menuRegionalPresetsDefault" Header="{x:Static resx:ResUI.menuRegionalPresetsDefault}" />
                             <MenuItem x:Name="menuRegionalPresetsRussia" Header="{x:Static resx:ResUI.menuRegionalPresetsRussia}" />
+                            <MenuItem x:Name="menuRegionalPresetsIran" Header="{x:Static resx:ResUI.menuRegionalPresetsIran}" />
                         </MenuItem>
                         <MenuItem x:Name="menuBackupAndRestore" Header="{x:Static resx:ResUI.menuBackupAndRestore}" />
                         <MenuItem x:Name="menuOpenTheFileLocation" Header="{x:Static resx:ResUI.menuOpenTheFileLocation}" />

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
@@ -104,6 +104,7 @@ namespace v2rayN.Desktop.Views
                 this.BindCommand(ViewModel, vm => vm.OpenTheFileLocationCmd, v => v.menuOpenTheFileLocation).DisposeWith(disposables);
                 this.BindCommand(ViewModel, vm => vm.RegionalPresetDefaultCmd, v => v.menuRegionalPresetsDefault).DisposeWith(disposables);
                 this.BindCommand(ViewModel, vm => vm.RegionalPresetRussiaCmd, v => v.menuRegionalPresetsRussia).DisposeWith(disposables);
+                this.BindCommand(ViewModel, vm => vm.RegionalPresetIranCmd, v => v.menuRegionalPresetsIran).DisposeWith(disposables);
 
                 this.BindCommand(ViewModel, vm => vm.ReloadCmd, v => v.menuReload).DisposeWith(disposables);
                 this.OneWayBind(ViewModel, vm => vm.BlReloadEnabled, v => v.menuReload.IsEnabled).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/MainWindow.xaml
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml
@@ -194,6 +194,10 @@
                                         x:Name="menuRegionalPresetsRussia"
                                         Height="{StaticResource MenuItemHeight}"
                                         Header="{x:Static resx:ResUI.menuRegionalPresetsRussia}" />
+                                    <MenuItem
+                                        x:Name="menuRegionalPresetsIran"
+                                        Height="{StaticResource MenuItemHeight}"
+                                        Header="{x:Static resx:ResUI.menuRegionalPresetsIran}" />
                                 </MenuItem>
                                 <MenuItem
                                     x:Name="menuBackupAndRestore"

--- a/v2rayN/v2rayN/Views/MainWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml.cs
@@ -102,6 +102,7 @@ namespace v2rayN.Views
                 this.BindCommand(ViewModel, vm => vm.OpenTheFileLocationCmd, v => v.menuOpenTheFileLocation).DisposeWith(disposables);
                 this.BindCommand(ViewModel, vm => vm.RegionalPresetDefaultCmd, v => v.menuRegionalPresetsDefault).DisposeWith(disposables);
                 this.BindCommand(ViewModel, vm => vm.RegionalPresetRussiaCmd, v => v.menuRegionalPresetsRussia).DisposeWith(disposables);
+                this.BindCommand(ViewModel, vm => vm.RegionalPresetIranCmd, v => v.menuRegionalPresetsIran).DisposeWith(disposables);
 
                 this.BindCommand(ViewModel, vm => vm.ReloadCmd, v => v.menuReload).DisposeWith(disposables);
                 this.OneWayBind(ViewModel, vm => vm.BlReloadEnabled, v => v.menuReload.IsEnabled).DisposeWith(disposables);


### PR DESCRIPTION
Exactly similar to and mirroring the existing one-click `Russia regional preset` support in v2rayN's recent builds, this PR adds support for `Iran regional preset` using Chocolate4U's repos for[ v2ray routing rules](https://github.com/Chocolate4U/Iran-v2ray-rules) and [SingBox routing rules](https://github.com/Chocolate4U/Iran-sing-box-rules).  

This is a well-known and established [repo ](https://github.com/Chocolate4U) with hundreds of github stars that maintains up-to-date geoip/geosite databases optimized for Iranian uses. Its released databases are used in several other projects including xray/Singbox user panels, e.g. [3x-ui panel](https://github.com/MHSanaei/3x-ui?tab=readme-ov-file#acknowledgment) among many others.

Mirroring what was done with the Russia preset, [the required routing/dns rules json files](https://cdn.jsdelivr.net/gh/Chocolate4U/Iran-v2ray-rules@main/v2rayN/) have been produced and uploaded ([in collaboration with Chocolate4U](https://github.com/Chocolate4U/Iran-v2ray-rules/pull/54)) and also tested to work using both proxy/tun modes of v2rayN (latest builds).

There are only two routing presets for Iran in this PR: a [global rule-set](https://cdn.jsdelivr.net/gh/Chocolate4U/Iran-v2ray-rules@main/v2rayN/all.json) and a [whitelist routing rule-set](https://cdn.jsdelivr.net/gh/Chocolate4U/Iran-v2ray-rules@main/v2rayN/all_except_ir.json) (due to so many sites being blocked by the Iran GFW, having a blacklist rule-set is pointless and there is no database for tracking them).

This PR will make v2rayN's support for multiple platforms, languages and countries more comprehensive.




Thank you.

![image](https://github.com/user-attachments/assets/c0d7394f-c09d-4b26-94b6-e96ad1642cec)

