### PR TITLE
docs: fix an incorrect link and improve README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # v2rayN
-A GUI client for Windows, Linux and macOS, support [Xray](https://github.com/XTLS/Xray-core) and [sing-box](https://github.com/SagerNet/sing-box/releases) and [others](https://github.com/2dust/v2rayN/wiki/List-of-supported-cores)
 
+A GUI client for Windows, Linux and macOS, support [Xray](https://github.com/XTLS/Xray-core)
+and [sing-box](https://github.com/SagerNet/sing-box)
+and [others](https://github.com/2dust/v2rayN/wiki/List-of-supported-cores)
 
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/2dust/v2rayN)](https://github.com/2dust/v2rayN/commits/master)
 [![CodeFactor](https://www.codefactor.io/repository/github/2dust/v2rayn/badge)](https://www.codefactor.io/repository/github/2dust/v2rayn)
 [![GitHub Releases](https://img.shields.io/github/downloads/2dust/v2rayN/latest/total?logo=github)](https://github.com/2dust/v2rayN/releases)
 [![Chat on Telegram](https://img.shields.io/badge/Chat%20on-Telegram-brightgreen.svg)](https://t.me/v2rayn)
 
-
 ## How to use
 
 Read the [Wiki](https://github.com/2dust/v2rayN/wiki) for details.
 
 ## Telegram Channel
+
 [github_2dust](https://t.me/github_2dust)


### PR DESCRIPTION
### Motivation
One existing link pointed to the releases page instead of the project homepage.

### Changes
* Split long description line for readability  
* Added consistent blank lines between sections  
* Fixed link to sing-box (now points to main repo)  
* Removed trailing blank lines

### Verification
* Rendered Markdown preview in PyCharm — layout looks correct  
* Click-tested all links

_These changes are documentation-only._
