### PR TITLE
Add accessibility labels to improve screen reader support

### DIFF
--- a/v2rayN/v2rayN/Views/MainWindow.xaml
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml
@@ -42,7 +42,8 @@
                         ClipToBounds="True"
                         Style="{StaticResource MaterialDesignToolBar}">
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
-                            <MenuItem Padding="8,0">
+                            <MenuItem Padding="8,0"
+                                AutomationProperties.Name="{x:Static resx:ResUI.menuServers}">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <materialDesign:PackIcon
@@ -110,7 +111,8 @@
                         </Menu>
                         <Separator />
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
-                            <MenuItem Padding="8,0">
+                            <MenuItem Padding="8,0"
+                                      AutomationProperties.Name="{x:Static resx:ResUI.menuSubscription}">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <materialDesign:PackIcon
@@ -145,7 +147,8 @@
                         </Menu>
                         <Separator />
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
-                            <MenuItem Padding="8,0">
+                            <MenuItem Padding="8,0" Width="86"
+                                      AutomationProperties.Name="{x:Static resx:ResUI.menuSetting}">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <materialDesign:PackIcon
@@ -211,7 +214,8 @@
                         </Menu>
                         <Separator />
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
-                            <MenuItem x:Name="menuReload" Padding="8,0">
+                            <MenuItem x:Name="menuReload" Padding="8,0"
+                                      AutomationProperties.Name="{x:Static resx:ResUI.menuReload}">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <materialDesign:PackIcon
@@ -225,7 +229,8 @@
                         </Menu>
                         <Separator />
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
-                            <MenuItem Name="menuCheckUpdate" Padding="8,0">
+                            <MenuItem Name="menuCheckUpdate" Padding="8,0"
+                                      AutomationProperties.Name="{x:Static resx:ResUI.menuCheckUpdate}">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <materialDesign:PackIcon
@@ -239,7 +244,8 @@
                         </Menu>
                         <Separator />
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
-                            <MenuItem x:Name="menuHelp" Padding="8,0">
+                            <MenuItem x:Name="menuHelp" Padding="8,0"
+                                      AutomationProperties.Name="{x:Static resx:ResUI.menuHelp}">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <materialDesign:PackIcon
@@ -253,7 +259,8 @@
                         </Menu>
                         <Separator />
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
-                            <MenuItem x:Name="menuPromotion" Padding="8,0">
+                            <MenuItem x:Name="menuPromotion" Padding="8,0"
+                                      AutomationProperties.Name="{x:Static resx:ResUI.menuPromotion}">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <materialDesign:PackIcon
@@ -267,7 +274,8 @@
                         </Menu>
                         <Separator />
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
-                            <MenuItem x:Name="menuClose" Padding="8,0">
+                            <MenuItem x:Name="menuClose" Padding="8,0"
+                                      AutomationProperties.Name="{x:Static resx:ResUI.menuClose}">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <materialDesign:PackIcon

--- a/v2rayN/v2rayN/Views/ProfilesView.xaml
+++ b/v2rayN/v2rayN/Views/ProfilesView.xaml
@@ -41,7 +41,8 @@
                     Height="30"
                     Margin="{StaticResource MarginLeftRight4}"
                     Style="{StaticResource MaterialDesignFloatingActionMiniLightButton}"
-                    ToolTip="{x:Static resx:ResUI.menuSubEdit}">
+                    ToolTip="{x:Static resx:ResUI.menuSubEdit}"
+                    AutomationProperties.Name="{x:Static resx:ResUI.menuSubEdit}">
                     <materialDesign:PackIcon VerticalAlignment="Center" Kind="Edit" />
                 </Button>
                 <Button
@@ -50,7 +51,8 @@
                     Height="30"
                     Margin="{StaticResource MarginLeftRight4}"
                     Style="{StaticResource MaterialDesignFloatingActionMiniLightButton}"
-                    ToolTip="{x:Static resx:ResUI.menuSubAdd}">
+                    ToolTip="{x:Static resx:ResUI.menuSubAdd}"
+                    AutomationProperties.Name="{x:Static resx:ResUI.menuSubAdd}">
                     <materialDesign:PackIcon VerticalAlignment="Center" Kind="Plus" />
                 </Button>
 
@@ -60,7 +62,8 @@
                     Height="30"
                     Margin="{StaticResource MarginLeftRight8}"
                     Style="{StaticResource MaterialDesignFloatingActionMiniLightButton}"
