### PR TITLE
migration to singbox 1.12 support

### DIFF
--- a/v2rayN/ServiceLib/Common/Utils.cs
+++ b/v2rayN/ServiceLib/Common/Utils.cs
@@ -427,11 +427,11 @@ public class Utils
         return false;
     }
 
-    public static int GetFreePort(int defaultPort = 9090)
+    public static int GetFreePort(int defaultPort = 0)
     {
         try
         {
-            if (!Utils.PortInUse(defaultPort))
+            if (!(defaultPort == 0 || Utils.PortInUse(defaultPort)))
             {
                 return defaultPort;
             }

--- a/v2rayN/ServiceLib/Enums/EConfigType.cs
+++ b/v2rayN/ServiceLib/Enums/EConfigType.cs
@@ -11,5 +11,6 @@ public enum EConfigType
     Hysteria2 = 7,
     TUIC = 8,
     WireGuard = 9,
-    HTTP = 10
+    HTTP = 10,
+    Anytls = 11
 }

--- a/v2rayN/ServiceLib/Global.cs
+++ b/v2rayN/ServiceLib/Global.cs
@@ -169,7 +169,8 @@ public class Global
             { EConfigType.Trojan, "trojan://" },
             { EConfigType.Hysteria2, "hysteria2://" },
             { EConfigType.TUIC, "tuic://" },
-            { EConfigType.WireGuard, "wireguard://" }
+            { EConfigType.WireGuard, "wireguard://" },
+            { EConfigType.Anytls, "anytls://" }
         };
 
     public static readonly Dictionary<EConfigType, string> ProtocolTypes = new()
@@ -182,7 +183,8 @@ public class Global
             { EConfigType.Trojan, "trojan" },
             { EConfigType.Hysteria2, "hysteria2" },
             { EConfigType.TUIC, "tuic" },
-            { EConfigType.WireGuard, "wireguard" }
+            { EConfigType.WireGuard, "wireguard" },
+            { EConfigType.Anytls, "anytls" }
         };
 
     public static readonly List<string> VmessSecurities =

--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -259,6 +259,7 @@ public class ConfigHandler
             EConfigType.Hysteria2 => await AddHysteria2Server(config, item),
             EConfigType.TUIC => await AddTuicServer(config, item),
             EConfigType.WireGuard => await AddWireguardServer(config, item),
+            EConfigType.Anytls => await AddAnytlsServer(config, item),
             _ => -1,
         };
         return ret;
@@ -784,6 +785,35 @@ public class ConfigHandler
     }
 
     /// <summary>
+    /// Add or edit a Anytls server
+    /// Validates and processes Anytls-specific settings
+    /// </summary>
+    /// <param name="config">Current configuration</param>
+    /// <param name="profileItem">Anytls profile to add</param>
+    /// <param name="toFile">Whether to save to file</param>
+    /// <returns>0 if successful, -1 if failed</returns>
+    public static async Task<int> AddAnytlsServer(Config config, ProfileItem profileItem, bool toFile = true)
+    {
+        profileItem.ConfigType = EConfigType.Anytls;
+        profileItem.CoreType = ECoreType.sing_box;
+
+        profileItem.Address = profileItem.Address.TrimEx();
+        profileItem.Id = profileItem.Id.TrimEx();
+        profileItem.Security = profileItem.Security.TrimEx();
+        profileItem.Network = string.Empty;
+        if (profileItem.StreamSecurity.IsNullOrEmpty())
+        {
+            profileItem.StreamSecurity = Global.StreamSecurity;
+        }
+        if (profileItem.Id.IsNullOrEmpty())
+        {
+            return -1;
+        }
+        await AddServerCommon(config, profileItem, toFile);
+        return 0;
+    }
+
+    /// <summary>
     /// Sort the server list by the specified column
     /// Updates the sort order in the profile extension data
     /// </summary>
@@ -1292,6 +1322,7 @@ public class ConfigHandler
                 EConfigType.Hysteria2 => await AddHysteria2Server(config, profileItem, false),
                 EConfigType.TUIC => await AddTuicServer(config, profileItem, false),
                 EConfigType.WireGuard => await AddWireguardServer(config, profileItem, false),
+                EConfigType.Anytls => await AddAnytlsServer(config, profileItem, false),
                 _ => -1,
             };
 

--- a/v2rayN/ServiceLib/Handler/CoreHandler.cs
+++ b/v2rayN/ServiceLib/Handler/CoreHandler.cs
@@ -101,7 +101,7 @@ public class CoreHandler
 
     public async Task<int> LoadCoreConfigSpeedtest(List<ServerTestItem> selecteds)
     {
-        var coreType = selecteds.Exists(t => t.ConfigType is EConfigType.Hysteria2 or EConfigType.TUIC) ? ECoreType.sing_box : ECoreType.Xray;
+        var coreType = selecteds.Exists(t => t.ConfigType is EConfigType.Hysteria2 or EConfigType.TUIC or EConfigType.Anytls) ? ECoreType.sing_box : ECoreType.Xray;
         var fileName = string.Format(Global.CoreSpeedtestConfigFileName, Utils.GetGuid(false));
         var configPath = Utils.GetBinConfigPath(fileName);
         var result = await CoreConfigHandler.GenerateClientSpeedtestConfig(_config, configPath, selecteds, coreType);

--- a/v2rayN/ServiceLib/Handler/Fmt/AnytlsFmt.cs
+++ b/v2rayN/ServiceLib/Handler/Fmt/AnytlsFmt.cs
@@ -1,0 +1,54 @@
+using static QRCoder.PayloadGenerator;
+
+namespace ServiceLib.Handler.Fmt;
+public class AnytlsFmt : BaseFmt
+{
+    public static ProfileItem? Resolve(string str, out string msg)
+    {
+        msg = ResUI.ConfigurationFormatIncorrect;
+
+        var parsedUrl = Utils.TryUri(str);
+        if (parsedUrl == null)
+        {
+            return null;
+        }
+
+        ProfileItem item = new()
+        {
+            ConfigType = EConfigType.Anytls,
+            Remarks = parsedUrl.GetComponents(UriComponents.Fragment, UriFormat.Unescaped),
+            Address = parsedUrl.IdnHost,
+            Port = parsedUrl.Port,
+        };
+        var rawUserInfo = Utils.UrlDecode(parsedUrl.UserInfo);
+        item.Id = rawUserInfo;
+
+        var query = Utils.ParseQueryString(parsedUrl.Query);
+        item.Sni = query["sni"] ?? Global.None;
+        item.AllowInsecure = (query["insecure"] ?? "") == "1" ? "true" : "false";
+
+        return item;
+    }
+
+    public static string? ToUri(ProfileItem? item)
+    {
+        if (item == null)
+        {
+            return null;
+        }
+        var remark = string.Empty;
+        if (item.Remarks.IsNotEmpty())
+        {
+            remark = "#" + Utils.UrlEncode(item.Remarks);
+        }
+        var pw = item.Id;
+        var dicQuery = new Dictionary<string, string>();
+        if (item.Sni.IsNotEmpty())
+        {
+            dicQuery.Add("sni", item.Sni);
+        }
+        dicQuery.Add("insecure", item.AllowInsecure.ToLower() == "true" ? "1" : "0");
+
+        return ToUri(EConfigType.Anytls, item.Address, item.Port, pw, dicQuery, remark);
+    }
+}

--- a/v2rayN/ServiceLib/Handler/Fmt/FmtHandler.cs
+++ b/v2rayN/ServiceLib/Handler/Fmt/FmtHandler.cs
@@ -18,6 +18,7 @@ public class FmtHandler
                 EConfigType.Hysteria2 => Hysteria2Fmt.ToUri(item),
                 EConfigType.TUIC => TuicFmt.ToUri(item),
                 EConfigType.WireGuard => WireguardFmt.ToUri(item),
+                EConfigType.Anytls => AnytlsFmt.ToUri(item),
                 _ => null,
             };
 
