### PR TITLE
Add Auto Route option to Tun mode settings

### DIFF
--- a/v2rayN/ServiceLib/Models/ConfigItems.cs
+++ b/v2rayN/ServiceLib/Models/ConfigItems.cs
@@ -142,6 +142,7 @@ public class CoreTypeItem
 public class TunModeItem
 {
     public bool EnableTun { get; set; }
+    public bool AutoRoute { get; set; } = true;
     public bool StrictRoute { get; set; } = true;
     public string Stack { get; set; }
     public int Mtu { get; set; }

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -628,6 +628,7 @@ public class CoreConfigSingboxService
                 var tunInbound = JsonUtils.Deserialize<Inbound4Sbox>(EmbedUtils.GetEmbedText(Global.TunSingboxInboundFileName)) ?? new Inbound4Sbox { };
                 tunInbound.interface_name = Utils.IsOSX() ? $"utun{new Random().Next(99)}" : "singbox_tun";
                 tunInbound.mtu = _config.TunModeItem.Mtu;
+                tunInbound.auto_route = _config.TunModeItem.AutoRoute;
                 tunInbound.strict_route = _config.TunModeItem.StrictRoute;
                 tunInbound.stack = _config.TunModeItem.Stack;
                 if (_config.TunModeItem.EnableIPv6Address == false)

--- a/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
@@ -84,6 +84,7 @@ public class OptionSettingViewModel : MyReactiveObject
 
     #region Tun mode
 
+    [Reactive] public bool TunAutoRoute { get; set; }
     [Reactive] public bool TunStrictRoute { get; set; }
     [Reactive] public string TunStack { get; set; }
     [Reactive] public int TunMtu { get; set; }
@@ -201,6 +202,7 @@ public class OptionSettingViewModel : MyReactiveObject
 
         #region Tun mode
 
+        TunAutoRoute = _config.TunModeItem.AutoRoute;
         TunStrictRoute = _config.TunModeItem.StrictRoute;
         TunStack = _config.TunModeItem.Stack;
         TunMtu = _config.TunModeItem.Mtu;
@@ -354,6 +356,7 @@ public class OptionSettingViewModel : MyReactiveObject
         _config.SystemProxyItem.SystemProxyAdvancedProtocol = systemProxyAdvancedProtocol;
 
         //tun mode
+        _config.TunModeItem.AutoRoute = TunAutoRoute;
         _config.TunModeItem.StrictRoute = TunStrictRoute;
         _config.TunModeItem.Stack = TunStack;
         _config.TunModeItem.Mtu = TunMtu;

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
@@ -729,71 +729,84 @@
                     Margin="{StaticResource Margin4}"
                     ColumnDefinitions="Auto,Auto,Auto"
                     DockPanel.Dock="Top"
-                    RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                    RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
 
                     <TextBlock
                         Grid.Row="2"
+                        Grid.Column="0"
+                        Margin="{StaticResource Margin4}"
+                        VerticalAlignment="Center"
+                        Text="Auto Route" />
+                    <ToggleSwitch
+                        x:Name="togAutoRoute"
+                        Grid.Row="2"
+                        Grid.Column="1"
+                        Margin="{StaticResource Margin4}"
+                        HorizontalAlignment="Left" />
+
+                    <TextBlock
+                        Grid.Row="3"
                         Grid.Column="0"
                         Margin="{StaticResource Margin4}"
                         VerticalAlignment="Center"
                         Text="Strict Route" />
                     <ToggleSwitch
                         x:Name="togStrictRoute"
-                        Grid.Row="2"
+                        Grid.Row="3"
                         Grid.Column="1"
                         Margin="{StaticResource Margin4}"
                         HorizontalAlignment="Left" />
 
                     <TextBlock
-                        Grid.Row="3"
+                        Grid.Row="4"
                         Grid.Column="0"
                         Margin="{StaticResource Margin4}"
                         VerticalAlignment="Center"
                         Text="Stack" />
                     <ComboBox
                         x:Name="cmbStack"
-                        Grid.Row="3"
+                        Grid.Row="4"
                         Grid.Column="1"
                         Width="200"
                         Margin="{StaticResource Margin4}"
                         HorizontalAlignment="Left" />
 
                     <TextBlock
-                        Grid.Row="4"
+                        Grid.Row="5"
                         Grid.Column="0"
                         Margin="{StaticResource Margin4}"
                         VerticalAlignment="Center"
                         Text="Mtu" />
                     <ComboBox
                         x:Name="cmbMtu"
-                        Grid.Row="4"
+                        Grid.Row="5"
                         Grid.Column="1"
                         Width="200"
                         Margin="{StaticResource Margin4}"
                         HorizontalAlignment="Left" />
 
                     <TextBlock
-                        Grid.Row="5"
+                        Grid.Row="6"
                         Grid.Column="0"
                         Margin="{StaticResource Margin4}"
                         VerticalAlignment="Center"
                         Text="{x:Static resx:ResUI.TbSettingsEnableExInbound}" />
                     <ToggleSwitch
                         x:Name="togEnableExInbound"
-                        Grid.Row="5"
+                        Grid.Row="6"
                         Grid.Column="1"
                         Margin="{StaticResource Margin4}"
                         HorizontalAlignment="Left" />
 
                     <TextBlock
-                        Grid.Row="6"
+                        Grid.Row="7"
                         Grid.Column="0"
                         Margin="{StaticResource Margin4}"
                         VerticalAlignment="Center"
                         Text="{x:Static resx:ResUI.TbSettingsEnableIPv6Address}" />
                     <ToggleSwitch
                         x:Name="togEnableIPv6Address"
-                        Grid.Row="6"
+                        Grid.Row="7"
                         Grid.Column="1"
                         Margin="{StaticResource Margin4}"
                         HorizontalAlignment="Left" />

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
@@ -105,6 +105,7 @@ public partial class OptionSettingWindow : WindowBase<OptionSettingViewModel>
             this.Bind(ViewModel, vm => vm.systemProxyAdvancedProtocol, v => v.cmbsystemProxyAdvancedProtocol.SelectedValue).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.systemProxyExceptions, v => v.txtsystemProxyExceptions.Text).DisposeWith(disposables);
 