-                    ToolTip="{x:Static resx:ResUI.menuProfileAutofitColumnWidth}">
+                    ToolTip="{x:Static resx:ResUI.menuProfileAutofitColumnWidth}"
+                    AutomationProperties.Name="{x:Static resx:ResUI.menuProfileAutofitColumnWidth}">
                     <materialDesign:PackIcon VerticalAlignment="Center" Kind="ArrowSplitVertical" />
                 </Button>
                 <TextBox
@@ -70,7 +73,8 @@
                     VerticalContentAlignment="Center"
                     materialDesign:HintAssist.Hint="{x:Static resx:ResUI.MsgServerTitle}"
                     materialDesign:TextFieldAssist.HasClearButton="True"
-                    Style="{StaticResource DefTextBox}" />
+                    Style="{StaticResource DefTextBox}"
+                    AutomationProperties.Name="{x:Static resx:ResUI.MsgServerTitle}" />
             </WrapPanel>
             <DataGrid
                 x:Name="lstProfiles"

--- a/v2rayN/v2rayN/Views/StatusBarView.xaml
+++ b/v2rayN/v2rayN/Views/StatusBarView.xaml
@@ -61,7 +61,7 @@
                         x:Name="togEnableTun"
                         Margin="{StaticResource Margin4}"
                         HorizontalAlignment="Left"
-                        VerticalAlignment="Center" />
+                        VerticalAlignment="Center" AutomationProperties.Name="{x:Static resx:ResUI.TbEnableTunAs}" />
                 </StackPanel>
 
                 <StackPanel
@@ -75,7 +75,8 @@
                         Margin="{StaticResource MarginLeftRight8}"
                         materialDesign:HintAssist.Hint="{x:Static resx:ResUI.menuSystemproxy}"
                         FontSize="{DynamicResource StdFontSize}"
-                        Style="{StaticResource MaterialDesignFloatingHintComboBox}">
+                        Style="{StaticResource MaterialDesignFloatingHintComboBox}"
+                        AutomationProperties.Name="{x:Static resx:ResUI.menuSystemproxy}">
                         <ComboBoxItem Content="{x:Static resx:ResUI.menuSystemProxyClear}" />
                         <ComboBoxItem Content="{x:Static resx:ResUI.menuSystemProxySet}" />
                         <ComboBoxItem Content="{x:Static resx:ResUI.menuSystemProxyNothing}" />
@@ -89,7 +90,8 @@
                         materialDesign:HintAssist.Hint="{x:Static resx:ResUI.menuRouting}"
                         DisplayMemberPath="Remarks"
                         FontSize="{DynamicResource StdFontSize}"
-                        Style="{StaticResource MaterialDesignFloatingHintComboBox}" />
+                        Style="{StaticResource MaterialDesignFloatingHintComboBox}"
+                        AutomationProperties.Name="{x:Static resx:ResUI.menuRouting}"/>
                 </StackPanel>
 
                 <StackPanel Margin="{StaticResource MarginLeftRight8}" VerticalAlignment="Center">
@@ -107,7 +109,8 @@
             ToolTipText="v2rayN">
             <tb:TaskbarIcon.ContextMenu>
                 <ContextMenu Style="{StaticResource DefContextMenu}">
-                    <MenuItem x:Name="menuSystemProxyClear" Height="{StaticResource MenuItemHeight}">
+                    <MenuItem x:Name="menuSystemProxyClear" Height="{StaticResource MenuItemHeight}"
+                              AutomationProperties.Name="{x:Static resx:ResUI.menuSystemProxyClear}">
                         <MenuItem.Header>
                             <StackPanel Orientation="Horizontal">
                                 <materialDesign:PackIcon
@@ -119,7 +122,8 @@
                             </StackPanel>
                         </MenuItem.Header>
                     </MenuItem>
-                    <MenuItem x:Name="menuSystemProxySet" Height="{StaticResource MenuItemHeight}">
+                    <MenuItem x:Name="menuSystemProxySet" Height="{StaticResource MenuItemHeight}"
+                              AutomationProperties.Name="{x:Static resx:ResUI.menuSystemProxySet}">
                         <MenuItem.Header>
                             <StackPanel Orientation="Horizontal">
                                 <materialDesign:PackIcon
@@ -131,7 +135,8 @@
                             </StackPanel>
                         </MenuItem.Header>
                     </MenuItem>