@@ -74,6 +75,10 @@ public class FmtHandler
             else if (str.StartsWith(Global.ProtocolShares[EConfigType.WireGuard]))
             {
                 return WireguardFmt.Resolve(str, out msg);
+            }
+            else if (str.StartsWith(Global.ProtocolShares[EConfigType.Anytls]))
+            {
+                return AnytlsFmt.Resolve(str, out msg);
             }
             else
             {

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -226,7 +226,7 @@ public class Server4Sbox
     public string? client_subnet { get; set; }
     public string? type { get; set; }
     public string? server { get; set; }
-    public string? server_resolver { get; set; }
+    public string? domain_resolver { get; set; }
     [JsonPropertyName("interface")] public string? Interface { get; set; }
     // Deprecated
     public string? address { get; set; }

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -67,6 +67,9 @@ public class Rule4Sbox
     public List<string>? process_name { get; set; }
     public List<string>? rule_set { get; set; }
     public List<Rule4Sbox>? rules { get; set; }
+    public string? action { get; set; }
+    public string? strategy { get; set; }
+    public List<string>? sniffer { get; set; }
 }
 
 [Serializable]
@@ -76,7 +79,6 @@ public class Inbound4Sbox
     public string tag { get; set; }
     public string listen { get; set; }
     public int? listen_port { get; set; }
-    public string? domain_strategy { get; set; }
     public string interface_name { get; set; }
     public List<string>? address { get; set; }
     public int? mtu { get; set; }
@@ -84,8 +86,6 @@ public class Inbound4Sbox
     public bool? strict_route { get; set; }
     public bool? endpoint_independent_nat { get; set; }
     public string? stack { get; set; }
-    public bool? sniff { get; set; }
-    public bool? sniff_override_destination { get; set; }
     public List<User4Sbox> users { get; set; }
 }
 
@@ -134,6 +134,32 @@ public class Outbound4Sbox
     public HyObfs4Sbox? obfs { get; set; }
     public List<string>? outbounds { get; set; }
     public bool? interrupt_exist_connections { get; set; }
+}
+
+public class Endpoints4Sbox
+{
+    public string type { get; set; }
+    public string tag { get; set; }
+    public bool? system { get; set; }
+    public string? name { get; set; }
+    public int? mtu { get; set; }
+    public List<string> address { get; set; }
+    public string private_key { get; set; }
+    public int listen_port { get; set; }
+    public string? udp_timeout { get; set; }
+    public int? workers { get; set; }
+    public List<Peer4Sbox> peers { get; set; }
+}
+
+public class Peer4Sbox
+{
+    public string address { get; set; }
+    public int port { get; set; }
+    public string public_key { get; set; }
+    public string? pre_shared_key { get; set; }
+    public List<string> allowed_ips { get; set; }
+    public int? persistent_keepalive_interval { get; set; }
+    public List<int> reserved { get; set; }
 }
 
 public class Tls4Sbox

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -228,6 +228,10 @@ public class Server4Sbox
     public string? server { get; set; }
     public string? domain_resolver { get; set; }
     [JsonPropertyName("interface")] public string? Interface { get; set; }
+    public int? server_port { get; set; }
+    public string? path { get; set; }
+    public Headers4Sbox? headers { get; set; }
+    public Tls4Sbox? tls { get; set; }
     // Deprecated
     public string? address { get; set; }
     public string? address_resolver { get; set; }

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -53,6 +53,7 @@ public class Rule4Sbox
     public string? mode { get; set; }
     public bool? ip_is_private { get; set; }
     public string? client_subnet { get; set; }
+    public int? rewrite_ttl { get; set; }
     public bool? invert { get; set; }
     public string? clash_mode { get; set; }
     public List<string>? inbound { get; set; }
@@ -74,6 +75,24 @@ public class Rule4Sbox
     public string? action { get; set; }
     public string? strategy { get; set; }
     public List<string>? sniffer { get; set; }
+    public string? rcode { get; set; }
+    public List<object>? query_type { get; set; }
+    public List<string>? answer { get; set; }
+    public List<string>? ns { get; set; }
+    public List<string>? extra { get; set; }
+    public string? method { get; set; }
+    public bool? no_drop { get; set; }
+    public bool? source_ip_is_private { get; set; }
+    public bool? ip_accept_any { get; set; }
+    public int? source_port { get; set; }
+    public List<string>? source_port_range { get; set; }
+    public List<string>? network_type { get; set; }
+    public bool? network_is_expensive { get; set; }
+    public bool? network_is_constrained { get; set; }
+    public List<string>? wifi_ssid { get; set; }
+    public List<string>? wifi_bssid { get; set; }
+    public bool? rule_set_ip_cidr_match_source { get; set; }
+    public bool? rule_set_ip_cidr_accept_empty { get; set; }
 }
 
 [Serializable]

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -227,6 +227,12 @@ public class Server4Sbox
     public string? server { get; set; }
     public string? server_resolver { get; set; }
     [JsonPropertyName("interface")] public string? Interface { get; set; }
+    // Deprecated
+    public string? address { get; set; }
+    public string? address_resolver { get; set; }
+    public string? address_strategy { get; set; }
+    public string? strategy { get; set; }
+    // Deprecated End
 }
 
 public class Experimental4Sbox

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -8,6 +8,7 @@ public class SingboxConfig
     public Dns4Sbox? dns { get; set; }
     public List<Inbound4Sbox> inbounds { get; set; }
     public List<Outbound4Sbox> outbounds { get; set; }
+    public List<Endpoints4Sbox>? endpoints { get; set; }
     public Route4Sbox route { get; set; }
     public Experimental4Sbox? experimental { get; set; }
 }
@@ -123,11 +124,6 @@ public class Outbound4Sbox
     public string? version { get; set; }
     public string? network { get; set; }
     public string? packet_encoding { get; set; }
-    public List<string>? local_address { get; set; }
-    public string? private_key { get; set; }
-    public string? peer_public_key { get; set; }
-    public List<int>? reserved { get; set; }
-    public int? mtu { get; set; }
     public string? plugin { get; set; }
     public string? plugin_opts { get; set; }
     public Tls4Sbox? tls { get; set; }
@@ -152,6 +148,8 @@ public class Endpoints4Sbox
     public string? udp_timeout { get; set; }
     public int? workers { get; set; }
     public List<Peer4Sbox> peers { get; set; }
+    public string? detour { get; set; }
+    public Rule4Sbox? domain_resolver { get; set; }
 }
 
 public class Peer4Sbox

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -134,6 +134,7 @@ public class Outbound4Sbox
     public HyObfs4Sbox? obfs { get; set; }
     public List<string>? outbounds { get; set; }
     public bool? interrupt_exist_connections { get; set; }
+    public Rule4Sbox? domain_resolver { get; set; }
 }
 
 public class Endpoints4Sbox
@@ -220,12 +221,12 @@ public class HyObfs4Sbox
 public class Server4Sbox
 {
     public string? tag { get; set; }
-    public string? address { get; set; }
-    public string? address_resolver { get; set; }
-    public string? address_strategy { get; set; }
-    public string? strategy { get; set; }
     public string? detour { get; set; }
     public string? client_subnet { get; set; }
+    public string? type { get; set; }
+    public string? server { get; set; }
+    public string? server_resolver { get; set; }
+    //public string? interface { get; set; }
 }
 
 public class Experimental4Sbox

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -40,6 +40,7 @@ public class Route4Sbox
     public bool? auto_detect_interface { get; set; }
     public List<Rule4Sbox> rules { get; set; }
     public List<Ruleset4Sbox>? rule_set { get; set; }
