### PR TITLE
Fixed Failed Gen Default Configuration

### DIFF
--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigSingboxService.cs
@@ -1658,6 +1658,7 @@ public class CoreConfigSingboxService
         {
             tag = Global.SingboxHostsDNSTag,
             type = "hosts",
+            predefined = new(),
         };
         if (simpleDNSItem.AddCommonHosts == true)
         {


### PR DESCRIPTION
不开启 `添加常用 DNS hosts` 触发