-                    <MenuItem x:Name="menuSystemProxyNothing" Height="{StaticResource MenuItemHeight}">
+                    <MenuItem x:Name="menuSystemProxyNothing" Height="{StaticResource MenuItemHeight}"
+                              AutomationProperties.Name="{x:Static resx:ResUI.menuSystemProxyNothing}">
                         <MenuItem.Header>
                             <StackPanel Orientation="Horizontal">
                                 <materialDesign:PackIcon
@@ -143,7 +148,8 @@
                             </StackPanel>
                         </MenuItem.Header>
                     </MenuItem>
-                    <MenuItem x:Name="menuSystemProxyPac" Height="{StaticResource MenuItemHeight}">
+                    <MenuItem x:Name="menuSystemProxyPac" Height="{StaticResource MenuItemHeight}"
+                              AutomationProperties.Name="{x:Static resx:ResUI.menuSystemProxyPac}">
                         <MenuItem.Header>
                             <StackPanel Orientation="Horizontal">
                                 <materialDesign:PackIcon
@@ -156,7 +162,8 @@
                         </MenuItem.Header>
                     </MenuItem>
                     <Separator x:Name="sepRoutings" />
-                    <MenuItem x:Name="menuRoutings" Height="Auto">
+                    <MenuItem x:Name="menuRoutings" Height="Auto"
+                              AutomationProperties.Name="{x:Static resx:ResUI.menuRouting}">
                         <MenuItem.Header>
                             <DockPanel>
                                 <ComboBox
@@ -165,11 +172,12 @@
                                     materialDesign:HintAssist.Hint="{x:Static resx:ResUI.menuRouting}"
                                     DisplayMemberPath="Remarks"
                                     FontSize="{DynamicResource StdFontSize}"
-                                    Style="{StaticResource MaterialDesignFilledComboBox}" />
+                                    Style="{StaticResource MaterialDesignFilledComboBox}"
+                                    AutomationProperties.Name="{x:Static resx:ResUI.menuRouting}"/>
                             </DockPanel>
                         </MenuItem.Header>
                     </MenuItem>
-                    <MenuItem Height="Auto">
+                    <MenuItem Height="Auto" AutomationProperties.Name="{x:Static resx:ResUI.menuServers}">
                         <MenuItem.Header>
                             <DockPanel>
                                 <ComboBox
@@ -178,7 +186,8 @@
                                     materialDesign:HintAssist.Hint="{x:Static resx:ResUI.menuServers}"
                                     DisplayMemberPath="Text"
                                     FontSize="{DynamicResource StdFontSize}"
-                                    Style="{StaticResource MaterialDesignFilledComboBox}" />
+                                    Style="{StaticResource MaterialDesignFilledComboBox}"
+                                    AutomationProperties.Name="{x:Static resx:ResUI.menuServers}"/>
                             </DockPanel>
                         </MenuItem.Header>
                     </MenuItem>


### PR DESCRIPTION
This pull request adds accessibility improvements to the v2rayN user interface by incorporating `AutomationProperties.Name` for key UI elements. These changes enhance the experience for users relying on screen readers like NVDA, ensuring better navigation and usability for visually impaired users.

### Changes Made:
- **MainWindow.xaml**:
  - Added `AutomationProperties.Name` to main menu items (e.g., Servers, Subscription, Setting, Reload, Check Update, Help, Promotion, Close) to improve screen reader navigation.

- **ProfilesView.xaml**:
  - Added `AutomationProperties.Name` to action buttons (`btnEditSub`, `btnAddSub`, `btnAutofitColumnWidth`) for better identification by screen readers (e.g., "Edit Subscription", "Add Subscription", "Autofit Column Width").
  - Added `AutomationProperties.Name` to the server filter textbox (`txtServerFilter`) to label it as "Server Filter" for screen readers.

- **StatusBarView.xaml**:
  - Added `AutomationProperties.Name` to the `togEnableTun` toggle button to label it as "Enable Tun" for screen readers.
  - Added `AutomationProperties.Name` to ComboBox elements (`cmbSystemProxy`, `cmbRoutings2`) to label them as "System Proxy" and "Routing" for screen readers.
  - Added `AutomationProperties.Name` to Taskbar context menu items (e.g., `menuSystemProxyClear`, `menuSystemProxySet`, `menuSystemProxyNothing`, `menuSystemProxyPac`, `menuRoutings`) to improve accessibility in the system tray menu.

### Why This Matters:
These accessibility labels ensure that visually impaired users can navigate the v2rayN interface more effectively using screen readers, making the application more inclusive.

@2dust Please review these accessibility improvements and let me know if any additional changes are needed.