+    public string? final { get; set; }
 }
 
 [Serializable]

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace ServiceLib.Models;
 
 public class SingboxConfig
@@ -226,7 +228,7 @@ public class Server4Sbox
     public string? type { get; set; }
     public string? server { get; set; }
     public string? server_resolver { get; set; }
-    //public string? interface { get; set; }
+    [JsonPropertyName("interface")] public string? Interface { get; set; }
 }
 
 public class Experimental4Sbox

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -673,6 +673,15 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Add [Anytls] Configuration 的本地化字符串。
+        /// </summary>
+        public static string menuAddAnytlsServer {
+            get {
+                return ResourceManager.GetString("menuAddAnytlsServer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Add a custom configuration Configuration 的本地化字符串。
         /// </summary>
         public static string menuAddCustomServer {

--- a/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
@@ -1416,4 +1416,7 @@
   <data name="menuExportConfig" xml:space="preserve">
     <value>صادر کردن سرور</value>
   </data>
+  <data name="menuAddAnytlsServer" xml:space="preserve">
+    <value>Add [Anytls] Configuration</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.hu.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.hu.resx
@@ -1416,4 +1416,7 @@
   <data name="menuExportConfig" xml:space="preserve">
     <value>Export server</value>
   </data>
+  <data name="menuAddAnytlsServer" xml:space="preserve">
+    <value>Add [Anytls] Configuration</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1416,4 +1416,7 @@
   <data name="menuExportConfig" xml:space="preserve">
     <value>Export Configuration</value>
   </data>
+  <data name="menuAddAnytlsServer" xml:space="preserve">
+    <value>Add [Anytls] Configuration</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1416,4 +1416,7 @@
   <data name="menuExportConfig" xml:space="preserve">
     <value>Export server</value>
   </data>
+  <data name="menuAddAnytlsServer" xml:space="preserve">
+    <value>Add [Anytls] Configuration</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1413,4 +1413,7 @@
   <data name="menuExportConfig" xml:space="preserve">
     <value>导出配置文件</value>
   </data>
+  <data name="menuAddAnytlsServer" xml:space="preserve">
+    <value>添加 [Anytls] 配置文件</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -1413,4 +1413,7 @@
   <data name="menuExportConfig" xml:space="preserve">
     <value>匯出設定檔</value>
   </data>
+  <data name="menuAddAnytlsServer" xml:space="preserve">
+    <value>新增 [Anytls] 設定檔</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Sample/SingboxSampleClientConfig
+++ b/v2rayN/ServiceLib/Sample/SingboxSampleClientConfig
@@ -1,4 +1,4 @@
-﻿{
+{
 	"log": {
 		"level": "debug",
 		"timestamp": true
@@ -14,22 +14,10 @@
 		{
 			"type": "direct",
 			"tag": "direct"
-		},
-		{
-			"type": "block",
-			"tag": "block"
-		},
-		{
-			"tag": "dns_out",
-			"type": "dns"
 		}
 	],
 	"route": {
 		"rules": [
-			{
-				"protocol": [ "dns" ],
-				"outbound": "dns_out"
-			}
 		]
 	}
 }

--- a/v2rayN/ServiceLib/Sample/dns_singbox_normal
+++ b/v2rayN/ServiceLib/Sample/dns_singbox_normal
@@ -16,6 +16,13 @@
   ],
   "rules": [
     {
+      "domain_suffix": [
+        "googleapis.cn",
+        "gstatic.com"
+      ],
+      "server": "remote"
+    },
+    {
       "rule_set": [
         "geosite-cn"
       ],

--- a/v2rayN/ServiceLib/Sample/dns_singbox_normal
+++ b/v2rayN/ServiceLib/Sample/dns_singbox_normal
@@ -4,14 +4,12 @@
       "tag": "remote",
       "type": "tcp",
       "server": "8.8.8.8",
-      "strategy": "prefer_ipv4",
       "detour": "proxy"
     },
     {
       "tag": "local",
       "type": "udp",
-      "server": "223.5.5.5",
-      "strategy": "prefer_ipv4"
+      "server": "223.5.5.5"
     }
   ],
   "rules": [

--- a/v2rayN/ServiceLib/Sample/dns_singbox_normal
+++ b/v2rayN/ServiceLib/Sample/dns_singbox_normal
@@ -2,19 +2,16 @@
   "servers": [
     {
       "tag": "remote",
-      "address": "tcp://8.8.8.8",
+      "type": "tcp",
+      "server": "8.8.8.8",
       "strategy": "prefer_ipv4",
       "detour": "proxy"
     },
     {
       "tag": "local",
-      "address": "223.5.5.5",
-      "strategy": "prefer_ipv4",
-      "detour": "direct"
-    },
-    {
-      "tag": "block",
-      "address": "rcode://success"
+      "type": "udp",
+      "server": "223.5.5.5",
+      "strategy": "prefer_ipv4"
     }
   ],
   "rules": [

--- a/v2rayN/ServiceLib/Sample/dns_singbox_normal
+++ b/v2rayN/ServiceLib/Sample/dns_singbox_normal
@@ -18,14 +18,17 @@
         "googleapis.cn",
         "gstatic.com"
       ],
-      "server": "remote"
+      "server": "remote",
+      "strategy": "prefer_ipv4"
     },
     {
       "rule_set": [
         "geosite-cn"
       ],
-      "server": "local"
+      "server": "local",
+      "strategy": "prefer_ipv4"
     }
   ],
-  "final": "remote"
+  "final": "remote",
+  "strategy": "prefer_ipv4"
 }

--- a/v2rayN/ServiceLib/Sample/tun_singbox_dns
+++ b/v2rayN/ServiceLib/Sample/tun_singbox_dns
@@ -16,6 +16,13 @@
   ],
   "rules": [
     {
+      "domain_suffix": [
+        "googleapis.cn",
+        "gstatic.com"
+      ],
+      "server": "remote"
+    },
+    {
       "rule_set": [
         "geosite-cn",
         "geosite-geolocation-cn"

--- a/v2rayN/ServiceLib/Sample/tun_singbox_dns
+++ b/v2rayN/ServiceLib/Sample/tun_singbox_dns
@@ -4,14 +4,12 @@
       "tag": "remote",
       "type": "tcp",
       "server": "8.8.8.8",
-      "strategy": "prefer_ipv4",
       "detour": "proxy"
     },
     {
       "tag": "local",
       "type": "udp",
-      "server": "223.5.5.5",
-      "strategy": "prefer_ipv4"
+      "server": "223.5.5.5"
     }
   ],
   "rules": [

--- a/v2rayN/ServiceLib/Sample/tun_singbox_dns
+++ b/v2rayN/ServiceLib/Sample/tun_singbox_dns
@@ -2,19 +2,16 @@
   "servers": [
     {
       "tag": "remote",
-      "address": "tcp://8.8.8.8",
+      "type": "tcp",
+      "server": "8.8.8.8",
       "strategy": "prefer_ipv4",
       "detour": "proxy"
     },
     {
       "tag": "local",
-      "address": "223.5.5.5",
-      "strategy": "prefer_ipv4",
-      "detour": "direct"
-    },
-    {
-      "tag": "block",
-      "address": "rcode://success"
+      "type": "udp",
+      "server": "223.5.5.5",
+      "strategy": "prefer_ipv4"
     }
   ],
   "rules": [

--- a/v2rayN/ServiceLib/Sample/tun_singbox_dns
+++ b/v2rayN/ServiceLib/Sample/tun_singbox_dns
@@ -18,15 +18,18 @@
         "googleapis.cn",
         "gstatic.com"
       ],
-      "server": "remote"
+      "server": "remote",
+      "strategy": "prefer_ipv4"
     },
     {
       "rule_set": [
         "geosite-cn",
         "geosite-geolocation-cn"
       ],
-      "server": "local"
+      "server": "local",
+      "strategy": "prefer_ipv4"
     }
   ],
-  "final": "remote"
+  "final": "remote",
+  "strategy": "prefer_ipv4"
 }

