### PR TITLE
Migrate to sing-box 1.12 support

### DIFF
--- a/v2rayN/ServiceLib/Common/Utils.cs
+++ b/v2rayN/ServiceLib/Common/Utils.cs
@@ -466,11 +466,11 @@ public class Utils
         return false;
     }
 
-    public static int GetFreePort(int defaultPort = 9090)
+    public static int GetFreePort(int defaultPort = 0)
     {
         try
         {
-            if (!Utils.PortInUse(defaultPort))
+            if (!(defaultPort == 0 || Utils.PortInUse(defaultPort)))
             {
                 return defaultPort;
             }

--- a/v2rayN/ServiceLib/Enums/EConfigType.cs
+++ b/v2rayN/ServiceLib/Enums/EConfigType.cs
@@ -11,5 +11,6 @@ public enum EConfigType
     Hysteria2 = 7,
     TUIC = 8,
     WireGuard = 9,
-    HTTP = 10
+    HTTP = 10,
+    Anytls = 11
 }

--- a/v2rayN/ServiceLib/Global.cs
+++ b/v2rayN/ServiceLib/Global.cs
@@ -169,7 +169,8 @@ public class Global
             { EConfigType.Trojan, "trojan://" },
             { EConfigType.Hysteria2, "hysteria2://" },
             { EConfigType.TUIC, "tuic://" },
-            { EConfigType.WireGuard, "wireguard://" }
+            { EConfigType.WireGuard, "wireguard://" },
+            { EConfigType.Anytls, "anytls://" }
         };
 
     public static readonly Dictionary<EConfigType, string> ProtocolTypes = new()
@@ -182,7 +183,8 @@ public class Global
             { EConfigType.Trojan, "trojan" },
             { EConfigType.Hysteria2, "hysteria2" },
             { EConfigType.TUIC, "tuic" },
-            { EConfigType.WireGuard, "wireguard" }
+            { EConfigType.WireGuard, "wireguard" },
+            { EConfigType.Anytls, "anytls" }
         };
 
     public static readonly List<string> VmessSecurities =

--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -262,6 +262,7 @@ public class ConfigHandler
             EConfigType.Hysteria2 => await AddHysteria2Server(config, item),
             EConfigType.TUIC => await AddTuicServer(config, item),
             EConfigType.WireGuard => await AddWireguardServer(config, item),
+            EConfigType.Anytls => await AddAnytlsServer(config, item),
             _ => -1,
         };
         return ret;
@@ -787,6 +788,35 @@ public class ConfigHandler
     }
 
     /// <summary>
+    /// Add or edit a Anytls server
+    /// Validates and processes Anytls-specific settings
+    /// </summary>
+    /// <param name="config">Current configuration</param>
+    /// <param name="profileItem">Anytls profile to add</param>
+    /// <param name="toFile">Whether to save to file</param>
+    /// <returns>0 if successful, -1 if failed</returns>
+    public static async Task<int> AddAnytlsServer(Config config, ProfileItem profileItem, bool toFile = true)
+    {
+        profileItem.ConfigType = EConfigType.Anytls;
+        profileItem.CoreType = ECoreType.sing_box;
+
+        profileItem.Address = profileItem.Address.TrimEx();
+        profileItem.Id = profileItem.Id.TrimEx();
+        profileItem.Security = profileItem.Security.TrimEx();
+        profileItem.Network = string.Empty;
+        if (profileItem.StreamSecurity.IsNullOrEmpty())
+        {
+            profileItem.StreamSecurity = Global.StreamSecurity;
+        }
+        if (profileItem.Id.IsNullOrEmpty())
+        {
+            return -1;
+        }
+        await AddServerCommon(config, profileItem, toFile);
+        return 0;
+    }
+
+    /// <summary>
     /// Sort the server list by the specified column
     /// Updates the sort order in the profile extension data
     /// </summary>
@@ -1295,6 +1325,7 @@ public class ConfigHandler
                 EConfigType.Hysteria2 => await AddHysteria2Server(config, profileItem, false),
                 EConfigType.TUIC => await AddTuicServer(config, profileItem, false),
                 EConfigType.WireGuard => await AddWireguardServer(config, profileItem, false),
+                EConfigType.Anytls => await AddAnytlsServer(config, profileItem, false),
                 _ => -1,
             };
 

--- a/v2rayN/ServiceLib/Handler/CoreHandler.cs
+++ b/v2rayN/ServiceLib/Handler/CoreHandler.cs
@@ -101,7 +101,7 @@ public class CoreHandler
 
     public async Task<int> LoadCoreConfigSpeedtest(List<ServerTestItem> selecteds)
     {
-        var coreType = selecteds.Exists(t => t.ConfigType is EConfigType.Hysteria2 or EConfigType.TUIC) ? ECoreType.sing_box : ECoreType.Xray;
+        var coreType = selecteds.Exists(t => t.ConfigType is EConfigType.Hysteria2 or EConfigType.TUIC or EConfigType.Anytls) ? ECoreType.sing_box : ECoreType.Xray;
         var fileName = string.Format(Global.CoreSpeedtestConfigFileName, Utils.GetGuid(false));
         var configPath = Utils.GetBinConfigPath(fileName);
         var result = await CoreConfigHandler.GenerateClientSpeedtestConfig(_config, configPath, selecteds, coreType);

--- a/v2rayN/ServiceLib/Handler/CoreHandler.cs
+++ b/v2rayN/ServiceLib/Handler/CoreHandler.cs
@@ -25,8 +25,6 @@ public class CoreHandler
         Environment.SetEnvironmentVariable(Global.V2RayLocalAsset, Utils.GetBinPath(""), EnvironmentVariableTarget.Process);
         Environment.SetEnvironmentVariable(Global.XrayLocalAsset, Utils.GetBinPath(""), EnvironmentVariableTarget.Process);
         Environment.SetEnvironmentVariable(Global.XrayLocalCert, Utils.GetBinPath(""), EnvironmentVariableTarget.Process);
-        // TODO Temporary addition to support proper use of sing-box v1.12
-        Environment.SetEnvironmentVariable("ENABLE_DEPRECATED_SPECIAL_OUTBOUNDS", "true", EnvironmentVariableTarget.Process);
 
         //Copy the bin folder to the storage location (for init)
         if (Environment.GetEnvironmentVariable(Global.LocalAppData) == "1")

--- a/v2rayN/ServiceLib/Handler/Fmt/AnytlsFmt.cs
+++ b/v2rayN/ServiceLib/Handler/Fmt/AnytlsFmt.cs
@@ -1,0 +1,54 @@
+using static QRCoder.PayloadGenerator;
+
+namespace ServiceLib.Handler.Fmt;
+public class AnytlsFmt : BaseFmt
+{
+    public static ProfileItem? Resolve(string str, out string msg)
+    {
+        msg = ResUI.ConfigurationFormatIncorrect;
+
+        var parsedUrl = Utils.TryUri(str);
+        if (parsedUrl == null)
+        {
+            return null;
+        }
+
+        ProfileItem item = new()
+        {
+            ConfigType = EConfigType.Anytls,
+            Remarks = parsedUrl.GetComponents(UriComponents.Fragment, UriFormat.Unescaped),
+            Address = parsedUrl.IdnHost,
+            Port = parsedUrl.Port,
+        };
+        var rawUserInfo = Utils.UrlDecode(parsedUrl.UserInfo);
+        item.Id = rawUserInfo;
+
+        var query = Utils.ParseQueryString(parsedUrl.Query);
+        item.Sni = query["sni"] ?? Global.None;
+        item.AllowInsecure = (query["insecure"] ?? "") == "1" ? "true" : "false";
+
+        return item;
+    }
+
+    public static string? ToUri(ProfileItem? item)
+    {
+        if (item == null)
+        {
+            return null;
+        }
+        var remark = string.Empty;
+        if (item.Remarks.IsNotEmpty())
+        {
+            remark = "#" + Utils.UrlEncode(item.Remarks);
+        }
+        var pw = item.Id;
+        var dicQuery = new Dictionary<string, string>();
+        if (item.Sni.IsNotEmpty())
+        {
+            dicQuery.Add("sni", item.Sni);
+        }
+        dicQuery.Add("insecure", item.AllowInsecure.ToLower() == "true" ? "1" : "0");
+
+        return ToUri(EConfigType.Anytls, item.Address, item.Port, pw, dicQuery, remark);
+    }
+}

--- a/v2rayN/ServiceLib/Handler/Fmt/AnytlsFmt.cs
+++ b/v2rayN/ServiceLib/Handler/Fmt/AnytlsFmt.cs
@@ -24,8 +24,7 @@ public class AnytlsFmt : BaseFmt
         item.Id = rawUserInfo;
 
         var query = Utils.ParseQueryString(parsedUrl.Query);
-        item.Sni = query["sni"] ?? Global.None;
-        item.AllowInsecure = (query["insecure"] ?? "") == "1" ? "true" : "false";
+        _ = ResolveStdTransport(query, ref item);
 
         return item;
     }
@@ -43,11 +42,7 @@ public class AnytlsFmt : BaseFmt
         }
         var pw = item.Id;
         var dicQuery = new Dictionary<string, string>();
-        if (item.Sni.IsNotEmpty())
-        {
-            dicQuery.Add("sni", item.Sni);
-        }
-        dicQuery.Add("insecure", item.AllowInsecure.ToLower() == "true" ? "1" : "0");
+        _ = GetStdTransport(item, Global.None, ref dicQuery);
 
         return ToUri(EConfigType.Anytls, item.Address, item.Port, pw, dicQuery, remark);
     }

