### PR TITLE
Fix tun

### DIFF
--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/CoreConfigSingboxService.cs
@@ -64,7 +64,7 @@ public partial class CoreConfigSingboxService(Config config)
 
             await GenRouting(singboxConfig);
 
-            await GenDns(singboxConfig);
+            await GenDns(node, singboxConfig);
 
             await GenExperimental(singboxConfig);
 
@@ -421,7 +421,7 @@ public partial class CoreConfigSingboxService(Config config)
             }
             await GenOutboundsList(proxyProfiles, singboxConfig);
 
-            await GenDns(singboxConfig);
+            await GenDns(null, singboxConfig);
             await ConvertGeo2Ruleset(singboxConfig);
 
             ret.Success = true;

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxDnsService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxDnsService.cs
@@ -2,14 +2,14 @@ namespace ServiceLib.Services.CoreConfig;
 
 public partial class CoreConfigSingboxService
 {
-    private async Task<int> GenDns(SingboxConfig singboxConfig)
+    private async Task<int> GenDns(ProfileItem? node, SingboxConfig singboxConfig)
     {
         try
         {
             var item = await AppManager.Instance.GetDNSItem(ECoreType.sing_box);
             if (item != null && item.Enabled == true)
             {
-                return await GenDnsCompatible(singboxConfig);
+                return await GenDnsCompatible(node, singboxConfig);
             }
 
             var simpleDNSItem = _config.SimpleDNSItem;
@@ -19,6 +19,7 @@ public partial class CoreConfigSingboxService
             singboxConfig.dns ??= new Dns4Sbox();
             singboxConfig.dns.independent_cache = true;
 
+            // final dns
             var routing = await ConfigHandler.GetDefaultRouting(_config);
             var useDirectDns = false;
             if (routing != null)
@@ -32,6 +33,17 @@ public partial class CoreConfigSingboxService
                                    lastRule.Ip?.Contains("0.0.0.0/0") == true);
             }
             singboxConfig.dns.final = useDirectDns ? Global.SingboxDirectDNSTag : Global.SingboxRemoteDNSTag;
+
+            // Tun2SocksAddress
+            if (node != null && Utils.IsDomain(node.Address))
+            {
+                singboxConfig.dns.rules ??= new List<Rule4Sbox>();
+                singboxConfig.dns.rules.Insert(0, new Rule4Sbox
+                {
+                    server = Global.SingboxOutboundResolverTag,
+                    domain = [node.Address],
+                });
+            }
         }
         catch (Exception ex)
         {
@@ -289,7 +301,7 @@ public partial class CoreConfigSingboxService
         return 0;
     }
 
-    private async Task<int> GenDnsCompatible(SingboxConfig singboxConfig)
+    private async Task<int> GenDnsCompatible(ProfileItem? node, SingboxConfig singboxConfig)
     {
         try
         {
@@ -318,6 +330,17 @@ public partial class CoreConfigSingboxService
             else
             {
                 await GenDnsDomainsLegacyCompatible(singboxConfig, item);
+            }
+
+            // Tun2SocksAddress
+            if (node != null && Utils.IsDomain(node.Address))
+            {
+                singboxConfig.dns.rules ??= new List<Rule4Sbox>();
+                singboxConfig.dns.rules.Insert(0, new Rule4Sbox
+                {
+                    server = Global.SingboxFinalResolverTag,
+                    domain = [node.Address],
+                });
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
#7801

将代理服务器域名写入 sing-box 的 dns 直连列表

想了一下，代理服务器域名 dns 缓存到系统和 sing-box 好像差不多，速度应该没区别