### PR TITLE
Update dns_singbox_normal

### DIFF
--- a/v2rayN/ServiceLib/Sample/dns_singbox_normal
+++ b/v2rayN/ServiceLib/Sample/dns_singbox_normal
@@ -2,7 +2,7 @@
   "servers": [
     {
       "tag": "remote",
-      "address": "8.8.8.8",
+      "address": "tcp://8.8.8.8",
       "strategy": "prefer_ipv4",
       "detour": "proxy"
     },


### PR DESCRIPTION
If 8.8.8.8 is empty and the configuration address is a domain, it will not work, but changing it to tcp://8.8.8.8 will fix this problem.