--- a/v2rayN/ServiceLib/Handler/Fmt/FmtHandler.cs
+++ b/v2rayN/ServiceLib/Handler/Fmt/FmtHandler.cs
@@ -18,6 +18,7 @@ public class FmtHandler
                 EConfigType.Hysteria2 => Hysteria2Fmt.ToUri(item),
                 EConfigType.TUIC => TuicFmt.ToUri(item),
                 EConfigType.WireGuard => WireguardFmt.ToUri(item),
+                EConfigType.Anytls => AnytlsFmt.ToUri(item),
                 _ => null,
             };
 
@@ -74,6 +75,10 @@ public class FmtHandler
             else if (str.StartsWith(Global.ProtocolShares[EConfigType.WireGuard]))
             {
                 return WireguardFmt.Resolve(str, out msg);
+            }
+            else if (str.StartsWith(Global.ProtocolShares[EConfigType.Anytls]))
+            {
+                return AnytlsFmt.Resolve(str, out msg);
             }
             else
             {

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -67,6 +67,9 @@ public class Rule4Sbox
     public List<string>? process_name { get; set; }
     public List<string>? rule_set { get; set; }
     public List<Rule4Sbox>? rules { get; set; }
+    public string? action { get; set; }
+    public string? strategy { get; set; }
+    public List<string>? sniffer { get; set; }
 }
 
 [Serializable]
@@ -76,7 +79,6 @@ public class Inbound4Sbox
     public string tag { get; set; }
     public string listen { get; set; }
     public int? listen_port { get; set; }
-    public string? domain_strategy { get; set; }
     public string interface_name { get; set; }
     public List<string>? address { get; set; }
     public int? mtu { get; set; }
@@ -84,8 +86,6 @@ public class Inbound4Sbox
     public bool? strict_route { get; set; }
     public bool? endpoint_independent_nat { get; set; }
     public string? stack { get; set; }
-    public bool? sniff { get; set; }
-    public bool? sniff_override_destination { get; set; }
     public List<User4Sbox> users { get; set; }
 }
 
@@ -134,6 +134,32 @@ public class Outbound4Sbox
     public HyObfs4Sbox? obfs { get; set; }
     public List<string>? outbounds { get; set; }
     public bool? interrupt_exist_connections { get; set; }
+}
+
+public class Endpoints4Sbox
+{
+    public string type { get; set; }
+    public string tag { get; set; }
+    public bool? system { get; set; }
+    public string? name { get; set; }
+    public int? mtu { get; set; }
+    public List<string> address { get; set; }
+    public string private_key { get; set; }
+    public int listen_port { get; set; }
+    public string? udp_timeout { get; set; }
+    public int? workers { get; set; }
+    public List<Peer4Sbox> peers { get; set; }
+}
+
+public class Peer4Sbox
+{
+    public string address { get; set; }
+    public int port { get; set; }
+    public string public_key { get; set; }
+    public string? pre_shared_key { get; set; }
+    public List<string> allowed_ips { get; set; }
+    public int? persistent_keepalive_interval { get; set; }
+    public List<int> reserved { get; set; }
 }
 
 public class Tls4Sbox

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -153,7 +153,7 @@ public class Endpoints4Sbox : BaseServer4Sbox
     public int? mtu { get; set; }
     public List<string> address { get; set; }
     public string private_key { get; set; }
-    public int listen_port { get; set; }
+    public int? listen_port { get; set; }
     public string? udp_timeout { get; set; }
     public int? workers { get; set; }
     public List<Peer4Sbox> peers { get; set; }

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -236,6 +236,8 @@ public class Server4Sbox : BaseServer4Sbox
     public int? server_port { get; set; }
     public string? path { get; set; }
     public Headers4Sbox? headers { get; set; }
+    // public List<string>? path { get; set; } // hosts
+    public Dictionary<string, object>? predefined { get; set; }
     // Deprecated
     public string? address { get; set; }
     public string? address_resolver { get; set; }

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -214,6 +214,9 @@ public class Server4Sbox : BaseServer4Sbox
     public string? server { get; set; }
     public new string? domain_resolver { get; set; }
     [JsonPropertyName("interface")] public string? Interface { get; set; }
+    public int? server_port { get; set; }
+    public string? path { get; set; }
+    public Headers4Sbox? headers { get; set; }
     // Deprecated
     public string? address { get; set; }
     public string? address_resolver { get; set; }

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace ServiceLib.Models;
 
 public class SingboxConfig
@@ -227,7 +229,7 @@ public class Server4Sbox
     public string? type { get; set; }
     public string? server { get; set; }
     public string? server_resolver { get; set; }
-    //public string? interface { get; set; }
+    [JsonPropertyName("interface")] public string? Interface { get; set; }
 }
 
 public class Experimental4Sbox

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -52,6 +52,7 @@ public class Rule4Sbox
     public string? mode { get; set; }
     public bool? ip_is_private { get; set; }
     public string? client_subnet { get; set; }
+    public int? rewrite_ttl { get; set; }
     public bool? invert { get; set; }
     public string? clash_mode { get; set; }
     public List<string>? inbound { get; set; }
@@ -73,6 +74,24 @@ public class Rule4Sbox
     public string? action { get; set; }
     public string? strategy { get; set; }
     public List<string>? sniffer { get; set; }
+    public string? rcode { get; set; }
+    public List<object>? query_type { get; set; }
+    public List<string>? answer { get; set; }
+    public List<string>? ns { get; set; }
+    public List<string>? extra { get; set; }
+    public string? method { get; set; }
+    public bool? no_drop { get; set; }
+    public bool? source_ip_is_private { get; set; }
+    public bool? ip_accept_any { get; set; }
+    public int? source_port { get; set; }
+    public List<string>? source_port_range { get; set; }
+    public List<string>? network_type { get; set; }
+    public bool? network_is_expensive { get; set; }
+    public bool? network_is_constrained { get; set; }
+    public List<string>? wifi_ssid { get; set; }
+    public List<string>? wifi_bssid { get; set; }
+    public bool? rule_set_ip_cidr_match_source { get; set; }
+    public bool? rule_set_ip_cidr_accept_empty { get; set; }
 }
 
 [Serializable]

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -8,6 +8,7 @@ public class SingboxConfig
     public Dns4Sbox? dns { get; set; }
     public List<Inbound4Sbox> inbounds { get; set; }
     public List<Outbound4Sbox> outbounds { get; set; }
+    public List<Endpoints4Sbox>? endpoints { get; set; }
     public Route4Sbox route { get; set; }
     public Experimental4Sbox? experimental { get; set; }
 }
@@ -96,10 +97,8 @@ public class User4Sbox
     public string password { get; set; }
 }
 
-public class Outbound4Sbox
+public class Outbound4Sbox : BaseServer4Sbox
 {
-    public string type { get; set; }
-    public string tag { get; set; }
     public string? server { get; set; }
     public int? server_port { get; set; }
     public List<string>? server_ports { get; set; }
@@ -114,7 +113,6 @@ public class Outbound4Sbox
     public int? recv_window_conn { get; set; }
     public int? recv_window { get; set; }
     public bool? disable_mtu_discovery { get; set; }
-    public string? detour { get; set; }
     public string? method { get; set; }
     public string? username { get; set; }
     public string? password { get; set; }
@@ -122,26 +120,14 @@ public class Outbound4Sbox
     public string? version { get; set; }
     public string? network { get; set; }
     public string? packet_encoding { get; set; }
-    public List<string>? local_address { get; set; }
-    public string? private_key { get; set; }
-    public string? peer_public_key { get; set; }
-    public List<int>? reserved { get; set; }
-    public int? mtu { get; set; }
     public string? plugin { get; set; }
     public string? plugin_opts { get; set; }
-    public Tls4Sbox? tls { get; set; }
-    public Multiplex4Sbox? multiplex { get; set; }
-    public Transport4Sbox? transport { get; set; }
-    public HyObfs4Sbox? obfs { get; set; }
     public List<string>? outbounds { get; set; }
     public bool? interrupt_exist_connections { get; set; }
-    public Rule4Sbox? domain_resolver { get; set; }
 }
 
-public class Endpoints4Sbox
+public class Endpoints4Sbox : BaseServer4Sbox
 {
-    public string type { get; set; }
-    public string tag { get; set; }
     public bool? system { get; set; }
     public string? name { get; set; }
     public int? mtu { get; set; }
@@ -219,14 +205,11 @@ public class HyObfs4Sbox
     public string? password { get; set; }
 }
 
-public class Server4Sbox
+public class Server4Sbox : BaseServer4Sbox
 {
-    public string? tag { get; set; }
-    public string? detour { get; set; }
     public string? inet4_range { get; set; }
     public string? inet6_range { get; set; }
     public string? client_subnet { get; set; }
-    public string? type { get; set; }
     public string? server { get; set; }
     public string? server_resolver { get; set; }
     [JsonPropertyName("interface")] public string? Interface { get; set; }
@@ -276,4 +259,34 @@ public class Ruleset4Sbox
     public string? url { get; set; }
     public string? download_detour { get; set; }
     public string? update_interval { get; set; }
+}
+
+public abstract class DialFields4Sbox
+{
+    public string? detour { get; set; }
+    public string? bind_interface { get; set; }
+    public string? inet4_bind_address { get; set; }
+    public string? inet6_bind_address { get; set; }
+    public int? routing_mark { get; set; }
+    public bool? reuse_addr { get; set; }
+    public string? netns { get; set; }
+    public string? connect_timeout { get; set; }
+    public bool? tcp_fast_open { get; set; }
+    public bool? tcp_multi_path { get; set; }
+    public bool? udp_fragment { get; set; }
+    public Rule4Sbox? domain_resolver { get; set; } // or string
+    public string? network_strategy { get; set; }
+    public List<string>? network_type { get; set; }
+    public List<string>? fallback_network_type { get; set; }
+    public string? fallback_delay { get; set; }
+    public Tls4Sbox? tls { get; set; }
+    public Multiplex4Sbox? multiplex { get; set; }
+    public Transport4Sbox? transport { get; set; }
+    public HyObfs4Sbox? obfs { get; set; }
+}
+
+public abstract class BaseServer4Sbox : DialFields4Sbox
+{
+    public string type { get; set; }
+    public string tag { get; set; }
 }

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -29,7 +29,6 @@ public class Dns4Sbox
     public bool? independent_cache { get; set; }
     public bool? reverse_mapping { get; set; }
     public string? client_subnet { get; set; }
