### PR TITLE
[macOS] amend: Child window visibility handling

### DIFF
--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
@@ -390,7 +390,6 @@ namespace v2rayN.Desktop.Views
             StorageUI();
 
 	        await ViewModel?.MyAppExitAsync(false);
-	        Close();
         }
 
         #endregion Event
@@ -414,6 +413,10 @@ namespace v2rayN.Desktop.Views
 	        {
 		        if (Utils.IsOSX() || _config.UiItem.Hide2TrayWhenClose)
 		        {
+			        foreach (var ownedWindow in this.OwnedWindows)
+			        {
+				        ownedWindow.Close();
+			        }
 			        this.Hide();
 		        }
 		        else


### PR DESCRIPTION
https://github.com/2dust/v2rayN/pull/6596

在这个提交中引入了错误的逻辑, 当有子窗口 (例如 settings ) 打开时, 如果通过 status bar 的按钮隐藏主窗口, 子窗口会被一起隐藏.
但当再次通过此按钮打开主窗口时, 子窗口不会被自动打开, 会导致无法再打开这个子窗口.

同时修复 https://github.com/2dust/v2rayN/pull/6596#issuecomment-2621396359 提到的错误


