### PR TITLE
sniff migration to singbox 1.11 support

### DIFF
--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -67,6 +67,9 @@ public class Rule4Sbox
     public List<string>? process_name { get; set; }
     public List<string>? rule_set { get; set; }
     public List<Rule4Sbox>? rules { get; set; }
+    public string? action { get; set; }
+    public string? strategy { get; set; }
+    public List<string>? sniffer { get; set; }
 }
 
 [Serializable]
@@ -76,7 +79,6 @@ public class Inbound4Sbox
     public string tag { get; set; }
     public string listen { get; set; }
     public int? listen_port { get; set; }
-    public string? domain_strategy { get; set; }
     public string interface_name { get; set; }
     public List<string>? address { get; set; }
     public int? mtu { get; set; }
@@ -84,8 +86,6 @@ public class Inbound4Sbox
     public bool? strict_route { get; set; }
     public bool? endpoint_independent_nat { get; set; }
     public string? stack { get; set; }
-    public bool? sniff { get; set; }
-    public bool? sniff_override_destination { get; set; }
     public List<User4Sbox> users { get; set; }
 }
 
@@ -134,6 +134,32 @@ public class Outbound4Sbox
     public HyObfs4Sbox? obfs { get; set; }
     public List<string>? outbounds { get; set; }
     public bool? interrupt_exist_connections { get; set; }
+}
+
+public class Endpoints4Sbox
+{
+    public string type { get; set; }
+    public string tag { get; set; }
+    public bool? system { get; set; }
+    public string? name { get; set; }
+    public int? mtu { get; set; }
+    public List<string> address { get; set; }
+    public string private_key { get; set; }
+    public int listen_port { get; set; }
+    public string? udp_timeout { get; set; }
+    public int? workers { get; set; }
+    public List<Peer4Sbox> peers { get; set; }
+}
+
+public class Peer4Sbox
+{
+    public string address { get; set; }
+    public int port { get; set; }
+    public string public_key { get; set; }
+    public string? pre_shared_key { get; set; }
+    public List<string> allowed_ips { get; set; }
+    public int? persistent_keepalive_interval { get; set; }
+    public List<int> reserved { get; set; }
 }
 
 public class Tls4Sbox

--- a/v2rayN/ServiceLib/Sample/SingboxSampleClientConfig
+++ b/v2rayN/ServiceLib/Sample/SingboxSampleClientConfig
@@ -1,4 +1,4 @@
-﻿{
+{
 	"log": {
 		"level": "debug",
 		"timestamp": true
@@ -14,22 +14,10 @@
 		{
 			"type": "direct",
 			"tag": "direct"
-		},
-		{
-			"type": "block",
-			"tag": "block"
-		},
-		{
-			"tag": "dns_out",
-			"type": "dns"
 		}
 	],
 	"route": {
 		"rules": [
-			{
-				"protocol": [ "dns" ],
-				"outbound": "dns_out"
-			}
 		]
 	}
 }

--- a/v2rayN/ServiceLib/Sample/tun_singbox_rules
+++ b/v2rayN/ServiceLib/Sample/tun_singbox_rules
@@ -8,13 +8,13 @@
       139,
       5353
     ],