-    public Fakeip4Sbox? fakeip { get; set; }
 }
 
 public class Route4Sbox
@@ -134,6 +133,7 @@ public class Outbound4Sbox
     public HyObfs4Sbox? obfs { get; set; }
     public List<string>? outbounds { get; set; }
     public bool? interrupt_exist_connections { get; set; }
+    public Rule4Sbox? domain_resolver { get; set; }
 }
 
 public class Endpoints4Sbox
@@ -220,12 +220,14 @@ public class HyObfs4Sbox
 public class Server4Sbox
 {
     public string? tag { get; set; }
-    public string? address { get; set; }
-    public string? address_resolver { get; set; }
-    public string? address_strategy { get; set; }
-    public string? strategy { get; set; }
     public string? detour { get; set; }
+    public string? inet4_range { get; set; }
+    public string? inet6_range { get; set; }
     public string? client_subnet { get; set; }
+    public string? type { get; set; }
+    public string? server { get; set; }
+    public string? server_resolver { get; set; }
+    //public string? interface { get; set; }
 }
 
 public class Experimental4Sbox
@@ -253,13 +255,6 @@ public class Stats4Sbox
     public List<string>? inbounds { get; set; }
     public List<string>? outbounds { get; set; }
     public List<string>? users { get; set; }
-}
-
-public class Fakeip4Sbox
-{
-    public bool enabled { get; set; }
-    public string inet4_range { get; set; }
-    public string inet6_range { get; set; }
 }
 
 public class CacheFile4Sbox

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -39,6 +39,7 @@ public class Route4Sbox
     public bool? auto_detect_interface { get; set; }
     public List<Rule4Sbox> rules { get; set; }
     public List<Ruleset4Sbox>? rule_set { get; set; }
+    public string? final { get; set; }
 }
 
 [Serializable]

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -212,7 +212,7 @@ public class Server4Sbox : BaseServer4Sbox
     public string? inet6_range { get; set; }
     public string? client_subnet { get; set; }
     public string? server { get; set; }
-    public string? server_resolver { get; set; }
+    public new string? domain_resolver { get; set; }
     [JsonPropertyName("interface")] public string? Interface { get; set; }
     // Deprecated
     public string? address { get; set; }

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -213,6 +213,12 @@ public class Server4Sbox : BaseServer4Sbox
     public string? server { get; set; }
     public string? server_resolver { get; set; }
     [JsonPropertyName("interface")] public string? Interface { get; set; }
+    // Deprecated
+    public string? address { get; set; }
+    public string? address_resolver { get; set; }
+    public string? address_strategy { get; set; }
+    public string? strategy { get; set; }
+    // Deprecated End
 }
 
 public class Experimental4Sbox

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -655,6 +655,15 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Add [Anytls] Configuration 的本地化字符串。
+        /// </summary>
+        public static string menuAddAnytlsServer {
+            get {
+                return ResourceManager.GetString("menuAddAnytlsServer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Add a custom configuration Configuration 的本地化字符串。
         /// </summary>
         public static string menuAddCustomServer {

--- a/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
@@ -1401,4 +1401,7 @@
   <data name="TbMldsa65Verify" xml:space="preserve">
     <value>Mldsa65Verify</value>
   </data>
+  <data name="menuAddAnytlsServer" xml:space="preserve">
+    <value>Add [Anytls] Configuration</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.hu.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.hu.resx
@@ -1401,4 +1401,7 @@
   <data name="TbMldsa65Verify" xml:space="preserve">
     <value>Mldsa65Verify</value>
   </data>
+  <data name="menuAddAnytlsServer" xml:space="preserve">
+    <value>Add [Anytls] Configuration</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.hu.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.hu.resx
@@ -1402,6 +1402,6 @@
     <value>Mldsa65Verify</value>
   </data>
   <data name="menuAddAnytlsServer" xml:space="preserve">
-    <value>Add [Anytls] Configuration</value>
+    <value>[Anytls] konfiguráció hozzáadása</value>
   </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1401,4 +1401,7 @@
   <data name="TbMldsa65Verify" xml:space="preserve">
     <value>Mldsa65Verify</value>
   </data>
+  <data name="menuAddAnytlsServer" xml:space="preserve">
+    <value>Add [Anytls] Configuration</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1402,6 +1402,6 @@
     <value>Mldsa65Verify</value>
   </data>
   <data name="menuAddAnytlsServer" xml:space="preserve">
-    <value>Add [Anytls] Configuration</value>
+    <value>Добавить сервер [Anytls]</value>
   </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1401,4 +1401,7 @@
   <data name="TbMldsa65Verify" xml:space="preserve">
     <value>Mldsa65Verify</value>
   </data>
+  <data name="menuAddAnytlsServer" xml:space="preserve">
+    <value>Add [Anytls] Configuration</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1398,4 +1398,7 @@
   <data name="TbMldsa65Verify" xml:space="preserve">
     <value>Mldsa65Verify</value>
   </data>
+  <data name="menuAddAnytlsServer" xml:space="preserve">
+    <value>添加 [Anytls] 配置文件</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -1398,4 +1398,7 @@
   <data name="TbMldsa65Verify" xml:space="preserve">
     <value>Mldsa65Verify</value>
   </data>
+  <data name="menuAddAnytlsServer" xml:space="preserve">
+    <value>新增 [Anytls] 設定檔</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Sample/SingboxSampleClientConfig
+++ b/v2rayN/ServiceLib/Sample/SingboxSampleClientConfig
@@ -1,4 +1,4 @@
-﻿{
+{
 	"log": {
 		"level": "debug",
 		"timestamp": true
@@ -14,22 +14,10 @@
 		{
 			"type": "direct",
 			"tag": "direct"
-		},
-		{
-			"type": "block",
-			"tag": "block"
-		},
-		{
-			"tag": "dns_out",
-			"type": "dns"
 		}
 	],
 	"route": {
 		"rules": [
-			{
-				"protocol": [ "dns" ],
-				"outbound": "dns_out"
-			}
 		]
 	}
 }

--- a/v2rayN/ServiceLib/Sample/dns_singbox_normal
+++ b/v2rayN/ServiceLib/Sample/dns_singbox_normal
@@ -16,6 +16,13 @@
   ],
   "rules": [
     {
+      "domain_suffix": [
+        "googleapis.cn",
+        "gstatic.com"
+      ],
+      "server": "remote"
+    },
+    {
       "rule_set": [
         "geosite-cn"
       ],

--- a/v2rayN/ServiceLib/Sample/dns_singbox_normal
+++ b/v2rayN/ServiceLib/Sample/dns_singbox_normal
@@ -4,14 +4,12 @@
       "tag": "remote",
       "type": "tcp",
       "server": "8.8.8.8",
-      "strategy": "prefer_ipv4",
       "detour": "proxy"
     },
     {
       "tag": "local",
       "type": "udp",
-      "server": "223.5.5.5",
-      "strategy": "prefer_ipv4"
+      "server": "223.5.5.5"
     }
   ],
   "rules": [

--- a/v2rayN/ServiceLib/Sample/dns_singbox_normal
+++ b/v2rayN/ServiceLib/Sample/dns_singbox_normal
@@ -2,19 +2,16 @@
   "servers": [
     {
       "tag": "remote",
-      "address": "tcp://8.8.8.8",
+      "type": "tcp",
+      "server": "8.8.8.8",
       "strategy": "prefer_ipv4",
       "detour": "proxy"
     },
     {
       "tag": "local",
-      "address": "223.5.5.5",
-      "strategy": "prefer_ipv4",
-      "detour": "direct"
-    },
-    {
-      "tag": "block",
-      "address": "rcode://success"
+      "type": "udp",
+      "server": "223.5.5.5",
+      "strategy": "prefer_ipv4"
     }
   ],
   "rules": [

--- a/v2rayN/ServiceLib/Sample/dns_singbox_normal
+++ b/v2rayN/ServiceLib/Sample/dns_singbox_normal
@@ -18,14 +18,17 @@
         "googleapis.cn",
         "gstatic.com"
       ],
-      "server": "remote"
+      "server": "remote",
+      "strategy": "prefer_ipv4"
     },
     {
       "rule_set": [
         "geosite-cn"
       ],
-      "server": "local"
+      "server": "local",
+      "strategy": "prefer_ipv4"
     }
   ],
-  "final": "remote"
+  "final": "remote",
+  "strategy": "prefer_ipv4"
 }

--- a/v2rayN/ServiceLib/Sample/tun_singbox_dns
+++ b/v2rayN/ServiceLib/Sample/tun_singbox_dns
@@ -16,6 +16,13 @@
   ],
   "rules": [
     {
+      "domain_suffix": [
+        "googleapis.cn",
+        "gstatic.com"
+      ],
+      "server": "remote"
+    },
+    {
       "rule_set": [
         "geosite-cn",
         "geosite-geolocation-cn"

--- a/v2rayN/ServiceLib/Sample/tun_singbox_dns
+++ b/v2rayN/ServiceLib/Sample/tun_singbox_dns
@@ -4,14 +4,12 @@
       "tag": "remote",
       "type": "tcp",
       "server": "8.8.8.8",
-      "strategy": "prefer_ipv4",
       "detour": "proxy"
     },
     {
       "tag": "local",
       "type": "udp",
-      "server": "223.5.5.5",
-      "strategy": "prefer_ipv4"
+      "server": "223.5.5.5"
     }
   ],
   "rules": [

--- a/v2rayN/ServiceLib/Sample/tun_singbox_dns
+++ b/v2rayN/ServiceLib/Sample/tun_singbox_dns
@@ -23,8 +23,7 @@
     },
     {
       "rule_set": [
-        "geosite-cn",
-        "geosite-geolocation-cn"
+        "geosite-cn"
       ],
       "server": "local",
       "strategy": "prefer_ipv4"

--- a/v2rayN/ServiceLib/Sample/tun_singbox_dns
+++ b/v2rayN/ServiceLib/Sample/tun_singbox_dns
@@ -2,19 +2,16 @@
   "servers": [
     {
       "tag": "remote",
-      "address": "tcp://8.8.8.8",
+      "type": "tcp",
+      "server": "8.8.8.8",
       "strategy": "prefer_ipv4",
       "detour": "proxy"
     },
     {
       "tag": "local",
-      "address": "223.5.5.5",
-      "strategy": "prefer_ipv4",
-      "detour": "direct"
-    },
-    {
-      "tag": "block",
-      "address": "rcode://success"
+      "type": "udp",
+      "server": "223.5.5.5",
+      "strategy": "prefer_ipv4"
     }
   ],
   "rules": [

--- a/v2rayN/ServiceLib/Sample/tun_singbox_dns
+++ b/v2rayN/ServiceLib/Sample/tun_singbox_dns
@@ -18,15 +18,18 @@
         "googleapis.cn",
         "gstatic.com"
       ],
-      "server": "remote"
+      "server": "remote",
+      "strategy": "prefer_ipv4"
     },
     {
       "rule_set": [
         "geosite-cn",
         "geosite-geolocation-cn"
       ],
-      "server": "local"
+      "server": "local",
+      "strategy": "prefer_ipv4"
     }
   ],
-  "final": "remote"
+  "final": "remote",
+  "strategy": "prefer_ipv4"
 }

