### PR TITLE
Modify default fallback load balancing rule

### DIFF
--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigV2rayService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigV2rayService.cs
@@ -184,7 +184,7 @@ namespace ServiceLib.Services.CoreConfig
                 }
                 v2rayConfig.routing.rules.Add(new()
                 {
-                    network = "tcp,udp",
+                    ip = ["0.0.0.0/0", "::/0"],
                     balancerTag = balancer.tag,
                     type = "field"
                 });

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigV2rayService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigV2rayService.cs
@@ -182,12 +182,24 @@ namespace ServiceLib.Services.CoreConfig
                         rule.balancerTag = balancer.tag;
                     }
                 }
-                v2rayConfig.routing.rules.Add(new()
+                if (v2rayConfig.routing.domainStrategy == "IPIfNonMatch")
                 {
-                    ip = ["0.0.0.0/0", "::/0"],
-                    balancerTag = balancer.tag,
-                    type = "field"
-                });
+                    v2rayConfig.routing.rules.Add(new()
+                    {
+                        ip = ["0.0.0.0/0", "::/0"],
+                        balancerTag = balancer.tag,
+                        type = "field"
+                    });
+                }
+                else
+                {
+                    v2rayConfig.routing.rules.Add(new()
+                    {
+                        network = "tcp,udp",
+                        balancerTag = balancer.tag,
+                        type = "field"
+                    });
+                }
 
                 ret.Success = true;
                 ret.Data = JsonUtils.Serialize(v2rayConfig);


### PR DESCRIPTION
将默认负载均衡兜底规则从基于网络类型（tcp,udp）匹配修改为基于 IP 范围（0.0.0.0/0, ::/0）匹配，避免当域名解析策略为IPIfNonMatch退化为AsIs。

https://github.com/XTLS/Xray-core/discussions/4480