### PR TITLE
Use Directory.Packages.props for Centralized Dependency Management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,31 @@
+<Project>
+
+	<PropertyGroup>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+		<CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+		<CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
+		<NoWarn>$(NoWarn);NU1507</NoWarn>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageVersion Include="Avalonia.Desktop" Version="11.2.3" />
+		<PackageVersion Include="Avalonia.Diagnostics" Version="11.2.3" />
+		<PackageVersion Include="Avalonia.ReactiveUI" Version="11.2.3" />
+		<PackageVersion Include="CliWrap" Version="3.7.1" />
+		<PackageVersion Include="Downloader" Version="3.3.3" />
+		<PackageVersion Include="H.NotifyIcon.Wpf" Version="2.2.0" />
+		<PackageVersion Include="MaterialDesignThemes" Version="5.2.1" />
+		<PackageVersion Include="MessageBox.Avalonia" Version="3.2.0" />
+		<PackageVersion Include="QRCoder" Version="1.6.0" />
+		<PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />
+		<PackageVersion Include="ReactiveUI.WPF" Version="20.1.63" />
+		<PackageVersion Include="Semi.Avalonia" Version="11.2.1.3" />
+		<PackageVersion Include="Splat.NLog" Version="15.2.22" />
+		<PackageVersion Include="sqlite-net-pcl" Version="1.9.172" />
+		<PackageVersion Include="TaskScheduler" Version="2.11.0" />
+		<PackageVersion Include="WebDav.Client" Version="2.8.0" />
+		<PackageVersion Include="YamlDotNet" Version="16.3.0" />
+		<PackageVersion Include="ZXing.Net.Bindings.SkiaSharp" Version="0.16.14" />
+	</ItemGroup>
+
+</Project>

--- a/v2rayN/AmazTool/AmazTool.csproj
+++ b/v2rayN/AmazTool/AmazTool.csproj
@@ -1,27 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-	<Copyright>Copyright © 2017-2025 (GPLv3)</Copyright>
-	<FileVersion>1.3.1</FileVersion>
-  </PropertyGroup>
- 
-  <ItemGroup>
-    <Compile Update="Resx\Resource.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Resource.resx</DependentUpon>
-    </Compile>
-  </ItemGroup>
- 
-  <ItemGroup>
-    <EmbeddedResource Update="Resx\Resource.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resource.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-  </ItemGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<Copyright>Copyright © 2017-2025 (GPLv3)</Copyright>
+		<FileVersion>1.3.1</FileVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Compile Update="Resx\Resource.Designer.cs">
+			<DesignTime>True</DesignTime>
+			<AutoGen>True</AutoGen>
+			<DependentUpon>Resource.resx</DependentUpon>
+		</Compile>
+	</ItemGroup>
+
+	<ItemGroup>
+		<EmbeddedResource Update="Resx\Resource.resx">
+			<Generator>ResXFileCodeGenerator</Generator>
+			<LastGenOutput>Resource.Designer.cs</LastGenOutput>
+		</EmbeddedResource>
+	</ItemGroup>
 
 </Project>