--- a/v2rayN/ServiceLib/Sample/tun_singbox_rules
+++ b/v2rayN/ServiceLib/Sample/tun_singbox_rules
@@ -8,13 +8,13 @@
       139,
       5353
     ],
-    "outbound": "block"
+    "action": "reject"
   },
   {
     "ip_cidr": [
       "224.0.0.0/3",
       "ff00::/8"
     ],
-    "outbound": "block"
+    "action": "reject"
   }
 ]

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1475,7 +1475,7 @@ public class CoreConfigSingboxService
         var tag = "local_local";
         var localDnsAddress = string.IsNullOrEmpty(dNSItem?.DomainDNSAddress) ? Global.SingboxDomainDNSAddress.FirstOrDefault() : dNSItem?.DomainDNSAddress;
         string? localDnsType = null;
-        //string? dhcpDnsInterface = null;
+        string? dhcpDnsInterface = null;
         if (localDnsAddress == "local")
         {
             localDnsType = "local";
@@ -1484,8 +1484,12 @@ public class CoreConfigSingboxService
         else if (localDnsAddress.StartsWith("dhcp") && localDnsAddress.Length > 7)
         {
             localDnsType = "dhcp";
-            // // dhcp://
-            // dhcpDnsInterface = localDnsAddress.Substring(7);
+            // dhcp://
+            dhcpDnsInterface = localDnsAddress.Substring(7);
+            if (dhcpDnsInterface == "auto")
+            {
+                dhcpDnsInterface = null;
+            }
             localDnsAddress = null;
         }
         else if (localDnsAddress.StartsWith("tcp") && localDnsAddress.Length > 6)
@@ -1521,7 +1525,8 @@ public class CoreConfigSingboxService
         {
             tag = tag,
             type = localDnsType,
-            server = localDnsAddress
+            server = localDnsAddress,
+            Interface = dhcpDnsInterface
         });
         dns4Sbox.rules.Insert(0, new()
         {

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -818,6 +818,7 @@ public class CoreConfigSingboxService
                         };
                         endpoint.private_key = node.Id;
                         endpoint.mtu = node.ShortId.IsNullOrEmpty() ? Global.TunMtus.First() : node.ShortId.ToInt();
+                        endpoint.peers = new() { peer };
                         break;
                     }
             }

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1481,46 +1481,36 @@ public class CoreConfigSingboxService
             localDnsType = "local";
             localDnsAddress = null;
         }
-        else if (localDnsAddress.StartsWith("dhcp"))
+        else if (localDnsAddress.StartsWith("dhcp") && localDnsAddress.Length > 7)
         {
             localDnsType = "dhcp";
-            //if (localDnsAddress.Length > 7) // dhcp://
-            //{
-            //    localDnsAddress = localDnsAddress.Substring(7);
-            //}
+            // // dhcp://
+            // dhcpDnsInterface = localDnsAddress.Substring(7);
             localDnsAddress = null;
         }
-        else if (localDnsAddress.StartsWith("tcp"))
+        else if (localDnsAddress.StartsWith("tcp") && localDnsAddress.Length > 6)
         {
             localDnsType = "tcp";
-            if (localDnsAddress.Length > 6) // tcp://
-            {
-                localDnsAddress = localDnsAddress.Substring(6);
-            }
+            // tcp://
+            localDnsAddress = localDnsAddress.Substring(6);
         }
-        else if (localDnsAddress.StartsWith("tls"))
+        else if (localDnsAddress.StartsWith("tls") && localDnsAddress.Length > 6)
         {
             localDnsType = "tls";
-            if (localDnsAddress.Length > 6) // tls://
-            {
-                localDnsAddress = localDnsAddress.Substring(6);
-            }
+            // tls://
+            localDnsAddress = localDnsAddress.Substring(6);
         }
-        else if (localDnsAddress.StartsWith("https"))
+        else if (localDnsAddress.StartsWith("https") && localDnsAddress.Length > 8)
         {
             localDnsType = "https";
-            if (localDnsAddress.Length > 8) // https://
-            {
-                localDnsAddress = localDnsAddress.Substring(8);
-            }
+            // https://
+            localDnsAddress = localDnsAddress.Substring(8);
         }
-        else if (localDnsAddress.StartsWith("quic"))
+        else if (localDnsAddress.StartsWith("quic") && localDnsAddress.Length > 7)
         {
             localDnsType = "quic";
-            if (localDnsAddress.Length > 7) // quic://
-            {
-                localDnsAddress = localDnsAddress.Substring(7);
-            }
+            // quic://
+            localDnsAddress = localDnsAddress.Substring(7);
         }
         else
         {

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -614,11 +614,11 @@ public class CoreConfigSingboxService
 
             if (Utils.IsDomain(node.Address))
             {
+                var item = await AppHandler.Instance.GetDNSItem(ECoreType.sing_box);
                 outbound.domain_resolver = new()
                 {
                     server = "local_local",
-                    // TODO
-                    //strategy = string.IsNullOrEmpty(dNSItem?.DomainStrategy4Freedom) ? null : dNSItem?.DomainStrategy4Freedom
+                    strategy = string.IsNullOrEmpty(item?.DomainStrategy4Freedom) ? null : item?.DomainStrategy4Freedom
                 };
             }
 

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -790,7 +790,6 @@ public class CoreConfigSingboxService
         try
         {
             endpoint.address = Utils.String2List(node.RequestHost);
-            // Utils.GetFreePort() 9090 ?
             endpoint.listen_port = Utils.GetFreePort();
             endpoint.type = Global.ProtocolTypes[node.ConfigType];
 

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1,6 +1,7 @@
 using System.Data;
 using System.Net;
 using System.Net.NetworkInformation;
+using System.Reactive;
 using DynamicData;
 using ServiceLib.Models;
 
@@ -55,7 +56,18 @@ public class CoreConfigSingboxService
 
             await GenInbounds(singboxConfig);
 
-            await GenOutbound(node, singboxConfig.outbounds.First());
+            if (node.ConfigType == EConfigType.WireGuard)
+            {
+                singboxConfig.outbounds.RemoveAt(0);
+                var endpoints = new Endpoints4Sbox();
+                await GenEndpoint(node, endpoints);
+                endpoints.tag = Global.ProxyTag;
+                singboxConfig.endpoints = new() { endpoints };
+            }
+            else
+            {
+                await GenOutbound(node, singboxConfig.outbounds.First());
+            }
 
             await GenMoreOutbounds(node, singboxConfig);
 
@@ -204,16 +216,29 @@ public class CoreConfigSingboxService
                     continue;
                 }
 
-                var outbound = JsonUtils.Deserialize<Outbound4Sbox>(txtOutbound);
-                await GenOutbound(item, outbound);
-                outbound.tag = Global.ProxyTag + inbound.listen_port.ToString();
-                singboxConfig.outbounds.Add(outbound);
+                var server = await GenServer(item);
+                if (server is null)
+                {
+                    ret.Msg = ResUI.FailedGenDefaultConfiguration;
+                    return ret;
+                }
+                var tag = Global.ProxyTag + inbound.listen_port.ToString();
+                server.tag = tag;
+                if (server is Endpoints4Sbox endpoint)
+                {
+                    singboxConfig.endpoints ??= new();
+                    singboxConfig.endpoints.Add(endpoint);
+                }
+                else if (server is Outbound4Sbox outbound)
+                {
+                    singboxConfig.outbounds.Add(outbound);
+                }
 
                 //rule
                 Rule4Sbox rule = new()
                 {
                     inbound = new List<string> { inbound.tag },
-                    outbound = outbound.tag
+                    outbound = tag
                 };
                 singboxConfig.route.rules.Add(rule);
             }
