### PR TITLE
Adds sing-box fragment support

### DIFF
--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -179,6 +179,9 @@ public class Tls4Sbox
     public List<string>? alpn { get; set; }
     public Utls4Sbox? utls { get; set; }
     public Reality4Sbox? reality { get; set; }
+    public bool? fragment { get; set; }
+    public string? fragment_fallback_delay { get; set; }
+    public bool? record_fragment { get; set; }
 }
 
 public class Multiplex4Sbox

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -3238,7 +3238,7 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
-        ///   查找类似 Use Xray and enable non-Tun mode, which conflicts with the group previous proxy 的本地化字符串。
+        ///   查找类似 which conflicts with the group previous proxy 的本地化字符串。
         /// </summary>
         public static string TbSettingsEnableFragmentTips {
             get {

--- a/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
@@ -1105,7 +1105,7 @@
     <value>افزودن سرور [HTTP]</value>
   </data>
   <data name="TbSettingsEnableFragmentTips" xml:space="preserve">
-    <value>از Xray استفاده کنید و حالت non-Tun را فعال کنید، که با پراکسی قبلی گروه در تضاد است</value>
+    <value>which conflicts with the group previous proxy</value>
   </data>
   <data name="TbSettingsEnableFragment" xml:space="preserve">
     <value>فعال کردن فرگمنت</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.hu.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.hu.resx
@@ -1105,7 +1105,7 @@
     <value>HTTP konfiguráció hozzáadása</value>
   </data>
   <data name="TbSettingsEnableFragmentTips" xml:space="preserve">
-    <value>Használja az Xray-t és engedélyezze a nem Tun módot, ami ütközik a csoport előző proxyjával</value>
+    <value>which conflicts with the group previous proxy</value>
   </data>
   <data name="TbSettingsEnableFragment" xml:space="preserve">
     <value>Fragment engedélyezése</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1105,7 +1105,7 @@
     <value>Add [HTTP] Configuration</value>
   </data>
   <data name="TbSettingsEnableFragmentTips" xml:space="preserve">
-    <value>Use Xray and enable non-Tun mode, which conflicts with the group previous proxy</value>
+    <value>which conflicts with the group previous proxy</value>
   </data>
   <data name="TbSettingsEnableFragment" xml:space="preserve">
     <value>Enable fragment</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1105,7 +1105,7 @@
     <value>Добавить сервер [HTTP]</value>
   </data>
   <data name="TbSettingsEnableFragmentTips" xml:space="preserve">
-    <value>Используйте Xray и отключите режим TUN, так как он конфликтует с предыдущим прокси-сервером группы</value>
+    <value>which conflicts with the group previous proxy</value>
   </data>
   <data name="TbSettingsEnableFragment" xml:space="preserve">
     <value>Включить фрагментацию (Fragment)</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1102,7 +1102,7 @@
     <value>添加 [HTTP] 配置文件</value>
   </data>
   <data name="TbSettingsEnableFragmentTips" xml:space="preserve">
-    <value>使用 Xray 且非 Tun 模式启用，和分组前置代理冲突</value>
+    <value>和分组前置代理冲突</value>
   </data>
   <data name="TbSettingsEnableFragment" xml:space="preserve">
     <value>启用分片 (Fragment)</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -1102,7 +1102,7 @@
     <value>新增 [HTTP] 設定檔</value>
   </data>
   <data name="TbSettingsEnableFragmentTips" xml:space="preserve">
-    <value>使用 Xray 且非 Tun 模式啟用，和分組前置代理衝突</value>
+    <value>和分組前置代理衝突</value>
   </data>
   <data name="TbSettingsEnableFragment" xml:space="preserve">
     <value>啟用分片（Fragment）</value>

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -890,6 +890,7 @@ public class CoreConfigSingboxService
                 var tls = new Tls4Sbox()
                 {
                     enabled = true,
+                    record_fragment = _config.CoreBasicItem.EnableFragment,
                     server_name = server_name,
                     insecure = Utils.ToBool(node.AllowInsecure.IsNullOrEmpty() ? _config.CoreBasicItem.DefAllowInsecure.ToString().ToLower() : node.AllowInsecure),
                     alpn = node.GetAlpn(),


### PR DESCRIPTION
record_fragment 对 tls 握手分片

而 fragment 是逐段单独 Write 并等待 Ack，若失败则回退到延时 fragment_fallback_delay 发送

两者都只作用于第一次 Write

https://github.com/SagerNet/sing-box/blob/fed9ad904646084649b7d05615d1afa6cbdabb35/common/tlsfragment/conn.go#L43