### PR TITLE
Fix DNS

### DIFF
--- a/v2rayN/ServiceLib/Sample/dns_v2ray_normal
+++ b/v2rayN/ServiceLib/Sample/dns_v2ray_normal
@@ -6,8 +6,10 @@
   "servers": [
     {
       "address": "1.1.1.1",
+      "skipFallback": true,
       "domains": [
-        "geosite:geolocation-!cn"
+        "domain:googleapis.cn",
+        "domain:gstatic.com"
       ],
       "expectIPs": [
         "geoip:!cn"
@@ -23,6 +25,7 @@
         "geoip:cn"
       ]
     },
+    "1.1.1.1",
     "8.8.8.8",
     "https://dns.google/dns-query"
   ]

--- a/v2rayN/ServiceLib/Sample/dns_v2ray_normal
+++ b/v2rayN/ServiceLib/Sample/dns_v2ray_normal
@@ -10,9 +10,6 @@
       "domains": [
         "domain:googleapis.cn",
         "domain:gstatic.com"
-      ],
-      "expectIPs": [
-        "geoip:!cn"
       ]
     },
     {


### PR DESCRIPTION
修复 https://github.com/2dust/v2rayN/pull/7227#issuecomment-2848487787 ，当 Outbound Freedom domainStrategy 为 UseIP 时，部分域名因为被 `geosite:geolocation-!cn` 和 `geosite:cn` 同时包含，导致 freedom 直连到国外 IP。比如 `dl.google.com` 等 Google CN 域名。

---

修复后： 

当 dns 查询域名在 `geosite:cn` 时，查询顺序为： `223.5.5.5` -> `1.1.1.1` -> `8.8.8.8` -> `https://dns.google/dns-query`

当 dns 查询域名不在 `geosite:cn` 时，查询顺序为：`1.1.1.1` -> `8.8.8.8` -> `https://dns.google/dns-query`

当 dns 查询域名为 `domain:gstatic.com` 时，查询顺序为：`1.1.1.1 ("skipFallback": true)` -> `1.1.1.1` -> `8.8.8.8` -> `https://dns.google/dns-query`

`1.1.1.1` 的 `"skipFallback": true` 是为了防止不在 `geosite:cn` 的域名多次查询到 `1.1.1.1`