@@ -277,7 +302,18 @@ public class CoreConfigSingboxService
             }
 
             await GenLog(singboxConfig);
-            await GenOutbound(node, singboxConfig.outbounds.First());
+            if (node.ConfigType == EConfigType.WireGuard)
+            {
+                singboxConfig.outbounds.RemoveAt(0);
+                var endpoints = new Endpoints4Sbox();
+                await GenEndpoint(node, endpoints);
+                endpoints.tag = Global.ProxyTag;
+                singboxConfig.endpoints = new() { endpoints };
+            }
+            else
+            {
+                await GenOutbound(node, singboxConfig.outbounds.First());
+            }
             await GenMoreOutbounds(node, singboxConfig);
             await GenDnsDomains(null, singboxConfig, null);
 
@@ -731,15 +767,6 @@ public class CoreConfigSingboxService
                         outbound.congestion_control = node.HeaderType;
                         break;
                     }
-                case EConfigType.WireGuard:
-                    {
-                        outbound.private_key = node.Id;
-                        outbound.peer_public_key = node.PublicKey;
-                        outbound.reserved = Utils.String2List(node.Path)?.Select(int.Parse).ToList();
-                        outbound.local_address = Utils.String2List(node.RequestHost);
-                        outbound.mtu = node.ShortId.IsNullOrEmpty() ? Global.TunMtus.First() : node.ShortId.ToInt();
-                        break;
-                    }
                 case EConfigType.Anytls:
                     {
                         outbound.password = node.Id;
@@ -756,6 +783,76 @@ public class CoreConfigSingboxService
             Logging.SaveLog(_tag, ex);
         }
         return 0;
+    }
+
+    private async Task<int> GenEndpoint(ProfileItem node, Endpoints4Sbox endpoint)
+    {
+        try
+        {
+            endpoint.address = Utils.String2List(node.RequestHost);
+            // Utils.GetFreePort() 9090 ?
+            endpoint.listen_port = Utils.GetFreePort();
+            endpoint.type = Global.ProtocolTypes[node.ConfigType];
+
+            if (Utils.IsDomain(node.Address))
+            {
+                var item = await AppHandler.Instance.GetDNSItem(ECoreType.sing_box);
+                endpoint.domain_resolver = new()
+                {
+                    server = "local_local",
+                    strategy = string.IsNullOrEmpty(item?.DomainStrategy4Freedom) ? null : item?.DomainStrategy4Freedom
+                };
+            }
+
+            switch (node.ConfigType)
+            {
+                case EConfigType.WireGuard:
+                    {
+                        var peer = new Peer4Sbox
+                        {
+                            public_key = node.PublicKey,
+                            reserved = Utils.String2List(node.Path)?.Select(int.Parse).ToList(),
+                            address = node.Address,
+                            port = node.Port,
+                            // TODO default ["0.0.0.0/0", "::/0"]
+                            allowed_ips = new() { "0.0.0.0/0", "::/0" },
+                        };
+                        endpoint.private_key = node.Id;
+                        endpoint.mtu = node.ShortId.IsNullOrEmpty() ? Global.TunMtus.First() : node.ShortId.ToInt();
+                        break;
+                    }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logging.SaveLog(_tag, ex);
+        }
+        return await Task.FromResult(0);
+    }
+
+    private async Task<BaseServer4Sbox?> GenServer(ProfileItem node)
+    {
+        try
+        {
+            var txtOutbound = EmbedUtils.GetEmbedText(Global.SingboxSampleOutbound);
+            if (node.ConfigType == EConfigType.WireGuard)
+            {
+                var endpoint = JsonUtils.Deserialize<Endpoints4Sbox>(txtOutbound);
+                await GenEndpoint(node, endpoint);
+                return endpoint;
+            }
+            else
+            {
+                var outbound = JsonUtils.Deserialize<Outbound4Sbox>(txtOutbound);
+                await GenOutbound(node, outbound);
+                return outbound;
+            }
+        }
+        catch (Exception ex)
+        {
+            Logging.SaveLog(_tag, ex);
+        }
+        return await Task.FromResult<BaseServer4Sbox?>(null);
     }
 
     private async Task<int> GenOutboundMux(ProfileItem node, Outbound4Sbox outbound)
@@ -924,7 +1021,8 @@ public class CoreConfigSingboxService
             }
 
             //current proxy
-            var outbound = singboxConfig.outbounds.First();
+            BaseServer4Sbox? outbound = singboxConfig.endpoints?.FirstOrDefault(t => t.tag == Global.ProxyTag) == null ? singboxConfig.outbounds.First() : null;
+
             var txtOutbound = EmbedUtils.GetEmbedText(Global.SingboxSampleOutbound);
 
             //Previous proxy
@@ -933,17 +1031,32 @@ public class CoreConfigSingboxService
             if (prevNode is not null
                 && prevNode.ConfigType != EConfigType.Custom)
             {
-                var prevOutbound = JsonUtils.Deserialize<Outbound4Sbox>(txtOutbound);
-                await GenOutbound(prevNode, prevOutbound);
                 prevOutboundTag = $"prev-{Global.ProxyTag}";
-                prevOutbound.tag = prevOutboundTag;
-                singboxConfig.outbounds.Add(prevOutbound);
+                var prevServer = await GenServer(prevNode);
+                prevServer.tag = prevOutboundTag;
+                if (prevServer is Endpoints4Sbox endpoint)
+                {
+                    singboxConfig.endpoints ??= new();
+                    singboxConfig.endpoints.Add(endpoint);
+                }
+                else if (prevServer is Outbound4Sbox outboundPrev)
+                {
+                    singboxConfig.outbounds.Add(outboundPrev);
+                }
             }
-            var nextOutbound = await GenChainOutbounds(subItem, outbound, prevOutboundTag);
+            var nextServer = await GenChainOutbounds(subItem, outbound, prevOutboundTag);
 
-            if (nextOutbound is not null)
+            if (nextServer is not null)
             {
-                singboxConfig.outbounds.Insert(0, nextOutbound);
+                if (nextServer is Endpoints4Sbox endpoint)
+                {
+                    singboxConfig.endpoints ??= new();
+                    singboxConfig.endpoints.Insert(0, endpoint);
+                }
+                else if (nextServer is Outbound4Sbox outboundNext)
+                {
+                    singboxConfig.outbounds.Insert(0, outboundNext);
+                }
             }
         }
         catch (Exception ex)
@@ -966,11 +1079,13 @@ public class CoreConfigSingboxService
             }
 
             var resultOutbounds = new List<Outbound4Sbox>();
+            var resultEndpoints = new List<Endpoints4Sbox>(); // For endpoints
             var prevOutbounds = new List<Outbound4Sbox>(); // Separate list for prev outbounds
+            var prevEndpoints = new List<Endpoints4Sbox>(); // Separate list for prev endpoints
             var proxyTags = new List<string>(); // For selector and urltest outbounds
 
             // Cache for chain proxies to avoid duplicate generation
-            var nextProxyCache = new Dictionary<string, Outbound4Sbox?>();
+            var nextProxyCache = new Dictionary<string, BaseServer4Sbox?>();
             var prevProxyTags = new Dictionary<string, string?>(); // Map from profile name to tag
             int prevIndex = 0; // Index for prev outbounds
 
@@ -982,19 +1097,18 @@ public class CoreConfigSingboxService
 
                 // Handle proxy chain
                 string? prevTag = null;
-                var currentOutbound = JsonUtils.Deserialize<Outbound4Sbox>(txtOutbound);
-                var nextOutbound = nextProxyCache.GetValueOrDefault(node.Subid, null);
-                if (nextOutbound != null)
+                var currentServer = await GenServer(node);
+                var nextServer = nextProxyCache.GetValueOrDefault(node.Subid, null);
+                if (nextServer != null)
                 {
-                    nextOutbound = JsonUtils.DeepCopy(nextOutbound);
+                    nextServer = JsonUtils.DeepCopy(nextServer);
                 }
 
                 var subItem = await AppHandler.Instance.GetSubItem(node.Subid);
 
                 // current proxy
-                await GenOutbound(node, currentOutbound);
-                currentOutbound.tag = $"{Global.ProxyTag}-{index}";
-                proxyTags.Add(currentOutbound.tag);
+                currentServer.tag = $"{Global.ProxyTag}-{index}";
+                proxyTags.Add(currentServer.tag);
 
                 if (!node.Subid.IsNullOrEmpty())
                 {
@@ -1017,18 +1131,32 @@ public class CoreConfigSingboxService
                         prevProxyTags[node.Subid] = prevTag;
                     }
 
-                    nextOutbound = await GenChainOutbounds(subItem, currentOutbound, prevTag, nextOutbound);
+                    nextServer = await GenChainOutbounds(subItem, currentServer, prevTag, nextServer);
                     if (!nextProxyCache.ContainsKey(node.Subid))
                     {
-                        nextProxyCache[node.Subid] = nextOutbound;
+                        nextProxyCache[node.Subid] = nextServer;
                     }
                 }
 