--- a/v2rayN/ServiceLib/ServiceLib.csproj
+++ b/v2rayN/ServiceLib/ServiceLib.csproj
@@ -1,83 +1,80 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-	<TargetFramework>net8.0</TargetFramework>
-	<ImplicitUsings>enable</ImplicitUsings>
-	<Nullable>enable</Nullable>
-	<Version>7.7.0</Version>
-  </PropertyGroup>
- 
-	<ItemGroup>
-		<PackageReference Include="Downloader" Version="3.3.3" />
-		<PackageReference Include="ReactiveUI" Version="20.1.63" />
-		<PackageReference Include="ReactiveUI.Fody" Version="19.5.41" />
-		<PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
-		<PackageReference Include="Splat.NLog" Version="15.2.22" />
-		<PackageReference Include="WebDav.Client" Version="2.8.0" />
-		<PackageReference Include="YamlDotNet" Version="16.3.0" />
-		<PackageReference Include="QRCoder" Version="1.6.0" />
-		<PackageReference Include="CliWrap" Version="3.7.1" /> 
-		<PackageReference Include="SkiaSharp.QrCode" Version="0.7.0" />
-		<PackageReference Include="ZXing.Net.Bindings.SkiaSharp" Version="0.16.14" />
-		<PackageReference Include="TaskScheduler" Version="2.11.0" />
-
-	</ItemGroup>
-	
-  <ItemGroup>
-    <EmbeddedResource Include="Sample\clash_mixin_yaml" />
-    <EmbeddedResource Include="Sample\clash_tun_yaml" />
-    <EmbeddedResource Include="Sample\custom_routing_black" />
-    <EmbeddedResource Include="Sample\custom_routing_global" />
-    <EmbeddedResource Include="Sample\custom_routing_white" />
-    <EmbeddedResource Include="Sample\dns_singbox_normal" />
-    <EmbeddedResource Include="Sample\dns_v2ray_normal" />
-    <EmbeddedResource Include="Sample\pac" />
-    <EmbeddedResource Include="Sample\SampleClientConfig" />
-    <EmbeddedResource Include="Sample\SampleHttpRequest" />
-    <EmbeddedResource Include="Sample\SampleHttpResponse" />
-    <EmbeddedResource Include="Sample\SampleInbound" />
-    <EmbeddedResource Include="Sample\SampleOutbound" />
-    <EmbeddedResource Include="Sample\SingboxSampleClientConfig" />
-    <EmbeddedResource Include="Sample\SingboxSampleOutbound" />
-    <EmbeddedResource Include="Sample\tun_singbox_dns" />
-    <EmbeddedResource Include="Sample\tun_singbox_inbound" />
-    <EmbeddedResource Include="Sample\tun_singbox_rules" />
-    <EmbeddedResource Include="Sample\linux_autostart_config" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<Version>7.7.0</Version>
+	</PropertyGroup>
 
 	<ItemGroup>
-	  <Compile Update="Resx\ResUI.Designer.cs">
-	    <DependentUpon>ResUI.resx</DependentUpon>
-	    <DesignTime>True</DesignTime>
-	    <AutoGen>True</AutoGen>
-	  </Compile>
+		<PackageReference Include="Downloader" />
+		<PackageReference Include="ReactiveUI.Fody" />
+		<PackageReference Include="sqlite-net-pcl" />
+		<PackageReference Include="Splat.NLog" />
+		<PackageReference Include="WebDav.Client" />
+		<PackageReference Include="YamlDotNet" />
+		<PackageReference Include="QRCoder" />
+		<PackageReference Include="CliWrap" />
+		<PackageReference Include="ZXing.Net.Bindings.SkiaSharp" />
+		<PackageReference Include="TaskScheduler" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <EmbeddedResource Update="Resx\ResUI.fa-Ir.resx">
-	    <SubType>Designer</SubType>
-	    <Generator>PublicResXFileCodeGenerator</Generator>
-	  </EmbeddedResource>
-	  <EmbeddedResource Update="Resx\ResUI.hu.resx">
-	    <Generator>PublicResXFileCodeGenerator</Generator>
-	  </EmbeddedResource>
-	  <EmbeddedResource Update="Resx\ResUI.resx">
-	    <SubType>Designer</SubType>
-	    <LastGenOutput>ResUI.Designer.cs</LastGenOutput>
-	    <Generator>PublicResXFileCodeGenerator</Generator>
-	  </EmbeddedResource>
-	  <EmbeddedResource Update="Resx\ResUI.ru.resx">
-	    <SubType>Designer</SubType>
-	    <Generator>PublicResXFileCodeGenerator</Generator>
-	  </EmbeddedResource>
-	  <EmbeddedResource Update="Resx\ResUI.zh-Hans.resx">
-	    <SubType>Designer</SubType>
-	    <Generator>PublicResXFileCodeGenerator</Generator>
-	  </EmbeddedResource>
-	  <EmbeddedResource Update="Resx\ResUI.zh-Hant.resx">
-	    <SubType>Designer</SubType>
-	    <Generator>PublicResXFileCodeGenerator</Generator>
-	  </EmbeddedResource>
+		<EmbeddedResource Include="Sample\clash_mixin_yaml" />
+		<EmbeddedResource Include="Sample\clash_tun_yaml" />
+		<EmbeddedResource Include="Sample\custom_routing_black" />
+		<EmbeddedResource Include="Sample\custom_routing_global" />
+		<EmbeddedResource Include="Sample\custom_routing_white" />
+		<EmbeddedResource Include="Sample\dns_singbox_normal" />
+		<EmbeddedResource Include="Sample\dns_v2ray_normal" />
+		<EmbeddedResource Include="Sample\pac" />
+		<EmbeddedResource Include="Sample\SampleClientConfig" />
+		<EmbeddedResource Include="Sample\SampleHttpRequest" />
+		<EmbeddedResource Include="Sample\SampleHttpResponse" />
+		<EmbeddedResource Include="Sample\SampleInbound" />
+		<EmbeddedResource Include="Sample\SampleOutbound" />
+		<EmbeddedResource Include="Sample\SingboxSampleClientConfig" />
+		<EmbeddedResource Include="Sample\SingboxSampleOutbound" />
+		<EmbeddedResource Include="Sample\tun_singbox_dns" />
+		<EmbeddedResource Include="Sample\tun_singbox_inbound" />
+		<EmbeddedResource Include="Sample\tun_singbox_rules" />
+		<EmbeddedResource Include="Sample\linux_autostart_config" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Update="Resx\ResUI.Designer.cs">
+			<DependentUpon>ResUI.resx</DependentUpon>
+			<DesignTime>True</DesignTime>
+			<AutoGen>True</AutoGen>
+		</Compile>
+	</ItemGroup>
+
+	<ItemGroup>
+		<EmbeddedResource Update="Resx\ResUI.fa-Ir.resx">
+			<SubType>Designer</SubType>
+			<Generator>PublicResXFileCodeGenerator</Generator>
+		</EmbeddedResource>
+		<EmbeddedResource Update="Resx\ResUI.hu.resx">
+			<Generator>PublicResXFileCodeGenerator</Generator>
+		</EmbeddedResource>
+		<EmbeddedResource Update="Resx\ResUI.resx">
+			<SubType>Designer</SubType>
+			<LastGenOutput>ResUI.Designer.cs</LastGenOutput>
+			<Generator>PublicResXFileCodeGenerator</Generator>
+		</EmbeddedResource>
+		<EmbeddedResource Update="Resx\ResUI.ru.resx">
+			<SubType>Designer</SubType>
+			<Generator>PublicResXFileCodeGenerator</Generator>
+		</EmbeddedResource>
+		<EmbeddedResource Update="Resx\ResUI.zh-Hans.resx">
+			<SubType>Designer</SubType>
+			<Generator>PublicResXFileCodeGenerator</Generator>
+		</EmbeddedResource>
+		<EmbeddedResource Update="Resx\ResUI.zh-Hant.resx">
+			<SubType>Designer</SubType>
+			<Generator>PublicResXFileCodeGenerator</Generator>
+		</EmbeddedResource>
 	</ItemGroup>
 
 </Project>

