### PR TITLE
macOS 一些优化

### DIFF
--- a/v2rayN/v2rayN.Desktop/Program.cs
+++ b/v2rayN/v2rayN.Desktop/Program.cs
@@ -52,5 +52,6 @@ internal class Program
         //.WithInterFont()
         .WithFontByDefault()
         .LogToTrace()
-        .UseReactiveUI();
+        .UseReactiveUI()
+        .With(new MacOSPlatformOptions { ShowInDock = false});
 }

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
@@ -399,28 +399,28 @@ namespace v2rayN.Desktop.Views
 
         public void ShowHideWindow(bool? blShow)
         {
-            var bl = blShow ?? !_config.UiItem.ShowInTaskbar;
-            if (bl)
-            {
-                this.Show();
-                if (this.WindowState == WindowState.Minimized)
-                {
-                    this.WindowState = WindowState.Normal;
-                }
-                this.Activate();
-                this.Focus();
-            }
-            else
-            {
-                if (_config.UiItem.Hide2TrayWhenClose)
-                {
-                    this.Hide();
-                }
-                else
-                {
-                    this.WindowState = WindowState.Minimized;
-                }
-            }
+	        var bl = blShow ?? (!_config.UiItem.ShowInTaskbar ^ (WindowState==WindowState.Minimized));
+	        if (bl)
+	        {
+		        this.Show();
+		        if (this.WindowState == WindowState.Minimized)
+		        {
+			        this.WindowState = WindowState.Normal;
+		        }
+		        this.Activate();
+		        this.Focus();
+	        }
+	        else
+	        {
+		        if (Utils.IsOSX() || _config.UiItem.Hide2TrayWhenClose)
+		        {
+			        this.Hide();
+		        }
+		        else
+		        {
+			        this.WindowState = WindowState.Minimized;
+		        }
+	        }
 
             _config.UiItem.ShowInTaskbar = bl;
         }

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
@@ -389,7 +389,8 @@ namespace v2rayN.Desktop.Views
             _blCloseByUser = true;
             StorageUI();
 
-            await ViewModel?.MyAppExitAsync(false);
+	        await ViewModel?.MyAppExitAsync(false);
+	        Close();
         }
 
         #endregion Event


### PR DESCRIPTION
1. https://github.com/2dust/v2rayN/issues/6383 隐藏 dock 栏图标
2. 关闭按钮无响应
3. 在最小化状态下，使用 status bar 的 `Show or hide the main window` 需要点击两次(关闭再打开)才能显示出窗口  
这个提交做了简单的处理，但仍然有个小问题未修复：窗口会先闪出来一下，再从 dock 栏最小化的情况下播放一个放大的动画才能正常显示

测试设备为 macmini m4, macOS Sequoia 15.2