-                if (nextOutbound is not null)
+                if (nextServer is not null)
                 {
-                    resultOutbounds.Add(nextOutbound);
+                    if (nextServer is Endpoints4Sbox nextEndpoint)
+                    {
+                        resultEndpoints.Add(nextEndpoint);
+                    }
+                    else if (nextServer is Outbound4Sbox nextOutbound)
+                    {
+                        resultOutbounds.Add(nextOutbound);
+                    }
                 }
-                resultOutbounds.Add(currentOutbound);
+                if (currentServer is Endpoints4Sbox currentEndpoint)
+                {
+                    resultEndpoints.Add(currentEndpoint);
+                }
+                else if (currentServer is Outbound4Sbox currentOutbound)
+                {
+                    resultOutbounds.Add(currentOutbound);
+                }
             }
 
             // Add urltest outbound (auto selection based on latency)
@@ -1061,6 +1189,9 @@ public class CoreConfigSingboxService
             resultOutbounds.AddRange(prevOutbounds);
             resultOutbounds.AddRange(singboxConfig.outbounds);
             singboxConfig.outbounds = resultOutbounds;
+            singboxConfig.endpoints ??= new List<Endpoints4Sbox>();
+            resultEndpoints.AddRange(singboxConfig.endpoints);
+            singboxConfig.endpoints = resultEndpoints;
         }
         catch (Exception ex)
         {
@@ -1082,7 +1213,7 @@ public class CoreConfigSingboxService
     /// <returns>
     /// The outbound configuration for the next proxy in the chain, or null if no next proxy exists.
     /// </returns>
-    private async Task<Outbound4Sbox?> GenChainOutbounds(SubItem subItem, Outbound4Sbox outbound, string? prevOutboundTag, Outbound4Sbox? nextOutbound = null)
+    private async Task<BaseServer4Sbox?> GenChainOutbounds(SubItem subItem, BaseServer4Sbox outbound, string? prevOutboundTag, BaseServer4Sbox? nextOutbound = null)
     {
         try
         {
@@ -1098,11 +1229,7 @@ public class CoreConfigSingboxService
             if (nextNode is not null
                 && nextNode.ConfigType != EConfigType.Custom)
             {
-                if (nextOutbound == null)
-                {
-                    nextOutbound = JsonUtils.Deserialize<Outbound4Sbox>(txtOutbound);
-                    await GenOutbound(nextNode, nextOutbound);
-                }
+                nextOutbound ??= await GenServer(nextNode);
                 nextOutbound.tag = outbound.tag;
 
                 outbound.tag = $"mid-{outbound.tag}";
@@ -1426,13 +1553,24 @@ public class CoreConfigSingboxService
             return Global.ProxyTag;
         }
 
-        var txtOutbound = EmbedUtils.GetEmbedText(Global.SingboxSampleOutbound);
-        var outbound = JsonUtils.Deserialize<Outbound4Sbox>(txtOutbound);
-        await GenOutbound(node, outbound);
-        outbound.tag = Global.ProxyTag + node.IndexId.ToString();
-        singboxConfig.outbounds.Add(outbound);
+        var server = await GenServer(node);
+        if (server is null)
+        {
+            return Global.ProxyTag;
+        }
 
-        return outbound.tag;
+        server.tag = Global.ProxyTag + node.IndexId.ToString();
+        if (server is Endpoints4Sbox endpoint)
+        {
+            singboxConfig.endpoints ??= new();
+            singboxConfig.endpoints.Add(endpoint);
+        }
+        else if (server is Outbound4Sbox outbound)
+        {
+            singboxConfig.outbounds.Add(outbound);
+        }
+
+        return server.tag;
     }
 
     private async Task<int> GenDns(ProfileItem? node, SingboxConfig singboxConfig)

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1134,8 +1134,7 @@ public class CoreConfigSingboxService
             {
                 singboxConfig.route.rules.Add(new()
                 {
-                    action = "sniff",
-                    sniffer = new() { "dns", _config.Inbound.First().DestOverride }
+                    action = "sniff"
                 });
                 singboxConfig.route.rules.Add(new()
                 {

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1380,24 +1380,28 @@ public class CoreConfigSingboxService
         {
             return false;
         }
-        else if (address.StartsWith("geoip:!"))
-        {
-            return false;
-        }
         else if (address.Equals("geoip:private"))
         {
             rule.ip_is_private = true;
         }
         else if (address.StartsWith("geoip:"))
         {
-            if (rule.geoip is null)
-            { rule.geoip = new(); }
+            rule.geoip ??= new();
             rule.geoip?.Add(address.Substring(6));
+        }
+        else if (address.Equals("geoip:!private"))
+        {
+            rule.ip_is_private = false;
+        }
+        else if (address.StartsWith("geoip:!"))
+        {
+            rule.geoip ??= new();
+            rule.geoip?.Add(address.Substring(6));
+            rule.invert = true;
         }
         else
         {
-            if (rule.ip_cidr is null)
-            { rule.ip_cidr = new(); }
+            rule.ip_cidr ??= new();
             rule.ip_cidr?.Add(address);
         }
         return true;

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1309,22 +1309,24 @@ public class CoreConfigSingboxService
                 clash_mode = ERuleMode.Global.ToString()
             });
 
-            if (!(_config.Inbound.First().RouteOnly || _config.TunModeItem.EnableTun))
+            var domainStrategy = _config.RoutingBasicItem.DomainStrategy4Singbox.IsNullOrEmpty() ? null : _config.RoutingBasicItem.DomainStrategy4Singbox;
+            var defaultRouting = await ConfigHandler.GetDefaultRouting(_config);
+            if (defaultRouting.DomainStrategy4Singbox.IsNotEmpty())
             {
-                var domainStrategy = _config.RoutingBasicItem.DomainStrategy4Singbox.IsNullOrEmpty() ? null : _config.RoutingBasicItem.DomainStrategy4Singbox;
-                var defaultRouting = await ConfigHandler.GetDefaultRouting(_config);
-                if (defaultRouting.DomainStrategy4Singbox.IsNotEmpty())
-                {
-                    domainStrategy = defaultRouting.DomainStrategy4Singbox;
-                }
-                singboxConfig.route.rules.Add(new()
-                {
-                    action = "resolve",
-                    strategy = domainStrategy
-                });
+                domainStrategy = defaultRouting.DomainStrategy4Singbox;
+            }
+            var resolveRule = new Rule4Sbox
+            {
+                action = "resolve",
+                strategy = domainStrategy
+            };
+            if (_config.RoutingBasicItem.DomainStrategy == "IPOnDemand")
+            {
+                singboxConfig.route.rules.Add(resolveRule);
             }
 
             var routing = await ConfigHandler.GetDefaultRouting(_config);
+            var ipRules = new List<RulesItem>();
             if (routing != null)
             {
                 var rules = JsonUtils.Deserialize<List<RulesItem>>(routing.RuleSet);
@@ -1333,7 +1335,19 @@ public class CoreConfigSingboxService
                     if (item.Enabled)
                     {
                         await GenRoutingUserRule(item, singboxConfig);
+                        if (item.Ip != null && item.Ip.Count > 0)
+                        {
+                            ipRules.Add(item);
+                        }
                     }
+                }
+            }
+            if (_config.RoutingBasicItem.DomainStrategy == "IPIfNonMatch")
+            {
+                singboxConfig.route.rules.Add(resolveRule);
+                foreach (var item in ipRules)
+                {
+                    await GenRoutingUserRule(item, singboxConfig);
                 }
             }
         }

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1248,6 +1248,8 @@ public class CoreConfigSingboxService
     {
         try
         {
+            singboxConfig.route.final = Global.ProxyTag;
+
             if (_config.TunModeItem.EnableTun)
             {
                 singboxConfig.route.auto_detect_interface = true;

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1594,7 +1594,14 @@ public class CoreConfigSingboxService
             }
             singboxConfig.dns = dns4Sbox;
 
-            await GenDnsDomains(node, singboxConfig, item);
+            if (dns4Sbox.servers != null && dns4Sbox.servers.Count > 0 && dns4Sbox.servers.First().address.IsNullOrEmpty())
+            {
+                await GenDnsDomains(node, singboxConfig, item);
+            }
+            else
+            {
+                await GenDnsDomainsLegacy(node, singboxConfig, item);
+            }
         }
         catch (Exception ex)
         {
@@ -1685,6 +1692,59 @@ public class CoreConfigSingboxService
                 server = tag,
                 domain = [node?.Sni],
                 strategy = string.IsNullOrEmpty(dNSItem?.DomainStrategy4Freedom) ? null : dNSItem?.DomainStrategy4Freedom
+            });
+        }
+
+        singboxConfig.dns = dns4Sbox;
+        return await Task.FromResult(0);
+    }
+
+    private async Task<int> GenDnsDomainsLegacy(ProfileItem? node, SingboxConfig singboxConfig, DNSItem? dNSItem)
+    {
+        var dns4Sbox = singboxConfig.dns ?? new();
+        dns4Sbox.servers ??= [];
+        dns4Sbox.rules ??= [];
+
+        var tag = "local_local";
+        dns4Sbox.servers.Add(new()
+        {
+            tag = tag,
+            address = string.IsNullOrEmpty(dNSItem?.DomainDNSAddress) ? Global.SingboxDomainDNSAddress.FirstOrDefault() : dNSItem?.DomainDNSAddress,
+            detour = Global.DirectTag,
+            strategy = string.IsNullOrEmpty(dNSItem?.DomainStrategy4Freedom) ? null : dNSItem?.DomainStrategy4Freedom,
+        });
+        dns4Sbox.rules.Insert(0, new()
+        {
+            server = tag,
+            clash_mode = ERuleMode.Direct.ToString()
+        });
+        dns4Sbox.rules.Insert(0, new()
+        {
+            server = dns4Sbox.servers.Where(t => t.detour == Global.ProxyTag).Select(t => t.tag).FirstOrDefault() ?? "remote",
+            clash_mode = ERuleMode.Global.ToString()
+        });
+
+        var lstDomain = singboxConfig.outbounds
+                       .Where(t => t.server.IsNotEmpty() && Utils.IsDomain(t.server))
+                       .Select(t => t.server)
+                       .Distinct()
+                       .ToList();
+        if (lstDomain != null && lstDomain.Count > 0)
+        {
+            dns4Sbox.rules.Insert(0, new()
+            {
+                server = tag,
+                domain = lstDomain
+            });
+        }
+
+        //Tun2SocksAddress
+        if (_config.TunModeItem.EnableTun && node?.ConfigType == EConfigType.SOCKS && Utils.IsDomain(node?.Sni))
+        {
+            dns4Sbox.rules.Insert(0, new()
+            {
+                server = tag,
+                domain = [node?.Sni]
             });
         }
 

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -740,6 +740,11 @@ public class CoreConfigSingboxService
                         outbound.mtu = node.ShortId.IsNullOrEmpty() ? Global.TunMtus.First() : node.ShortId.ToInt();
                         break;
                     }