--- a/v2rayN/ServiceLib/Sample/tun_singbox_rules
+++ b/v2rayN/ServiceLib/Sample/tun_singbox_rules
@@ -8,13 +8,13 @@
       139,
       5353
     ],
-    "outbound": "block"
+    "action": "reject"
   },
   {
     "ip_cidr": [
       "224.0.0.0/3",
       "ff00::/8"
     ],
-    "outbound": "block"
+    "action": "reject"
   }
 ]

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1320,46 +1320,36 @@ public class CoreConfigSingboxService
             localDnsType = "local";
             localDnsAddress = null;
         }
-        else if (localDnsAddress.StartsWith("dhcp"))
+        else if (localDnsAddress.StartsWith("dhcp") && localDnsAddress.Length > 7)
         {
             localDnsType = "dhcp";
-            //if (localDnsAddress.Length > 7) // dhcp://
-            //{
-            //    localDnsAddress = localDnsAddress.Substring(7);
-            //}
+            // // dhcp://
+            // dhcpDnsInterface = localDnsAddress.Substring(7);
             localDnsAddress = null;
         }
-        else if (localDnsAddress.StartsWith("tcp"))
+        else if (localDnsAddress.StartsWith("tcp") && localDnsAddress.Length > 6)
         {
             localDnsType = "tcp";
-            if (localDnsAddress.Length > 6) // tcp://
-            {
-                localDnsAddress = localDnsAddress.Substring(6);
-            }
+            // tcp://
+            localDnsAddress = localDnsAddress.Substring(6);
         }
-        else if (localDnsAddress.StartsWith("tls"))
+        else if (localDnsAddress.StartsWith("tls") && localDnsAddress.Length > 6)
         {
             localDnsType = "tls";
-            if (localDnsAddress.Length > 6) // tls://
-            {
-                localDnsAddress = localDnsAddress.Substring(6);
-            }
+            // tls://
+            localDnsAddress = localDnsAddress.Substring(6);
         }
-        else if (localDnsAddress.StartsWith("https"))
+        else if (localDnsAddress.StartsWith("https") && localDnsAddress.Length > 8)
         {
             localDnsType = "https";
-            if (localDnsAddress.Length > 8) // https://
-            {
-                localDnsAddress = localDnsAddress.Substring(8);
-            }
+            // https://
+            localDnsAddress = localDnsAddress.Substring(8);
         }
