### PR TITLE
Improve default DNS

### DIFF
--- a/v2rayN/ServiceLib/Sample/dns_v2ray_normal
+++ b/v2rayN/ServiceLib/Sample/dns_v2ray_normal
@@ -5,7 +5,7 @@
   },
   "servers": [
     {
-      "address": "https://1.1.1.1/dns-query",
+      "address": "1.1.1.1",
       "domains": [
         "geosite:geolocation-!cn"
       ],
@@ -14,7 +14,7 @@
       ]
     },
     {
-      "address": "https://dns.google/dns-query",
+      "address": "8.8.8.8",
       "domains": [
         "geosite:geolocation-!cn"
       ],
@@ -32,6 +32,7 @@
         "geoip:cn"
       ]
     },
+    "https://1.1.1.1/dns-query",
     "https://dns.google/dns-query"
   ]
 }

--- a/v2rayN/ServiceLib/Sample/dns_v2ray_normal
+++ b/v2rayN/ServiceLib/Sample/dns_v2ray_normal
@@ -5,7 +5,16 @@
   },
   "servers": [
     {
-      "address": "1.1.1.1",
+      "address": "tcp://1.1.1.1",
+      "domains": [
+        "geosite:geolocation-!cn"
+      ],
+      "expectIPs": [
+        "geoip:!cn"
+      ]
+    },
+    {
+      "address": "tcp://8.8.8.8"",
       "domains": [
         "geosite:geolocation-!cn"
       ],
@@ -23,7 +32,6 @@
         "geoip:cn"
       ]
     },
-    "8.8.8.8",
     "https://dns.google/dns-query"
   ]
 }

--- a/v2rayN/ServiceLib/Sample/dns_v2ray_normal
+++ b/v2rayN/ServiceLib/Sample/dns_v2ray_normal
@@ -5,7 +5,7 @@
   },
   "servers": [
     {
-      "address": "tcp://1.1.1.1",
+      "address": "https://1.1.1.1/dns-query",
       "domains": [
         "geosite:geolocation-!cn"
       ],
@@ -14,7 +14,7 @@
       ]
     },
     {
-      "address": "tcp://8.8.8.8"",
+      "address": "https://dns.google/dns-query",
       "domains": [
         "geosite:geolocation-!cn"
       ],


### PR DESCRIPTION
~~Remote proxy server may not support UDP relay,
use TCP to make DNS via proxy;
It is also possible to set up a backup DNS.~~

**Testing found that many public DNS Servers have serious problems with DNS over TCP.
Decided not to change the DNS and simply add backup DNS.**

Mainland DNS usually chooses Direct Outbound,
Consider whether to use the following instead to reduce latency? (bypass Routing)

```JSON
    {
      "address": "tcp+local://223.5.5.5",
      "skipFallback": true,
      "domains": [
        "geosite:cn"
      ],
      "expectIPs": [
        "geoip:cn"
      ]
    }
```