+                case EConfigType.Anytls:
+                    {
+                        outbound.password = node.Id;
+                        break;
+                    }
             }
 
             await GenOutboundTls(node, outbound);

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1683,8 +1683,7 @@ public class CoreConfigSingboxService
         dns4Sbox.rules.Insert(0, new()
         {
             server = tag,
-            clash_mode = ERuleMode.Direct.ToString(),
-            strategy = string.IsNullOrEmpty(dNSItem?.DomainStrategy4Freedom) ? null : dNSItem?.DomainStrategy4Freedom
+            clash_mode = ERuleMode.Direct.ToString()
         });
         dns4Sbox.rules.Insert(0, new()
         {

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -790,7 +790,6 @@ public class CoreConfigSingboxService
         try
         {
             endpoint.address = Utils.String2List(node.RequestHost);
-            endpoint.listen_port = Utils.GetFreePort();
             endpoint.type = Global.ProtocolTypes[node.ConfigType];
 
             if (Utils.IsDomain(node.Address))

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigV2rayService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigV2rayService.cs
@@ -120,7 +120,7 @@ public class CoreConfigV2rayService
                 {
                     continue;
                 }
-                if (it.ConfigType is EConfigType.Hysteria2 or EConfigType.TUIC)
+                if (it.ConfigType is EConfigType.Hysteria2 or EConfigType.TUIC or EConfigType.Anytls)
                 {
                     continue;
                 }
@@ -640,7 +640,8 @@ public class CoreConfigV2rayService
         if (node == null
             || node.ConfigType == EConfigType.Custom
             || node.ConfigType == EConfigType.Hysteria2
-            || node.ConfigType == EConfigType.TUIC)
+            || node.ConfigType == EConfigType.TUIC
+            || node.ConfigType == EConfigType.Anytls)
         {
             return Global.ProxyTag;
         }
@@ -1222,6 +1223,7 @@ public class CoreConfigV2rayService
                     && prevNode.ConfigType != EConfigType.Custom
                     && prevNode.ConfigType != EConfigType.Hysteria2
                     && prevNode.ConfigType != EConfigType.TUIC
+                    && prevNode.ConfigType != EConfigType.Anytls
                     && Utils.IsDomain(prevNode.Address))
                 {
                     domainList.Add(prevNode.Address);
@@ -1233,6 +1235,7 @@ public class CoreConfigV2rayService
                     && nextNode.ConfigType != EConfigType.Custom
                     && nextNode.ConfigType != EConfigType.Hysteria2
                     && nextNode.ConfigType != EConfigType.TUIC
+                    && nextNode.ConfigType != EConfigType.Anytls
                     && Utils.IsDomain(nextNode.Address))
                 {
                     domainList.Add(nextNode.Address);

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigV2rayService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigV2rayService.cs
@@ -1426,7 +1426,8 @@ public class CoreConfigV2rayService
                         if (prevNode is not null
                             && prevNode.ConfigType != EConfigType.Custom
                             && prevNode.ConfigType != EConfigType.Hysteria2
-                            && prevNode.ConfigType != EConfigType.TUIC)
+                            && prevNode.ConfigType != EConfigType.TUIC
+                            && prevNode.ConfigType != EConfigType.Anytls)
                         {
                             var prevOutbound = JsonUtils.Deserialize<Outbounds4Ray>(txtOutbound);
                             await GenOutbound(prevNode, prevOutbound);
@@ -1495,7 +1496,8 @@ public class CoreConfigV2rayService
             if (nextNode is not null
                 && nextNode.ConfigType != EConfigType.Custom
                 && nextNode.ConfigType != EConfigType.Hysteria2
-                && nextNode.ConfigType != EConfigType.TUIC)
+                && nextNode.ConfigType != EConfigType.TUIC
+                && nextNode.ConfigType != EConfigType.Anytls)
             {
                 if (nextOutbound == null)
                 {

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigV2rayService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigV2rayService.cs
@@ -1350,7 +1350,8 @@ public class CoreConfigV2rayService
             if (prevNode is not null
                 && prevNode.ConfigType != EConfigType.Custom
                 && prevNode.ConfigType != EConfigType.Hysteria2
-                && prevNode.ConfigType != EConfigType.TUIC)
+                && prevNode.ConfigType != EConfigType.TUIC
+                && prevNode.ConfigType != EConfigType.Anytls)
             {
                 var prevOutbound = JsonUtils.Deserialize<Outbounds4Ray>(txtOutbound);
                 await GenOutbound(prevNode, prevOutbound);

--- a/v2rayN/ServiceLib/Services/SpeedtestService.cs
+++ b/v2rayN/ServiceLib/Services/SpeedtestService.cs
@@ -358,8 +358,8 @@ public class SpeedtestService
     private List<List<ServerTestItem>> GetTestBatchItem(List<ServerTestItem> lstSelected, int pageSize)
     {
         List<List<ServerTestItem>> lstTest = new();
-        var lst1 = lstSelected.Where(t => t.ConfigType is not (EConfigType.Hysteria2 or EConfigType.TUIC)).ToList();
-        var lst2 = lstSelected.Where(t => t.ConfigType is EConfigType.Hysteria2 or EConfigType.TUIC).ToList();
+        var lst1 = lstSelected.Where(t => t.ConfigType is not (EConfigType.Hysteria2 or EConfigType.TUIC or EConfigType.Anytls)).ToList();
+        var lst2 = lstSelected.Where(t => t.ConfigType is EConfigType.Hysteria2 or EConfigType.TUIC or EConfigType.Anytls).ToList();
 
         for (var num = 0; num < (int)Math.Ceiling(lst1.Count * 1.0 / pageSize); num++)
         {

--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -20,6 +20,7 @@ public class MainWindowViewModel : MyReactiveObject
     public ReactiveCommand<Unit, Unit> AddHysteria2ServerCmd { get; }
     public ReactiveCommand<Unit, Unit> AddTuicServerCmd { get; }
     public ReactiveCommand<Unit, Unit> AddWireguardServerCmd { get; }
+    public ReactiveCommand<Unit, Unit> AddAnytlsServerCmd { get; }
     public ReactiveCommand<Unit, Unit> AddCustomServerCmd { get; }
     public ReactiveCommand<Unit, Unit> AddServerViaClipboardCmd { get; }
     public ReactiveCommand<Unit, Unit> AddServerViaScanCmd { get; }
@@ -110,6 +111,10 @@ public class MainWindowViewModel : MyReactiveObject
         AddWireguardServerCmd = ReactiveCommand.CreateFromTask(async () =>
         {
             await AddServerAsync(true, EConfigType.WireGuard);
+        });
+        AddAnytlsServerCmd = ReactiveCommand.CreateFromTask(async () =>
+        {
+            await AddServerAsync(true, EConfigType.Anytls);
         });
         AddCustomServerCmd = ReactiveCommand.CreateFromTask(async () =>
         {

--- a/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml
@@ -533,6 +533,26 @@
                         HorizontalAlignment="Left"
                         Watermark="1500" />
                 </Grid>
+                <Grid
+                    x:Name="gridAnytls"
+                    Grid.Row="2"
+                    ColumnDefinitions="180,Auto"
+                    IsVisible="False"
+                    RowDefinitions="Auto,Auto,Auto">
+
+                    <TextBlock
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        Margin="{StaticResource Margin4}"
+                        VerticalAlignment="Center"
+                        Text="{x:Static resx:ResUI.TbId3}" />
+                    <TextBox
+                        x:Name="txtId10"
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        Width="400"
+                        Margin="{StaticResource Margin4}" />
+                </Grid>
 
                 <Separator
                     x:Name="sepa2"

--- a/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml.cs
@@ -102,6 +102,11 @@ public partial class AddServerWindow : WindowBase<AddServerViewModel>
                 gridTls.IsVisible = false;
 
                 break;
+
+            case EConfigType.Anytls:
+                gridAnytls.IsVisible = true;
+                cmbCoreType.IsEnabled = false;
+                break;
         }
         cmbStreamSecurity.ItemsSource = lstStreamSecurity;
 
@@ -166,6 +171,10 @@ public partial class AddServerWindow : WindowBase<AddServerViewModel>
                     this.Bind(ViewModel, vm => vm.SelectedSource.Path, v => v.txtPath9.Text).DisposeWith(disposables);
                     this.Bind(ViewModel, vm => vm.SelectedSource.RequestHost, v => v.txtRequestHost9.Text).DisposeWith(disposables);
                     this.Bind(ViewModel, vm => vm.SelectedSource.ShortId, v => v.txtShortId9.Text).DisposeWith(disposables);
+                    break;
+
+                case EConfigType.Anytls:
+                    this.Bind(ViewModel, vm => vm.SelectedSource.Id, v => v.txtId10.Text).DisposeWith(disposables);
                     break;
             }
             this.Bind(ViewModel, vm => vm.SelectedSource.Network, v => v.cmbNetwork.SelectedValue).DisposeWith(disposables);

--- a/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml.cs
@@ -105,6 +105,7 @@ public partial class AddServerWindow : WindowBase<AddServerViewModel>
 
             case EConfigType.Anytls:
                 gridAnytls.IsVisible = true;
+                lstStreamSecurity.Add(Global.StreamSecurityReality);
                 cmbCoreType.IsEnabled = false;
                 break;
         }

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml
@@ -46,6 +46,7 @@
                         <Separator />
                         <MenuItem x:Name="menuAddHysteria2Server" Header="{x:Static resx:ResUI.menuAddHysteria2Server}" />
                         <MenuItem x:Name="menuAddTuicServer" Header="{x:Static resx:ResUI.menuAddTuicServer}" />
+                        <MenuItem x:Name="menuAddAnytlsServer" Header="{x:Static resx:ResUI.menuAddAnytlsServer}" />
                     </MenuItem>
 
                     <MenuItem Padding="8,0">

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
@@ -83,6 +83,7 @@ public partial class MainWindow : WindowBase<MainWindowViewModel>
             this.BindCommand(ViewModel, vm => vm.AddHysteria2ServerCmd, v => v.menuAddHysteria2Server).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddTuicServerCmd, v => v.menuAddTuicServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddWireguardServerCmd, v => v.menuAddWireguardServer).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.AddAnytlsServerCmd, v => v.menuAddAnytlsServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddCustomServerCmd, v => v.menuAddCustomServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddServerViaClipboardCmd, v => v.menuAddServerViaClipboard).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddServerViaScanCmd, v => v.menuAddServerViaScan).DisposeWith(disposables);

--- a/v2rayN/v2rayN.Desktop/Views/RoutingSettingWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/RoutingSettingWindow.axaml.cs
@@ -117,7 +117,7 @@ public partial class RoutingSettingWindow : WindowBase<RoutingSettingViewModel>
 
     private void linkdomainStrategy4Singbox_Click(object? sender, RoutedEventArgs e)
     {
-        ProcUtils.ProcessStart("https://sing-box.sagernet.org/zh/configuration/shared/listen/#domain_strategy");
+        ProcUtils.ProcessStart("https://sing-box.sagernet.org/zh/configuration/route/rule_action/#strategy");
     }
 
     private void btnCancel_Click(object? sender, RoutedEventArgs e)

--- a/v2rayN/v2rayN/Views/AddServerWindow.xaml
+++ b/v2rayN/v2rayN/Views/AddServerWindow.xaml
@@ -707,6 +707,35 @@
                         materialDesign:HintAssist.Hint="1500"
                         Style="{StaticResource DefTextBox}" />
                 </Grid>
+                <Grid
+                    x:Name="gridAnytls"
+                    Grid.Row="2"
+                    Visibility="Hidden">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="180" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        Margin="{StaticResource Margin4}"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource ToolbarTextBlock}"
+                        Text="{x:Static resx:ResUI.TbId3}" />
+                    <TextBox
+                        x:Name="txtId10"
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        Width="400"
+                        Margin="{StaticResource Margin4}"
+                        Style="{StaticResource DefTextBox}" />
+                </Grid>
 
                 <Separator
                     x:Name="sepa2"

