### PR TITLE
Fix Tab Navigation in ToolBar for v2rayN

### DIFF
--- a/v2rayN/v2rayN/Views/MainWindow.xaml
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml
@@ -40,7 +40,8 @@
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
                         ClipToBounds="True"
-                        Style="{StaticResource MaterialDesignToolBar}">
+                        Style="{StaticResource MaterialDesignToolBar}"
+                        KeyboardNavigation.TabNavigation="Continue">
                         <Menu Margin="0,1" Style="{StaticResource ToolbarMenu}">
                             <MenuItem Padding="8,0"
                                 AutomationProperties.Name="{x:Static resx:ResUI.menuServers}">


### PR DESCRIPTION
### Description
This Pull Request fixes an issue with Tab navigation in the `v2rayN` application, where the focus was previously trapped within the toolbar and could not move to other UI sections.

#### Changes:
- Added `KeyboardNavigation.TabNavigation="Continue"` to the `ToolBar` in `MainWindow.xaml`, allowing focus to move from the toolbar to other sections like `StatusBarView`.

#### Impact:
- Improves keyboard navigation by ensuring users can seamlessly move focus between the toolbar and other UI elements using the Tab key.

#### Related Commits:
- `Fix Tab navigation in ToolBar by setting KeyboardNavigation to Continue`

#### Notes:
- Tested to confirm that Tab navigation now works as expected across the UI.