--- a/v2rayN/v2rayN.Desktop/v2rayN.Desktop.csproj
+++ b/v2rayN/v2rayN.Desktop/v2rayN.Desktop.csproj
@@ -1,56 +1,50 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <OutputType>WinExe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
-        <Nullable>enable</Nullable>
+
+	<PropertyGroup>
+		<OutputType>WinExe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ApplicationIcon>Assets\v2rayN.ico</ApplicationIcon>
-        <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
-	    <Copyright>Copyright © 2017-2025 (GPLv3)</Copyright>
-        <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-        <AssemblyName>v2rayN</AssemblyName>
-    </PropertyGroup>
+		<BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+		<Copyright>Copyright © 2017-2025 (GPLv3)</Copyright>
+		<AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+		<AssemblyName>v2rayN</AssemblyName>
+	</PropertyGroup>
 
-    <ItemGroup>
-        <AvaloniaResource Include="Assets\**" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectCapability Include="Avalonia" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.2.3" />
-        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.3" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.2.3" />
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.3" />
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.3" />
-        <PackageReference Include="Avalonia.ReactiveUI" Version="11.2.3" />
-        <PackageReference Include="DialogHost.Avalonia" Version="0.8.1" />
-        <PackageReference Include="MessageBox.Avalonia" Version="3.2.0" />		
-        <PackageReference Include="Semi.Avalonia" Version="11.2.1.3" />
-        <PackageReference Include="Semi.Avalonia.DataGrid" Version="11.2.1.3" />
-        <PackageReference Include="ReactiveUI" Version="20.1.63" />
-        <PackageReference Include="ReactiveUI.Fody" Version="19.5.41" />
+	<ItemGroup>
+		<AvaloniaResource Include="Assets\**" />
 	</ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\ServiceLib\ServiceLib.csproj" />
