### PR TITLE
CloneServerStatItem 时检查indexId和toIndexId是否相同

### DIFF
--- a/v2rayN/ServiceLib/Handler/StatisticsHandler.cs
+++ b/v2rayN/ServiceLib/Handler/StatisticsHandler.cs
@@ -72,6 +72,11 @@
                 return;
             }
 
+            if(indexId == toIndexId)
+            {
+                return;
+            }
+
             var stat = _lstServerStat.FirstOrDefault(t => t.IndexId == indexId);
             if (stat == null)
             {


### PR DESCRIPTION
在订阅分组下手动创建自定义服务器，并且使用它（产生统计数据），然后更新订阅，执行ConfigHandler内的AddBatchServers对相同服务器统计信息迁移时，会为该自定义服务器Clone一条统计信息（自定义服务器IndexId并未变化）。

订阅更新完毕后，执行刷新RefreshServersBiz 调用 ProfileItemsEx ，内部的 lstModel 在linq 操作时生成由于统计信息（lstServerStat）重复，导致生成的lstModel也重复，最终UI界面显示时多出一条服务器记录。