-    "outbound": "block"
+    "action": "reject"
   },
   {
     "ip_cidr": [
       "224.0.0.0/3",
       "ff00::/8"
     ],
-    "outbound": "block"
+    "action": "reject"
   }
 ]

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -983,8 +983,7 @@ public class CoreConfigSingboxService
             {
                 singboxConfig.route.rules.Add(new()
                 {
-                    action = "sniff",
-                    sniffer = new() { "dns", _config.Inbound.First().DestOverride }
+                    action = "sniff"
                 });
                 singboxConfig.route.rules.Add(new()
                 {

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1,6 +1,7 @@
 using System.Data;
 using System.Net;
 using System.Net.NetworkInformation;
+using DynamicData;
 
 namespace ServiceLib.Services.CoreConfig;
 
@@ -558,15 +559,6 @@ public class CoreConfigSingboxService
                 singboxConfig.inbounds.Add(inbound);
 
                 inbound.listen_port = AppHandler.Instance.GetLocalPort(EInboundProtocol.socks);
-                inbound.sniff = _config.Inbound.First().SniffingEnabled;
-                inbound.sniff_override_destination = _config.Inbound.First().RouteOnly ? false : _config.Inbound.First().SniffingEnabled;
-                inbound.domain_strategy = _config.RoutingBasicItem.DomainStrategy4Singbox.IsNullOrEmpty() ? null : _config.RoutingBasicItem.DomainStrategy4Singbox;
-
-                var routing = await ConfigHandler.GetDefaultRouting(_config);
-                if (routing.DomainStrategy4Singbox.IsNotEmpty())
-                {
-                    inbound.domain_strategy = routing.DomainStrategy4Singbox;
-                }
 
                 if (_config.Inbound.First().SecondLocalPortEnabled)
                 {
@@ -611,8 +603,6 @@ public class CoreConfigSingboxService
                 tunInbound.mtu = _config.TunModeItem.Mtu;
                 tunInbound.strict_route = _config.TunModeItem.StrictRoute;
                 tunInbound.stack = _config.TunModeItem.Stack;
-                tunInbound.sniff = _config.Inbound.First().SniffingEnabled;
-                //tunInbound.sniff_override_destination = _config.inbound.First().routeOnly ? false : _config.inbound.First().sniffingEnabled;
                 if (_config.TunModeItem.EnableIPv6Address == false)
                 {
                     tunInbound.address = ["172.18.0.1/30"];
@@ -978,17 +968,6 @@ public class CoreConfigSingboxService
     {
         try
         {
-            var dnsOutbound = "dns_out";
-            if (!_config.Inbound.First().SniffingEnabled)
-            {
-                singboxConfig.route.rules.Add(new()
-                {
-                    port = [53],
-                    network = ["udp"],
-                    outbound = dnsOutbound
-                });
-            }
-
             singboxConfig.route.rules.Insert(0, new()
             {
                 outbound = Global.DirectTag,
@@ -999,6 +978,44 @@ public class CoreConfigSingboxService
                 outbound = Global.ProxyTag,
                 clash_mode = ERuleMode.Global.ToString()
             });
+
+            if (_config.Inbound.First().SniffingEnabled)
+            {
+                singboxConfig.route.rules.Add(new()
+                {
+                    action = "sniff",
+                    sniffer = new() { "dns", _config.Inbound.First().DestOverride }
+                });
+                singboxConfig.route.rules.Add(new()
+                {
+                    protocol = new() { "dns" },
+                    action = "hijack-dns"
+                });
+            }
+            else
+            {
+                singboxConfig.route.rules.Add(new()
+                {
+                    port = new() { 53 },
+                    network = new() { "udp" },
+                    action = "hijack-dns"
+                });
+            }
+
+            if (!(_config.Inbound.First().RouteOnly || _config.TunModeItem.EnableTun))
+            {
+                var domainStrategy = _config.RoutingBasicItem.DomainStrategy4Singbox.IsNullOrEmpty() ? null : _config.RoutingBasicItem.DomainStrategy4Singbox;
+                var defaultRouting = await ConfigHandler.GetDefaultRouting(_config);
+                if (defaultRouting.DomainStrategy4Singbox.IsNotEmpty())
+                {
+                    domainStrategy = defaultRouting.DomainStrategy4Singbox;
+                }
+                singboxConfig.route.rules.Add(new()
+                {
+                    action = "resolve",
+                    strategy = domainStrategy
+                });
+            }
 
             if (_config.TunModeItem.EnableTun)
             {
@@ -1014,7 +1031,7 @@ public class CoreConfigSingboxService
                 singboxConfig.route.rules.Add(new()
                 {
                     port = new() { 53 },
-                    outbound = dnsOutbound,
+                    action = "hijack-dns",
                     process_name = lstDnsExe
                 });
 
@@ -1080,10 +1097,15 @@ public class CoreConfigSingboxService
                 return 0;
             }
 
-            var rule = new Rule4Sbox()
+            var rule = new Rule4Sbox();
+            if (item.OutboundTag == "block")
             {
-                outbound = item.OutboundTag,
-            };
+                rule.action = "reject";
+            }
+            else
+            {
+                rule.outbound = item.OutboundTag;
+            }
 
             if (item.Port.IsNotEmpty())
             {


### PR DESCRIPTION
这个 pr 仅将 inbounds 的 sniff 等移动到 route 中，还差以下功能：

- WireGuard 的 Endpoint 支持
- ~~[sing-box 的协议探测类型比 xray 多](https://sing-box.sagernet.org/configuration/route/sniff/)，可能要考虑在设置界面和 Config 中添加 DestOverrideSingbox 字段。~~ singbox只嗅探，不 override，影响不大

Warning：

- `sniff_override_destination` 被弃用，只能使用 `fake-ip` 替代。SagerNet/sing-box#2407
- ["action": "resolve"](https://sing-box.sagernet.org/configuration/route/rule_action/#resolve) 的行为没搞懂，目前是仅当 `RouteOnly` 和 `EnableTun` 都为 `false` 时启用。