-    </ItemGroup>
- 
-    <ItemGroup>
-      <EmbeddedResource Include="Assets\v2rayN.ico">
-        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-      </EmbeddedResource>
-    </ItemGroup>
- 
-    <ItemGroup>
-      <None Update="v2rayN.png">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </None>
-      <None Update="v2rayN.icns">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </None>
-    </ItemGroup> 
- 
+	<ItemGroup>
+		<ProjectCapability Include="Avalonia" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Avalonia.Desktop" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
+		<PackageReference Include="Avalonia.ReactiveUI" />
+		<PackageReference Include="MessageBox.Avalonia" />
+		<PackageReference Include="Semi.Avalonia" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\ServiceLib\ServiceLib.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<EmbeddedResource Include="Assets\v2rayN.ico">
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+		</EmbeddedResource>
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Update="v2rayN.png">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="v2rayN.icns">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
+
 </Project>

--- a/v2rayN/v2rayN/v2rayN.csproj
+++ b/v2rayN/v2rayN/v2rayN.csproj
@@ -5,35 +5,34 @@
 		<OutputType>WinExe</OutputType>
 		<TargetFramework>net8.0-windows10.0.17763</TargetFramework>
 		<Nullable>enable</Nullable>
-		<UseWPF>true</UseWPF>  
+		<UseWPF>true</UseWPF>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ApplicationIcon>Resources\v2rayN.ico</ApplicationIcon>
 		<Copyright>Copyright © 2017-2025 (GPLv3)</Copyright>
 		<SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
 	</PropertyGroup>
-	
+
 	<ItemGroup>
-		<PackageReference Include="MaterialDesignThemes" Version="5.2.1" />
-		<PackageReference Include="H.NotifyIcon.Wpf" Version="2.2.0" />
-		<PackageReference Include="ReactiveUI.Fody" Version="19.5.41" /> 
-		<PackageReference Include="ReactiveUI.WPF" Version="20.1.63" />
+		<PackageReference Include="MaterialDesignThemes" />
+		<PackageReference Include="H.NotifyIcon.Wpf" />
+		<PackageReference Include="ReactiveUI.WPF" />
 	</ItemGroup>
-	
-	<ItemGroup>       
-        <AdditionalFiles Include="app.manifest" />       
-        <EmbeddedResource Include="Resources\v2rayN.ico">
-          <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-        </EmbeddedResource>
-        <Resource Include="Resources\NotifyIcon1.ico" />
-        <Resource Include="Resources\NotifyIcon2.ico" />
-        <Resource Include="Resources\NotifyIcon3.ico" />
-        <Resource Include="Resources\NotifyIcon4.ico" />
-        <Resource Include="Resources\v2rayN.ico" />
-    </ItemGroup> 	 
-	
+
 	<ItemGroup>
-	  <ProjectReference Include="..\ServiceLib\ServiceLib.csproj" />
+		<AdditionalFiles Include="app.manifest" />
+		<EmbeddedResource Include="Resources\v2rayN.ico">
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+		</EmbeddedResource>
+		<Resource Include="Resources\NotifyIcon1.ico" />
+		<Resource Include="Resources\NotifyIcon2.ico" />
+		<Resource Include="Resources\NotifyIcon3.ico" />
+		<Resource Include="Resources\NotifyIcon4.ico" />
+		<Resource Include="Resources\v2rayN.ico" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\ServiceLib\ServiceLib.csproj" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Use Directory.Packages.props for Centralized Dependency Management

This PR introduces a `Directory.Packages.props` file to enable [centralized management of NuGet package versions](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management) across all projects in the solution.

## Benefits of This Change

**Managing package versions centrally ensures consistency across the projects, reducing the risk of version conflicts.**

**Updating a package version now requires changing it in a single location rather than modifying multiple `.csproj` files.**

   **The following dependencies were repeated across multiple projects:**
   - `ReactiveUI`
   - `ReactiveUI.Fody`
   - `Avalonia`
   - `Avalonia.ReactiveUI`
   - `Avalonia.Controls.DataGrid`
   - `Avalonia.Desktop`
   - `MaterialDesignThemes`
   - `H.NotifyIcon.Wpf`

### Specific Changes
- Some dependencies were removed because they are now transitive (this is fine since `TransitivePinningEnabled` is set to `true`).
- Added `Directory.Packages.props` with the list of package versions used across the solution.
- Updated all `.csproj` files to remove version numbers for dependencies listed in `Directory.Packages.props`.