-        else if (localDnsAddress.StartsWith("quic"))
+        else if (localDnsAddress.StartsWith("quic") && localDnsAddress.Length > 7)
         {
             localDnsType = "quic";
-            if (localDnsAddress.Length > 7) // quic://
-            {
-                localDnsAddress = localDnsAddress.Substring(7);
-            }
+            // quic://
+            localDnsAddress = localDnsAddress.Substring(7);
         }
         else
         {

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -638,11 +638,11 @@ public class CoreConfigSingboxService
 
             if (Utils.IsDomain(node.Address))
             {
+                var item = await AppHandler.Instance.GetDNSItem(ECoreType.sing_box);
                 outbound.domain_resolver = new()
                 {
                     server = "local_local",
-                    // TODO
-                    //strategy = string.IsNullOrEmpty(dNSItem?.DomainStrategy4Freedom) ? null : dNSItem?.DomainStrategy4Freedom
+                    strategy = string.IsNullOrEmpty(item?.DomainStrategy4Freedom) ? null : item?.DomainStrategy4Freedom
                 };
             }
 

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -997,8 +997,7 @@ public class CoreConfigSingboxService
             {
                 singboxConfig.route.rules.Add(new()
                 {
-                    action = "sniff",
-                    sniffer = new() { "dns", _config.Inbound.First().DestOverride }
+                    action = "sniff"
                 });
                 singboxConfig.route.rules.Add(new()
                 {

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -853,6 +853,7 @@ public class CoreConfigSingboxService
                         };
                         endpoints.private_key = node.Id;
                         endpoints.mtu = node.ShortId.IsNullOrEmpty() ? Global.TunMtus.First() : node.ShortId.ToInt();
+                        endpoints.peers = new() { peer };
                         break;
                     }
             }
@@ -1088,6 +1089,7 @@ public class CoreConfigSingboxService
                     var nextEndpoint = JsonUtils.Deserialize<Endpoints4Sbox>(txtOutbound);
                     await GenEndpoint(nextNode, nextEndpoint);
                     nextEndpoint.tag = Global.ProxyTag;
+                    singboxConfig.endpoints ??= new();
                     singboxConfig.endpoints.Insert(0, nextEndpoint);
 
                     nextEndpoint.detour = tag;
@@ -1097,6 +1099,7 @@ public class CoreConfigSingboxService
                     var nextOutbound = JsonUtils.Deserialize<Outbound4Sbox>(txtOutbound);
                     await GenOutbound(nextNode, nextOutbound);
                     nextOutbound.tag = Global.ProxyTag;
+                    singboxConfig.outbounds ??= new();
                     singboxConfig.outbounds.Insert(0, nextOutbound);
 
                     nextOutbound.detour = tag;

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -825,7 +825,6 @@ public class CoreConfigSingboxService
         try
         {
             endpoints.address = Utils.String2List(node.RequestHost);
-            // Utils.GetFreePort() 9090 ?
             endpoints.listen_port = Utils.GetFreePort();
             endpoints.type = Global.ProtocolTypes[node.ConfigType];
 

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1518,8 +1518,7 @@ public class CoreConfigSingboxService
         dns4Sbox.rules.Insert(0, new()
         {
             server = tag,
-            clash_mode = ERuleMode.Direct.ToString(),
-            strategy = string.IsNullOrEmpty(dNSItem?.DomainStrategy4Freedom) ? null : dNSItem?.DomainStrategy4Freedom
+            clash_mode = ERuleMode.Direct.ToString()
         });
         dns4Sbox.rules.Insert(0, new()
         {

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -759,6 +759,11 @@ public class CoreConfigSingboxService
                         outbound.mtu = node.ShortId.IsNullOrEmpty() ? Global.TunMtus.First() : node.ShortId.ToInt();
                         break;
                     }
+                case EConfigType.Anytls:
+                    {
+                        outbound.password = node.Id;
+                        break;
+                    }
             }
 
             await GenOutboundTls(node, outbound);

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1242,24 +1242,28 @@ public class CoreConfigSingboxService
         {
             return false;
         }
-        else if (address.StartsWith("geoip:!"))
-        {
-            return false;
-        }
         else if (address.Equals("geoip:private"))
         {
             rule.ip_is_private = true;
         }
         else if (address.StartsWith("geoip:"))
         {
-            if (rule.geoip is null)
-            { rule.geoip = new(); }
+            rule.geoip ??= new();
             rule.geoip?.Add(address.Substring(6));
+        }
+        else if (address.Equals("geoip:!private"))
+        {
+            rule.ip_is_private = false;
+        }
+        else if (address.StartsWith("geoip:!"))
+        {
+            rule.geoip ??= new();
+            rule.geoip?.Add(address.Substring(6));
+            rule.invert = true;
         }
         else
         {
-            if (rule.ip_cidr is null)
-            { rule.ip_cidr = new(); }
+            rule.ip_cidr ??= new();
             rule.ip_cidr?.Add(address);
         }
         return true;

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1,6 +1,7 @@
 using System.Data;
 using System.Net;
 using System.Net.NetworkInformation;
+using DynamicData;
 
 namespace ServiceLib.Services.CoreConfig;
 
@@ -558,15 +559,6 @@ public class CoreConfigSingboxService
                 singboxConfig.inbounds.Add(inbound);
 
                 inbound.listen_port = AppHandler.Instance.GetLocalPort(EInboundProtocol.socks);
-                inbound.sniff = _config.Inbound.First().SniffingEnabled;
-                inbound.sniff_override_destination = _config.Inbound.First().RouteOnly ? false : _config.Inbound.First().SniffingEnabled;
-                inbound.domain_strategy = _config.RoutingBasicItem.DomainStrategy4Singbox.IsNullOrEmpty() ? null : _config.RoutingBasicItem.DomainStrategy4Singbox;
-
-                var routing = await ConfigHandler.GetDefaultRouting(_config);
-                if (routing.DomainStrategy4Singbox.IsNotEmpty())
-                {
-                    inbound.domain_strategy = routing.DomainStrategy4Singbox;
-                }
 
                 if (_config.Inbound.First().SecondLocalPortEnabled)
                 {
@@ -611,8 +603,6 @@ public class CoreConfigSingboxService
                 tunInbound.mtu = _config.TunModeItem.Mtu;
                 tunInbound.strict_route = _config.TunModeItem.StrictRoute;
                 tunInbound.stack = _config.TunModeItem.Stack;
-                tunInbound.sniff = _config.Inbound.First().SniffingEnabled;
-                //tunInbound.sniff_override_destination = _config.inbound.First().routeOnly ? false : _config.inbound.First().sniffingEnabled;
                 if (_config.TunModeItem.EnableIPv6Address == false)
                 {
                     tunInbound.address = ["172.18.0.1/30"];
@@ -978,8 +968,6 @@ public class CoreConfigSingboxService
     {
         try
         {
-            var dnsOutbound = "dns_out";
-
             if (_config.TunModeItem.EnableTun)
             {
                 singboxConfig.route.auto_detect_interface = true;
@@ -994,7 +982,7 @@ public class CoreConfigSingboxService
                 singboxConfig.route.rules.Add(new()
                 {
                     port = new() { 53 },
-                    outbound = dnsOutbound,
+                    action = "hijack-dns",
                     process_name = lstDnsExe
                 });
 
@@ -1005,13 +993,26 @@ public class CoreConfigSingboxService
                 });
             }
 
-            if (!_config.Inbound.First().SniffingEnabled)
+            if (_config.Inbound.First().SniffingEnabled)
             {
                 singboxConfig.route.rules.Add(new()
                 {
-                    port = [53],
-                    network = ["udp"],
-                    outbound = dnsOutbound
+                    action = "sniff",
+                    sniffer = new() { "dns", _config.Inbound.First().DestOverride }
+                });
+                singboxConfig.route.rules.Add(new()
+                {
+                    protocol = new() { "dns" },
+                    action = "hijack-dns"
+                });
+            }
+            else
+            {
+                singboxConfig.route.rules.Add(new()
+                {
+                    port = new() { 53 },
+                    network = new() { "udp" },
+                    action = "hijack-dns"
                 });
             }
 
@@ -1025,6 +1026,21 @@ public class CoreConfigSingboxService
                 outbound = Global.ProxyTag,
                 clash_mode = ERuleMode.Global.ToString()
             });
+
+            if (!(_config.Inbound.First().RouteOnly || _config.TunModeItem.EnableTun))
+            {
+                var domainStrategy = _config.RoutingBasicItem.DomainStrategy4Singbox.IsNullOrEmpty() ? null : _config.RoutingBasicItem.DomainStrategy4Singbox;
+                var defaultRouting = await ConfigHandler.GetDefaultRouting(_config);
+                if (defaultRouting.DomainStrategy4Singbox.IsNotEmpty())
+                {
+                    domainStrategy = defaultRouting.DomainStrategy4Singbox;
+                }
+                singboxConfig.route.rules.Add(new()
+                {
+                    action = "resolve",
+                    strategy = domainStrategy
+                });
+            }
 
             var routing = await ConfigHandler.GetDefaultRouting(_config);
             if (routing != null)
@@ -1081,10 +1097,15 @@ public class CoreConfigSingboxService
                 return 0;
             }
 
-            var rule = new Rule4Sbox()
+            var rule = new Rule4Sbox();
+            if (item.OutboundTag == "block")
             {
-                outbound = item.OutboundTag,
-            };
+                rule.action = "reject";
+            }
+            else
+            {
+                rule.outbound = item.OutboundTag;
+            }
 
             if (item.Port.IsNotEmpty())
             {

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1314,7 +1314,7 @@ public class CoreConfigSingboxService
         var tag = "local_local";
         var localDnsAddress = string.IsNullOrEmpty(dNSItem?.DomainDNSAddress) ? Global.SingboxDomainDNSAddress.FirstOrDefault() : dNSItem?.DomainDNSAddress;
         string? localDnsType = null;
-        //string? dhcpDnsInterface = null;
+        string? dhcpDnsInterface = null;
         if (localDnsAddress == "local")
         {
             localDnsType = "local";
@@ -1323,8 +1323,12 @@ public class CoreConfigSingboxService
         else if (localDnsAddress.StartsWith("dhcp") && localDnsAddress.Length > 7)
         {
             localDnsType = "dhcp";
-            // // dhcp://
-            // dhcpDnsInterface = localDnsAddress.Substring(7);
+            // dhcp://
+            dhcpDnsInterface = localDnsAddress.Substring(7);
+            if (dhcpDnsInterface == "auto")
+            {
+                dhcpDnsInterface = null;
+            }
             localDnsAddress = null;
         }
         else if (localDnsAddress.StartsWith("tcp") && localDnsAddress.Length > 6)
@@ -1360,7 +1364,8 @@ public class CoreConfigSingboxService
         {
             tag = tag,
             type = localDnsType,
-            server = localDnsAddress
+            server = localDnsAddress,
+            Interface = dhcpDnsInterface
         });
         dns4Sbox.rules.Insert(0, new()
         {

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1453,45 +1453,50 @@ public class CoreConfigSingboxService
         var localDnsAddress = string.IsNullOrEmpty(dNSItem?.DomainDNSAddress) ? Global.SingboxDomainDNSAddress.FirstOrDefault() : dNSItem?.DomainDNSAddress;
         string? localDnsType = null;
         string? dhcpDnsInterface = null;
+        var dnsProtocols = new List<string>
+        {
+            "dhcp",
+            "https",
+            "tcp",
+            "tls",
+            "quic",
+            "h3",
+            "udp"
+        };
         if (localDnsAddress == "local")
         {
             localDnsType = "local";
             localDnsAddress = null;
         }
-        else if (localDnsAddress.StartsWith("dhcp") && localDnsAddress.Length > 7)
+        else if (dnsProtocols.Any(protocol => localDnsAddress.StartsWith(protocol)))
         {
-            localDnsType = "dhcp";
-            // dhcp://
-            dhcpDnsInterface = localDnsAddress.Substring(7);
-            if (dhcpDnsInterface == "auto")
+            var protocol = dnsProtocols.First(p => localDnsAddress.StartsWith(p));
+            localDnsType = protocol;
+            // +3 for "://"
+            if (localDnsAddress.Length > protocol.Length + 3)
             {
-                dhcpDnsInterface = null;
+                localDnsAddress = localDnsAddress.Substring(protocol.Length + 3);
+                if (protocol == "dhcp")
+                {
+                    dhcpDnsInterface = localDnsAddress;
+                    if (dhcpDnsInterface == "auto")
+                    {
+                        dhcpDnsInterface = null;
+                    }
+                    localDnsAddress = null;
+                }
+                else if (protocol is "https" or "h3")
+                {
+                    if (localDnsAddress.Contains('/'))
+                    {
+                        localDnsAddress = localDnsAddress.Substring(0, localDnsAddress.IndexOf('/'));
+                    }
+                }
             }
-            localDnsAddress = null;
-        }
-        else if (localDnsAddress.StartsWith("tcp") && localDnsAddress.Length > 6)
-        {
-            localDnsType = "tcp";
-            // tcp://
-            localDnsAddress = localDnsAddress.Substring(6);
-        }
-        else if (localDnsAddress.StartsWith("tls") && localDnsAddress.Length > 6)
-        {
-            localDnsType = "tls";
-            // tls://
-            localDnsAddress = localDnsAddress.Substring(6);
-        }
-        else if (localDnsAddress.StartsWith("https") && localDnsAddress.Length > 8)
-        {
-            localDnsType = "https";
-            // https://
-            localDnsAddress = localDnsAddress.Substring(8);
-        }
-        else if (localDnsAddress.StartsWith("quic") && localDnsAddress.Length > 7)
-        {
-            localDnsType = "quic";
-            // quic://
-            localDnsAddress = localDnsAddress.Substring(7);
+            else
+            {
+                localDnsAddress = null;
+            }
         }
         else
         {

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -2,6 +2,7 @@ using System.Data;
 using System.Net;
 using System.Net.NetworkInformation;
 using DynamicData;
+using ServiceLib.Models;
 
 namespace ServiceLib.Services.CoreConfig;
 
@@ -634,6 +635,16 @@ public class CoreConfigSingboxService
             outbound.server = node.Address;
             outbound.server_port = node.Port;
             outbound.type = Global.ProtocolTypes[node.ConfigType];
+
+            if (Utils.IsDomain(node.Address))
+            {
+                outbound.domain_resolver = new()
+                {
+                    server = "local_local",
+                    // TODO
+                    //strategy = string.IsNullOrEmpty(dNSItem?.DomainStrategy4Freedom) ? null : dNSItem?.DomainStrategy4Freedom
+                };
+            }
 
             switch (node.ConfigType)
             {
@@ -1292,17 +1303,71 @@ public class CoreConfigSingboxService
         dns4Sbox.rules ??= [];
 
         var tag = "local_local";
+        var localDnsAddress = string.IsNullOrEmpty(dNSItem?.DomainDNSAddress) ? Global.SingboxDomainDNSAddress.FirstOrDefault() : dNSItem?.DomainDNSAddress;
+        string? localDnsType = null;
+        //string? dhcpDnsInterface = null;
+        if (localDnsAddress == "local")
+        {
+            localDnsType = "local";
+            localDnsAddress = null;
+        }
+        else if (localDnsAddress.StartsWith("dhcp"))
+        {
+            localDnsType = "dhcp";
+            //if (localDnsAddress.Length > 7) // dhcp://
+            //{
+            //    localDnsAddress = localDnsAddress.Substring(7);
+            //}
+            localDnsAddress = null;
+        }
+        else if (localDnsAddress.StartsWith("tcp"))
+        {
+            localDnsType = "tcp";
+            if (localDnsAddress.Length > 6) // tcp://
+            {
+                localDnsAddress = localDnsAddress.Substring(6);
+            }
+        }
+        else if (localDnsAddress.StartsWith("tls"))
+        {
+            localDnsType = "tls";
+            if (localDnsAddress.Length > 6) // tls://
+            {
+                localDnsAddress = localDnsAddress.Substring(6);
+            }
+        }
+        else if (localDnsAddress.StartsWith("https"))
+        {
+            localDnsType = "https";
+            if (localDnsAddress.Length > 8) // https://
+            {
+                localDnsAddress = localDnsAddress.Substring(8);
+            }
+        }
+        else if (localDnsAddress.StartsWith("quic"))
+        {
+            localDnsType = "quic";
+            if (localDnsAddress.Length > 7) // quic://
+            {
+                localDnsAddress = localDnsAddress.Substring(7);
+            }
+        }
+        else
+        {
+            localDnsType = "udp";
+        }
+
         dns4Sbox.servers.Add(new()
         {
             tag = tag,
-            address = string.IsNullOrEmpty(dNSItem?.DomainDNSAddress) ? Global.SingboxDomainDNSAddress.FirstOrDefault() : dNSItem?.DomainDNSAddress,
-            detour = Global.DirectTag,
-            strategy = string.IsNullOrEmpty(dNSItem?.DomainStrategy4Freedom) ? null : dNSItem?.DomainStrategy4Freedom,
+            type = localDnsType,
+            server = localDnsAddress
         });
         dns4Sbox.rules.Insert(0, new()
         {
             server = tag,
-            clash_mode = ERuleMode.Direct.ToString()
+            clash_mode = ERuleMode.Direct.ToString(),
+            strategy = string.IsNullOrEmpty(dNSItem?.DomainStrategy4Freedom) ? null : dNSItem?.DomainStrategy4Freedom
         });
         dns4Sbox.rules.Insert(0, new()
         {
@@ -1310,27 +1375,14 @@ public class CoreConfigSingboxService
             clash_mode = ERuleMode.Global.ToString()
         });
 
-        var lstDomain = singboxConfig.outbounds
-                       .Where(t => t.server.IsNotEmpty() && Utils.IsDomain(t.server))
-                       .Select(t => t.server)
-                       .Distinct()
-                       .ToList();
-        if (lstDomain != null && lstDomain.Count > 0)
-        {
-            dns4Sbox.rules.Insert(0, new()
-            {
-                server = tag,
-                domain = lstDomain
-            });
-        }
-
         //Tun2SocksAddress
         if (_config.TunModeItem.EnableTun && node?.ConfigType == EConfigType.SOCKS && Utils.IsDomain(node?.Sni))
         {
             dns4Sbox.rules.Insert(0, new()
             {
                 server = tag,
-                domain = [node?.Sni]
+                domain = [node?.Sni],
+                strategy = string.IsNullOrEmpty(dNSItem?.DomainStrategy4Freedom) ? null : dNSItem?.DomainStrategy4Freedom
             });
         }
 

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1118,6 +1118,8 @@ public class CoreConfigSingboxService
     {
         try
         {
+            singboxConfig.route.final = Global.ProxyTag;
+
             if (_config.TunModeItem.EnableTun)
             {
                 singboxConfig.route.auto_detect_interface = true;

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1456,65 +1456,19 @@ public class CoreConfigSingboxService
 
         var tag = "local_local";
         var localDnsAddress = string.IsNullOrEmpty(dNSItem?.DomainDNSAddress) ? Global.SingboxDomainDNSAddress.FirstOrDefault() : dNSItem?.DomainDNSAddress;
-        string? localDnsType = null;
-        string? dhcpDnsInterface = null;
-        var dnsProtocols = new List<string>
-        {
-            "dhcp",
-            "https",
-            "tcp",
-            "tls",
-            "quic",
-            "h3",
-            "udp"
-        };
-        if (localDnsAddress == "local")
-        {
-            localDnsType = "local";
-            localDnsAddress = null;
-        }
-        else if (dnsProtocols.Any(protocol => localDnsAddress.StartsWith(protocol)))
-        {
-            var protocol = dnsProtocols.First(p => localDnsAddress.StartsWith(p));
-            localDnsType = protocol;
-            // +3 for "://"
-            if (localDnsAddress.Length > protocol.Length + 3)
-            {
-                localDnsAddress = localDnsAddress.Substring(protocol.Length + 3);
-                if (protocol == "dhcp")
-                {
-                    dhcpDnsInterface = localDnsAddress;
-                    if (dhcpDnsInterface == "auto")
-                    {
-                        dhcpDnsInterface = null;
-                    }
-                    localDnsAddress = null;
-                }
-                else if (protocol is "https" or "h3")
-                {
-                    if (localDnsAddress.Contains('/'))
-                    {
-                        localDnsAddress = localDnsAddress.Substring(0, localDnsAddress.IndexOf('/'));
-                    }
-                }
-            }
-            else
-            {
-                localDnsAddress = null;
-            }
-        }
-        else
-        {
-            localDnsType = "udp";
-        }
+
+        var (dnsType, dnsHost, dnsPort, dnsPath) = ParseDnsAddress(localDnsAddress);
 
         dns4Sbox.servers.Add(new()
         {
             tag = tag,
-            type = localDnsType,
-            server = localDnsAddress,
-            Interface = dhcpDnsInterface
+            type = dnsType,
+            server = dnsHost,
+            Interface = dnsType == "dhcp" ? dnsHost : null,
+            server_port = dnsPort,
+            path = dnsPath
         });
+
         dns4Sbox.rules.Insert(0, new()
         {
             server = tag,
@@ -1592,6 +1546,91 @@ public class CoreConfigSingboxService
 
         singboxConfig.dns = dns4Sbox;
         return await Task.FromResult(0);
+    }
+
+    private (string type, string? host, int? port, string? path) ParseDnsAddress(string address)
+    {
+        string type = "udp";
+        string? host = null;
+        int? port = null;
+        string? path = null;
+
+        if (address is "local" or "localhost")
+        {
+            return ("local", null, null, null);
+        }
+
+        if (address.StartsWith("dhcp://", StringComparison.OrdinalIgnoreCase))
+        {
+            string interface_name = address.Substring(7);
+            return ("dhcp", interface_name == "auto" ? null : interface_name, null, null);
+        }
+
+        if (!address.Contains("://"))
+        {
+            // udp dns
+            host = address;
+            return (type, host, port, path);
+        }
+
+        try
+        {
+            int protocolEndIndex = address.IndexOf("://", StringComparison.Ordinal);
+            type = address.Substring(0, protocolEndIndex).ToLower();
+
+            var uri = new Uri(address);
+            host = uri.Host;
+
+            if (!uri.IsDefaultPort)
+            {
+                port = uri.Port;
+            }
+
+            if ((type == "https" || type == "h3") && !string.IsNullOrEmpty(uri.AbsolutePath) && uri.AbsolutePath != "/")
+            {
+                path = uri.AbsolutePath;
+            }
+        }
+        catch (UriFormatException)
+        {
+            int protocolEndIndex = address.IndexOf("://", StringComparison.Ordinal);
+            if (protocolEndIndex > 0)
+            {
+                type = address.Substring(0, protocolEndIndex).ToLower();
+                string remaining = address.Substring(protocolEndIndex + 3);
+
+                int portIndex = remaining.IndexOf(':');
+                int pathIndex = remaining.IndexOf('/');
+
+                if (portIndex > 0)
+                {
+                    host = remaining.Substring(0, portIndex);
+                    string portPart = pathIndex > portIndex
+                        ? remaining.Substring(portIndex + 1, pathIndex - portIndex - 1)
+                        : remaining.Substring(portIndex + 1);
+
+                    if (int.TryParse(portPart, out int parsedPort))
+                    {
+                        port = parsedPort;
+                    }
+                }
+                else if (pathIndex > 0)
+                {
+                    host = remaining.Substring(0, pathIndex);
+                }
+                else
+                {
+                    host = remaining;
+                }
+
+                if (pathIndex > 0 && (type == "https" || type == "h3"))
+                {
+                    path = remaining.Substring(pathIndex);
+                }
+            }
+        }
+
+        return (type, host, port, path);
     }
 
     private async Task<int> GenExperimental(SingboxConfig singboxConfig)

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigV2rayService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigV2rayService.cs
@@ -1323,7 +1323,8 @@ public class CoreConfigV2rayService
             if (prevNode is not null
                 && prevNode.ConfigType != EConfigType.Custom
                 && prevNode.ConfigType != EConfigType.Hysteria2
-                && prevNode.ConfigType != EConfigType.TUIC)
+                && prevNode.ConfigType != EConfigType.TUIC
+                && prevNode.ConfigType != EConfigType.Anytls)
             {
                 var prevOutbound = JsonUtils.Deserialize<Outbounds4Ray>(txtOutbound);
                 await GenOutbound(prevNode, prevOutbound);
@@ -1341,7 +1342,8 @@ public class CoreConfigV2rayService
             if (nextNode is not null
                 && nextNode.ConfigType != EConfigType.Custom
                 && nextNode.ConfigType != EConfigType.Hysteria2
-                && nextNode.ConfigType != EConfigType.TUIC)
+                && nextNode.ConfigType != EConfigType.TUIC
+                && prevNode.ConfigType != EConfigType.Anytls)
             {
                 var nextOutbound = JsonUtils.Deserialize<Outbounds4Ray>(txtOutbound);
                 await GenOutbound(nextNode, nextOutbound);

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigV2rayService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigV2rayService.cs
@@ -1343,7 +1343,7 @@ public class CoreConfigV2rayService
                 && nextNode.ConfigType != EConfigType.Custom
                 && nextNode.ConfigType != EConfigType.Hysteria2
                 && nextNode.ConfigType != EConfigType.TUIC
-                && prevNode.ConfigType != EConfigType.Anytls)
+                && nextNode.ConfigType != EConfigType.Anytls)
             {
                 var nextOutbound = JsonUtils.Deserialize<Outbounds4Ray>(txtOutbound);
                 await GenOutbound(nextNode, nextOutbound);

--- a/v2rayN/ServiceLib/Services/SpeedtestService.cs
+++ b/v2rayN/ServiceLib/Services/SpeedtestService.cs
@@ -357,8 +357,8 @@ public class SpeedtestService
     private List<List<ServerTestItem>> GetTestBatchItem(List<ServerTestItem> lstSelected, int pageSize)
     {
         List<List<ServerTestItem>> lstTest = new();
-        var lst1 = lstSelected.Where(t => t.ConfigType is not (EConfigType.Hysteria2 or EConfigType.TUIC)).ToList();
-        var lst2 = lstSelected.Where(t => t.ConfigType is EConfigType.Hysteria2 or EConfigType.TUIC).ToList();
+        var lst1 = lstSelected.Where(t => t.ConfigType is not (EConfigType.Hysteria2 or EConfigType.TUIC or EConfigType.Anytls)).ToList();
+        var lst2 = lstSelected.Where(t => t.ConfigType is EConfigType.Hysteria2 or EConfigType.TUIC or EConfigType.Anytls).ToList();
 
         for (var num = 0; num < (int)Math.Ceiling(lst1.Count * 1.0 / pageSize); num++)
         {

--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -20,6 +20,7 @@ public class MainWindowViewModel : MyReactiveObject
     public ReactiveCommand<Unit, Unit> AddHysteria2ServerCmd { get; }
     public ReactiveCommand<Unit, Unit> AddTuicServerCmd { get; }
     public ReactiveCommand<Unit, Unit> AddWireguardServerCmd { get; }
+    public ReactiveCommand<Unit, Unit> AddAnytlsServerCmd { get; }
     public ReactiveCommand<Unit, Unit> AddCustomServerCmd { get; }
     public ReactiveCommand<Unit, Unit> AddServerViaClipboardCmd { get; }
     public ReactiveCommand<Unit, Unit> AddServerViaScanCmd { get; }
@@ -110,6 +111,10 @@ public class MainWindowViewModel : MyReactiveObject
         AddWireguardServerCmd = ReactiveCommand.CreateFromTask(async () =>
         {
             await AddServerAsync(true, EConfigType.WireGuard);
+        });
+        AddAnytlsServerCmd = ReactiveCommand.CreateFromTask(async () =>
+        {
+            await AddServerAsync(true, EConfigType.Anytls);
         });
         AddCustomServerCmd = ReactiveCommand.CreateFromTask(async () =>
         {

--- a/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml
@@ -481,6 +481,26 @@
                         HorizontalAlignment="Left"
                         Watermark="1500" />
                 </Grid>
+                <Grid
+                    x:Name="gridAnytls"
+                    Grid.Row="2"
+                    ColumnDefinitions="180,Auto"
+                    IsVisible="False"
+                    RowDefinitions="Auto,Auto,Auto">
+
+                    <TextBlock
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        Margin="{StaticResource Margin4}"
+                        VerticalAlignment="Center"
+                        Text="{x:Static resx:ResUI.TbId3}" />
+                    <TextBox
+                        x:Name="txtId10"
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        Width="400"
+                        Margin="{StaticResource Margin4}" />
+                </Grid>
 
                 <Separator
                     x:Name="sepa2"

--- a/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml.cs
@@ -133,6 +133,11 @@ public partial class AddServerWindow : ReactiveWindow<AddServerViewModel>
                 gridTls.IsVisible = false;
 
                 break;
+
+            case EConfigType.Anytls:
+                gridAnytls.IsVisible = true;
+                cmbCoreType.IsEnabled = false;
+                break;
         }
 
         gridTlsMore.IsVisible = false;
@@ -192,6 +197,10 @@ public partial class AddServerWindow : ReactiveWindow<AddServerViewModel>
                     this.Bind(ViewModel, vm => vm.SelectedSource.Path, v => v.txtPath9.Text).DisposeWith(disposables);
                     this.Bind(ViewModel, vm => vm.SelectedSource.RequestHost, v => v.txtRequestHost9.Text).DisposeWith(disposables);
                     this.Bind(ViewModel, vm => vm.SelectedSource.ShortId, v => v.txtShortId9.Text).DisposeWith(disposables);
+                    break;
+
+                case EConfigType.Anytls:
+                    this.Bind(ViewModel, vm => vm.SelectedSource.Id, v => v.txtId10.Text).DisposeWith(disposables);
                     break;
             }
             this.Bind(ViewModel, vm => vm.SelectedSource.Network, v => v.cmbNetwork.SelectedValue).DisposeWith(disposables);

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml
@@ -46,6 +46,7 @@
                         <Separator />
                         <MenuItem x:Name="menuAddHysteria2Server" Header="{x:Static resx:ResUI.menuAddHysteria2Server}" />
                         <MenuItem x:Name="menuAddTuicServer" Header="{x:Static resx:ResUI.menuAddTuicServer}" />
+                        <MenuItem x:Name="menuAddAnytlsServer" Header="{x:Static resx:ResUI.menuAddAnytlsServer}" />
                     </MenuItem>
 
                     <MenuItem Padding="8,0">

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
@@ -83,6 +83,7 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
             this.BindCommand(ViewModel, vm => vm.AddHysteria2ServerCmd, v => v.menuAddHysteria2Server).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddTuicServerCmd, v => v.menuAddTuicServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddWireguardServerCmd, v => v.menuAddWireguardServer).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.AddAnytlsServerCmd, v => v.menuAddAnytlsServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddCustomServerCmd, v => v.menuAddCustomServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddServerViaClipboardCmd, v => v.menuAddServerViaClipboard).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddServerViaScanCmd, v => v.menuAddServerViaScan).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/AddServerWindow.xaml
+++ b/v2rayN/v2rayN/Views/AddServerWindow.xaml
@@ -646,6 +646,35 @@
                         materialDesign:HintAssist.Hint="1500"
                         Style="{StaticResource DefTextBox}" />
                 </Grid>
+                <Grid
+                    x:Name="gridAnytls"
+                    Grid.Row="2"
+                    Visibility="Hidden">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="180" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        Margin="{StaticResource Margin4}"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource ToolbarTextBlock}"
+                        Text="{x:Static resx:ResUI.TbId3}" />
+                    <TextBox
+                        x:Name="txtId10"
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        Width="400"
+                        Margin="{StaticResource Margin4}"
+                        Style="{StaticResource DefTextBox}" />
+                </Grid>
 
                 <Separator
                     x:Name="sepa2"

--- a/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
@@ -127,6 +127,10 @@ public partial class AddServerWindow
                 gridTls.Visibility = Visibility.Collapsed;
 
                 break;
+            case EConfigType.Anytls:
+                gridAnytls.Visibility = Visibility.Visible;
+                cmbCoreType.IsEnabled = false;
+                break;
         }
 
         gridTlsMore.Visibility = Visibility.Hidden;
@@ -186,6 +190,10 @@ public partial class AddServerWindow
                     this.Bind(ViewModel, vm => vm.SelectedSource.Path, v => v.txtPath9.Text).DisposeWith(disposables);
                     this.Bind(ViewModel, vm => vm.SelectedSource.RequestHost, v => v.txtRequestHost9.Text).DisposeWith(disposables);
                     this.Bind(ViewModel, vm => vm.SelectedSource.ShortId, v => v.txtShortId9.Text).DisposeWith(disposables);
+                    break;
+
+                case EConfigType.Anytls:
+                    this.Bind(ViewModel, vm => vm.SelectedSource.Id, v => v.txtId10.Text).DisposeWith(disposables);
                     break;
             }
             this.Bind(ViewModel, vm => vm.SelectedSource.Network, v => v.cmbNetwork.Text).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/MainWindow.xaml
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml
@@ -107,6 +107,10 @@
                                     x:Name="menuAddTuicServer"
                                     Height="{StaticResource MenuItemHeight}"
                                     Header="{x:Static resx:ResUI.menuAddTuicServer}" />
+                                <MenuItem
+                                    x:Name="menuAddAnytlsServer"
+                                    Height="{StaticResource MenuItemHeight}"
+                                    Header="{x:Static resx:ResUI.menuAddAnytlsServer}" />
                             </MenuItem>
                         </Menu>
                         <Separator />

--- a/v2rayN/v2rayN/Views/MainWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml.cs
@@ -80,6 +80,7 @@ public partial class MainWindow
             this.BindCommand(ViewModel, vm => vm.AddHysteria2ServerCmd, v => v.menuAddHysteria2Server).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddTuicServerCmd, v => v.menuAddTuicServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddWireguardServerCmd, v => v.menuAddWireguardServer).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.AddAnytlsServerCmd, v => v.menuAddAnytlsServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddCustomServerCmd, v => v.menuAddCustomServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddServerViaClipboardCmd, v => v.menuAddServerViaClipboard).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddServerViaScanCmd, v => v.menuAddServerViaScan).DisposeWith(disposables);


### PR DESCRIPTION
- [ ] ["action": "resolve"](https://sing-box.sagernet.org/configuration/route/rule_action/#resolve) 需要确认是否适配
- [ ] 当配置 route.default_domain_resolver 或 direct outbound domain_resolver 的行为是否适配；目前是为含有域名的 proxy outbound 配置 domain_resolver
- [x] endpoints wireguard 支持
- [x] sniff 迁移到路由规则
- [x] dns 默认配置迁移为 1.12 版本
  - [x] 同时兼容旧版写法
  - [x] 添加 Google cn 走远程 dns
  - [x] 可将 `Outbound 域名解析地址` 转换为新版写法
- [x] anytls 支持