--- a/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
@@ -96,6 +96,10 @@ public partial class AddServerWindow
                 gridTls.Visibility = Visibility.Collapsed;
 
                 break;
+            case EConfigType.Anytls:
+                gridAnytls.Visibility = Visibility.Visible;
+                cmbCoreType.IsEnabled = false;
+                break;
         }
         cmbStreamSecurity.ItemsSource = lstStreamSecurity;
 
@@ -160,6 +164,10 @@ public partial class AddServerWindow
                     this.Bind(ViewModel, vm => vm.SelectedSource.Path, v => v.txtPath9.Text).DisposeWith(disposables);
                     this.Bind(ViewModel, vm => vm.SelectedSource.RequestHost, v => v.txtRequestHost9.Text).DisposeWith(disposables);
                     this.Bind(ViewModel, vm => vm.SelectedSource.ShortId, v => v.txtShortId9.Text).DisposeWith(disposables);
+                    break;
+
+                case EConfigType.Anytls:
+                    this.Bind(ViewModel, vm => vm.SelectedSource.Id, v => v.txtId10.Text).DisposeWith(disposables);
                     break;
             }
             this.Bind(ViewModel, vm => vm.SelectedSource.Network, v => v.cmbNetwork.Text).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
@@ -96,6 +96,7 @@ public partial class AddServerWindow
                 gridTls.Visibility = Visibility.Collapsed;
 
                 break;
+
             case EConfigType.Anytls:
                 gridAnytls.Visibility = Visibility.Visible;
                 cmbCoreType.IsEnabled = false;

--- a/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
@@ -99,6 +99,7 @@ public partial class AddServerWindow
             case EConfigType.Anytls:
                 gridAnytls.Visibility = Visibility.Visible;
                 cmbCoreType.IsEnabled = false;
+                lstStreamSecurity.Add(Global.StreamSecurityReality);
                 break;
         }
         cmbStreamSecurity.ItemsSource = lstStreamSecurity;

--- a/v2rayN/v2rayN/Views/MainWindow.xaml
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml
@@ -108,6 +108,10 @@
                                     x:Name="menuAddTuicServer"
                                     Height="{StaticResource MenuItemHeight}"
                                     Header="{x:Static resx:ResUI.menuAddTuicServer}" />
+                                <MenuItem
+                                    x:Name="menuAddAnytlsServer"
+                                    Height="{StaticResource MenuItemHeight}"
+                                    Header="{x:Static resx:ResUI.menuAddAnytlsServer}" />
                             </MenuItem>
                         </Menu>
                         <Separator />

--- a/v2rayN/v2rayN/Views/MainWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml.cs
@@ -80,6 +80,7 @@ public partial class MainWindow
             this.BindCommand(ViewModel, vm => vm.AddHysteria2ServerCmd, v => v.menuAddHysteria2Server).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddTuicServerCmd, v => v.menuAddTuicServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddWireguardServerCmd, v => v.menuAddWireguardServer).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.AddAnytlsServerCmd, v => v.menuAddAnytlsServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddCustomServerCmd, v => v.menuAddCustomServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddServerViaClipboardCmd, v => v.menuAddServerViaClipboard).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddServerViaScanCmd, v => v.menuAddServerViaScan).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/RoutingSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/RoutingSettingWindow.xaml.cs
@@ -122,7 +122,7 @@ public partial class RoutingSettingWindow
 
     private void linkdomainStrategy4Singbox_Click(object sender, RoutedEventArgs e)
     {
-        ProcUtils.ProcessStart("https://sing-box.sagernet.org/zh/configuration/shared/listen/#domain_strategy");
+        ProcUtils.ProcessStart("https://sing-box.sagernet.org/zh/configuration/route/rule_action/#strategy");
     }
 
     private void btnCancel_Click(object sender, System.Windows.RoutedEventArgs e)


### PR DESCRIPTION
### Features

- 支持 anytls 配置
- 支持类似于 Xray 的 `IPIfNonMatch` 等域名策略

### Changes

- dns 配置配置迁移为 1.12 版本
- 将 sniff 配置迁移到 Rule Action
- 迁移 WireGuard 到 endpoint
- 为每个带域名的出站添加 `domain_resolver`，`direct` 出站不添加

### Removed

- `sniff_override_destination`，因为核心已将其弃用

### Notes

- **关于 `sniff_override_destination` 移除：**
  - 请确保 DNS 配置正确且未被污染（包括 sing-box 和 Windows 网络设置）。如果传入被污染的 IP 地址，可能导致无法访问，除非服务器端配置了 `sniff_override_destination`。
  - 建议将代理出站的域名使用远程 DNS 服务器解析，避免解析为国内 IP，会导致屏蔽回国流量的服务端访问失败（如 gstatic.com 等）。

- **`resolve` 规则动作说明：**
  - 仅对目标为域名的规则生效，不影响 `sniff` 解析出的域名。
  - 后续所有规则匹配和出站均基于 `resolve` 动作解析出的 IP 地址。

- **路由域名策略说明：**
  - `AsIs`：原样生成用户规则，不添加 `resolve` 动作。
  - `IPIfNonMatch`：先生成用户规则，再添加 `resolve` 动作并再次生成含 IP 的用户规则。
  - `IPOnDemand`：先添加 `resolve` 动作，再原样生成用户规则。

- **兼容性：**
  - DNS 配置暂时兼容旧版写法。

- **sing-box DNS 设置：**
  - `Outbound 域名解析地址` 可填写 `tag://dns-local`，需在自定义 DNS 配置中添加对应的 `dns-local` 服务器。