+            this.Bind(ViewModel, vm => vm.TunAutoRoute, v => v.togAutoRoute.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.TunStrictRoute, v => v.togStrictRoute.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.TunStack, v => v.cmbStack.SelectedValue).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.TunMtu, v => v.cmbMtu.SelectedValue).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
@@ -1023,6 +1023,7 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
@@ -1036,9 +1037,9 @@
                         Margin="{StaticResource Margin8}"
                         VerticalAlignment="Center"
                         Style="{StaticResource ToolbarTextBlock}"
-                        Text="Strict Route" />
+                        Text="Auto Route" />
                     <ToggleButton
-                        x:Name="togStrictRoute"
+                        x:Name="togAutoRoute"
                         Grid.Row="2"
                         Grid.Column="1"
                         Margin="{StaticResource Margin8}"
@@ -1050,10 +1051,24 @@
                         Margin="{StaticResource Margin8}"
                         VerticalAlignment="Center"
                         Style="{StaticResource ToolbarTextBlock}"
+                        Text="Strict Route" />
+                    <ToggleButton
+                        x:Name="togStrictRoute"
+                        Grid.Row="3"
+                        Grid.Column="1"
+                        Margin="{StaticResource Margin8}"
+                        HorizontalAlignment="Left" />
+
+                    <TextBlock
+                        Grid.Row="4"
+                        Grid.Column="0"
+                        Margin="{StaticResource Margin8}"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource ToolbarTextBlock}"
                         Text="Stack" />
                     <ComboBox
                         x:Name="cmbStack"
-                        Grid.Row="3"
+                        Grid.Row="4"
                         Grid.Column="1"
                         Width="200"
                         Margin="{StaticResource Margin8}"
@@ -1061,7 +1076,7 @@
                         Style="{StaticResource DefComboBox}" />
 
                     <TextBlock
-                        Grid.Row="4"
+                        Grid.Row="5"
                         Grid.Column="0"
                         Margin="{StaticResource Margin8}"
                         VerticalAlignment="Center"
@@ -1069,7 +1084,7 @@
                         Text="Mtu" />
                     <ComboBox
                         x:Name="cmbMtu"
-                        Grid.Row="4"
+                        Grid.Row="5"
                         Grid.Column="1"
                         Width="200"
                         Margin="{StaticResource Margin8}"
@@ -1077,7 +1092,7 @@
                         Style="{StaticResource DefComboBox}" />
 
                     <TextBlock
-                        Grid.Row="5"
+                        Grid.Row="6"
                         Grid.Column="0"
                         Margin="{StaticResource Margin8}"
                         VerticalAlignment="Center"
@@ -1085,13 +1100,13 @@
                         Text="{x:Static resx:ResUI.TbSettingsEnableExInbound}" />
                     <ToggleButton
                         x:Name="togEnableExInbound"
-                        Grid.Row="5"
+                        Grid.Row="6"
                         Grid.Column="1"
                         Margin="{StaticResource Margin8}"
                         HorizontalAlignment="Left" />
 
                     <TextBlock
-                        Grid.Row="6"
+                        Grid.Row="7"
                         Grid.Column="0"
                         Margin="{StaticResource Margin8}"
                         VerticalAlignment="Center"
@@ -1099,7 +1114,7 @@
                         Text="{x:Static resx:ResUI.TbSettingsEnableIPv6Address}" />
                     <ToggleButton
                         x:Name="togEnableIPv6Address"
-                        Grid.Row="6"
+                        Grid.Row="7"
                         Grid.Column="1"
                         Margin="{StaticResource Margin8}"
                         HorizontalAlignment="Left" />
@@ -1231,3 +1246,4 @@
         </TabControl>
     </DockPanel>
 </base:WindowBase>
+

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
@@ -117,6 +117,7 @@ public partial class OptionSettingWindow
             this.Bind(ViewModel, vm => vm.systemProxyAdvancedProtocol, v => v.cmbsystemProxyAdvancedProtocol.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.systemProxyExceptions, v => v.txtsystemProxyExceptions.Text).DisposeWith(disposables);
 
+            this.Bind(ViewModel, vm => vm.TunAutoRoute, v => v.togAutoRoute.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.TunStrictRoute, v => v.togStrictRoute.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.TunStack, v => v.cmbStack.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.TunMtu, v => v.cmbMtu.Text).DisposeWith(disposables);


### PR DESCRIPTION
Introduces a new 'Auto Route' option for Tun mode in the configuration, view models, and UI. Updates both Avalonia and WPF option setting windows to allow users to enable or disable automatic routing for Tun mode. Also ensures the new setting is properly bound and saved in the configuration.
This allows users to use Tun mode without setting the default route to Tun, for example, forwarding data from another network interface to Tun via IP routing.