### PR TITLE
Fix Observatory

### DIFF
--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigV2rayService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigV2rayService.cs
@@ -1366,16 +1366,31 @@ public class CoreConfigV2rayService
 
     private async Task<int> GenBalancer(V2rayConfig v2rayConfig, EMultipleLoad multipleLoad)
     {
-        if (multipleLoad is EMultipleLoad.LeastLoad or EMultipleLoad.LeastPing)
+        if (multipleLoad == EMultipleLoad.LeastPing)
         {
             var observatory = new Observatory4Ray
             {
                 subjectSelector = [Global.ProxyTag],
                 probeUrl = AppHandler.Instance.Config.SpeedTestItem.SpeedPingTestUrl,
                 probeInterval = "3m",
-                enableConcurrency = true
+                enableConcurrency = true,
             };
             v2rayConfig.observatory = observatory;
+        }
+        else if (multipleLoad == EMultipleLoad.LeastLoad)
+        {
+            var burstObservatory = new BurstObservatory4Ray
+            {
+                subjectSelector = [Global.ProxyTag],
+                pingConfig = new()
+                {
+                    destination = AppHandler.Instance.Config.SpeedTestItem.SpeedPingTestUrl,
+                    interval = "5m",
+                    timeout = "30s",
+                    sampling = 2,
+                }
+            };
+            v2rayConfig.burstObservatory = burstObservatory;
         }
         var strategyType = multipleLoad switch
         {

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigV2rayService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigV2rayService.cs
@@ -1372,7 +1372,8 @@ public class CoreConfigV2rayService
             {
                 subjectSelector = [Global.ProxyTag],
                 probeUrl = AppHandler.Instance.Config.SpeedTestItem.SpeedPingTestUrl,
-                probeInterval = "3m"
+                probeInterval = "3m",
+                enableConcurrency = true
             };
             v2rayConfig.observatory = observatory;
         }


### PR DESCRIPTION
1. LeastPing 并发探测，全部完成后暂停 3m
2. LeastLoad 配置 burstObservatory 用于测定每个出站之间的 rtt 值，固定并发检测，每个出站测3次，全部完成后暂停 5m (https://github.com/2dust/v2rayN/issues/7358#issuecomment-2973443035)