### PR TITLE
PreCheck

### DIFF
--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -2095,6 +2095,15 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Not support protocol &apos;{0}&apos;. 的本地化字符串。
+        /// </summary>
+        public static string NotSupportProtocol {
+            get {
+                return ResourceManager.GetString("NotSupportProtocol", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Scan completed, no valid QR code found 的本地化字符串。
         /// </summary>
         public static string NoValidQRcodeFound {

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -115,6 +115,33 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Core &apos;{0}&apos; does not support network type &apos;{1}&apos;. 的本地化字符串。
+        /// </summary>
+        public static string CoreNotSupportNetwork {
+            get {
+                return ResourceManager.GetString("CoreNotSupportNetwork", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Core &apos;{0}&apos; does not support protocol &apos;{1}&apos;. 的本地化字符串。
+        /// </summary>
+        public static string CoreNotSupportProtocol {
+            get {
+                return ResourceManager.GetString("CoreNotSupportProtocol", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Core &apos;{0}&apos; does not support protocol &apos;{1}&apos; when using transport &apos;{2}&apos;. 的本地化字符串。
+        /// </summary>
+        public static string CoreNotSupportProtocolTransport {
+            get {
+                return ResourceManager.GetString("CoreNotSupportProtocolTransport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Note that custom configuration relies entirely on your own configuration and does not work with all settings. If you want to use the system proxy, please modify the listening port manually. 的本地化字符串。
         /// </summary>
         public static string CustomServerTips {
@@ -268,6 +295,24 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Group &apos;{0}&apos; is empty. Please add at least one node. 的本地化字符串。
+        /// </summary>
+        public static string GroupEmpty {
+            get {
+                return ResourceManager.GetString("GroupEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 The group &quot;{0}&quot; cannot reference itself. 的本地化字符串。
+        /// </summary>
+        public static string GroupSelfReference {
+            get {
+                return ResourceManager.GetString("GroupSelfReference", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 This is not the correct configuration, please check 的本地化字符串。
         /// </summary>
         public static string Incorrectconfiguration {
@@ -291,6 +336,15 @@ namespace ServiceLib.Resx {
         public static string InsecureUrlProtocol {
             get {
                 return ResourceManager.GetString("InsecureUrlProtocol", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 The {0} property is invalid, please check. 的本地化字符串。
+        /// </summary>
+        public static string InvalidProperty {
+            get {
+                return ResourceManager.GetString("InvalidProperty", resourceCulture);
             }
         }
         
@@ -2005,6 +2059,15 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Node alias &apos;{0}&apos; does not exist. 的本地化字符串。
+        /// </summary>
+        public static string NodeTagNotExist {
+            get {
+                return ResourceManager.GetString("NodeTagNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Non-VMess or SS protocol 的本地化字符串。
         /// </summary>
         public static string NonvmessOrssProtocol {
@@ -2113,6 +2176,24 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Policy group:  的本地化字符串。
+        /// </summary>
+        public static string PolicyGroupPrefix {
+            get {
+                return ResourceManager.GetString("PolicyGroupPrefix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Proxy chained:  的本地化字符串。
+        /// </summary>
+        public static string ProxyChainedPrefix {
+            get {
+                return ResourceManager.GetString("ProxyChainedPrefix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Global hotkey {0} registration failed, reason: {1} 的本地化字符串。
         /// </summary>
         public static string RegisterGlobalHotkeyFailed {
@@ -2172,6 +2253,15 @@ namespace ServiceLib.Resx {
         public static string RoutingRuleDetailRequiredTips {
             get {
                 return ResourceManager.GetString("RoutingRuleDetailRequiredTips", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Routing rule outbound:  的本地化字符串。
+        /// </summary>
+        public static string RoutingRuleOutboundPrefix {
+            get {
+                return ResourceManager.GetString("RoutingRuleOutboundPrefix", resourceCulture);
             }
         }
         

--- a/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
@@ -1560,4 +1560,34 @@
   <data name="menuGenGroupMultipleServerXrayFallback" xml:space="preserve">
     <value>Multi-Configuration Fallback by Xray</value>
   </data>
+  <data name="CoreNotSupportNetwork" xml:space="preserve">
+    <value>Core '{0}' does not support network type '{1}'.</value>
+  </data>
+  <data name="CoreNotSupportProtocolTransport" xml:space="preserve">
+    <value>Core '{0}' does not support protocol '{1}' when using transport '{2}'.</value>
+  </data>
+  <data name="CoreNotSupportProtocol" xml:space="preserve">
+    <value>Core '{0}' does not support protocol '{1}'.</value>
+  </data>
+  <data name="ProxyChainedPrefix" xml:space="preserve">
+    <value>Proxy chained: </value>
+  </data>
+  <data name="RoutingRuleOutboundPrefix" xml:space="preserve">
+    <value>Routing rule outbound: </value>
+  </data>
+  <data name="PolicyGroupPrefix" xml:space="preserve">
+    <value>Policy group: </value>
+  </data>
+  <data name="NodeTagNotExist" xml:space="preserve">
+    <value>Node alias '{0}' does not exist.</value>
+  </data>
+  <data name="GroupEmpty" xml:space="preserve">
+    <value>Group '{0}' is empty. Please add at least one node.</value>
+  </data>
+  <data name="InvalidProperty" xml:space="preserve">
+    <value>The {0} property is invalid, please check.</value>
+  </data>
+  <data name="GroupSelfReference" xml:space="preserve">
+    <value>The group "{0}" cannot reference itself.</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
@@ -1590,4 +1590,7 @@
   <data name="GroupSelfReference" xml:space="preserve">
     <value>The group "{0}" cannot reference itself.</value>
   </data>
+  <data name="NotSupportProtocol" xml:space="preserve">
+    <value>Not support protocol '{0}'.</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.hu.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.hu.resx
@@ -1560,4 +1560,34 @@
   <data name="menuGenGroupMultipleServerXrayFallback" xml:space="preserve">
     <value>Multi-Configuration Fallback by Xray</value>
   </data>
+  <data name="CoreNotSupportNetwork" xml:space="preserve">
+    <value>Core '{0}' does not support network type '{1}'.</value>
+  </data>
+  <data name="CoreNotSupportProtocolTransport" xml:space="preserve">
+    <value>Core '{0}' does not support protocol '{1}' when using transport '{2}'.</value>
+  </data>
+  <data name="CoreNotSupportProtocol" xml:space="preserve">
+    <value>Core '{0}' does not support protocol '{1}'.</value>
+  </data>
+  <data name="ProxyChainedPrefix" xml:space="preserve">
+    <value>Proxy chained: </value>
+  </data>
+  <data name="RoutingRuleOutboundPrefix" xml:space="preserve">
+    <value>Routing rule outbound: </value>
+  </data>
+  <data name="PolicyGroupPrefix" xml:space="preserve">
+    <value>Policy group: </value>
+  </data>
+  <data name="NodeTagNotExist" xml:space="preserve">
+    <value>Node alias '{0}' does not exist.</value>
+  </data>
+  <data name="GroupEmpty" xml:space="preserve">
+    <value>Group '{0}' is empty. Please add at least one node.</value>
+  </data>
+  <data name="InvalidProperty" xml:space="preserve">
+    <value>The {0} property is invalid, please check.</value>
+  </data>
+  <data name="GroupSelfReference" xml:space="preserve">
+    <value>The group "{0}" cannot reference itself.</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.hu.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.hu.resx
@@ -1590,4 +1590,7 @@
   <data name="GroupSelfReference" xml:space="preserve">
     <value>The group "{0}" cannot reference itself.</value>
   </data>
+  <data name="NotSupportProtocol" xml:space="preserve">
+    <value>Not support protocol '{0}'.</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1560,4 +1560,34 @@
   <data name="menuGenGroupMultipleServerXrayFallback" xml:space="preserve">
     <value>Multi-Configuration Fallback by Xray</value>
   </data>
+  <data name="CoreNotSupportNetwork" xml:space="preserve">
+    <value>Core '{0}' does not support network type '{1}'.</value>
+  </data>
+  <data name="CoreNotSupportProtocolTransport" xml:space="preserve">
+    <value>Core '{0}' does not support protocol '{1}' when using transport '{2}'.</value>
+  </data>
+  <data name="CoreNotSupportProtocol" xml:space="preserve">
+    <value>Core '{0}' does not support protocol '{1}'.</value>
+  </data>
+  <data name="ProxyChainedPrefix" xml:space="preserve">
+    <value>Proxy chained: </value>
+  </data>
+  <data name="RoutingRuleOutboundPrefix" xml:space="preserve">
+    <value>Routing rule outbound: </value>
+  </data>
+  <data name="PolicyGroupPrefix" xml:space="preserve">
+    <value>Policy group: </value>
+  </data>
+  <data name="NodeTagNotExist" xml:space="preserve">
+    <value>Node alias '{0}' does not exist.</value>
+  </data>
+  <data name="GroupEmpty" xml:space="preserve">
+    <value>Group '{0}' is empty. Please add at least one node.</value>
+  </data>
+  <data name="InvalidProperty" xml:space="preserve">
+    <value>The {0} property is invalid, please check.</value>
+  </data>
+  <data name="GroupSelfReference" xml:space="preserve">
+    <value>The group "{0}" cannot reference itself.</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1590,4 +1590,7 @@
   <data name="GroupSelfReference" xml:space="preserve">
     <value>The group "{0}" cannot reference itself.</value>
   </data>
+  <data name="NotSupportProtocol" xml:space="preserve">
+    <value>Not support protocol '{0}'.</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1560,4 +1560,34 @@
   <data name="menuGenGroupMultipleServerXrayFallback" xml:space="preserve">
     <value>Multi-Configuration Fallback by Xray</value>
   </data>
+  <data name="CoreNotSupportNetwork" xml:space="preserve">
+    <value>Core '{0}' does not support network type '{1}'.</value>
+  </data>
+  <data name="CoreNotSupportProtocolTransport" xml:space="preserve">
+    <value>Core '{0}' does not support protocol '{1}' when using transport '{2}'.</value>
+  </data>
+  <data name="CoreNotSupportProtocol" xml:space="preserve">
+    <value>Core '{0}' does not support protocol '{1}'.</value>
+  </data>
+  <data name="ProxyChainedPrefix" xml:space="preserve">
+    <value>Proxy chained: </value>
+  </data>
+  <data name="RoutingRuleOutboundPrefix" xml:space="preserve">
+    <value>Routing rule outbound: </value>
+  </data>
+  <data name="PolicyGroupPrefix" xml:space="preserve">
+    <value>Policy group: </value>
+  </data>
+  <data name="NodeTagNotExist" xml:space="preserve">
+    <value>Node alias '{0}' does not exist.</value>
+  </data>
+  <data name="GroupEmpty" xml:space="preserve">
+    <value>Group '{0}' is empty. Please add at least one node.</value>
+  </data>
+  <data name="InvalidProperty" xml:space="preserve">
+    <value>The {0} property is invalid, please check.</value>
+  </data>
+  <data name="GroupSelfReference" xml:space="preserve">
+    <value>The group "{0}" cannot reference itself.</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1590,4 +1590,7 @@
   <data name="GroupSelfReference" xml:space="preserve">
     <value>The group "{0}" cannot reference itself.</value>
   </data>
+  <data name="NotSupportProtocol" xml:space="preserve">
+    <value>Not support protocol '{0}'.</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1557,4 +1557,34 @@
   <data name="menuGenGroupMultipleServerXrayFallback" xml:space="preserve">
     <value>多配置文件故障转移 Xray</value>
   </data>
+  <data name="CoreNotSupportNetwork" xml:space="preserve">
+    <value>核心 '{0}' 不支持网络类型 '{1}'。</value>
+  </data>
+  <data name="CoreNotSupportProtocolTransport" xml:space="preserve">
+    <value>核心 '{0}' 在使用传输方式 '{2}' 时不支持协议 '{1}'。</value>
+  </data>
+  <data name="CoreNotSupportProtocol" xml:space="preserve">
+    <value>核心 '{0}' 不支持协议 '{1}'。</value>
+  </data>
+  <data name="ProxyChainedPrefix" xml:space="preserve">
+    <value>代理链： </value>
+  </data>
+  <data name="RoutingRuleOutboundPrefix" xml:space="preserve">
+    <value>路由规则出站： </value>
+  </data>
+  <data name="PolicyGroupPrefix" xml:space="preserve">
+    <value>策略组： </value>
+  </data>
+  <data name="NodeTagNotExist" xml:space="preserve">
+    <value>节点别名 '{0}' 不存在。</value>
+  </data>
+  <data name="GroupEmpty" xml:space="preserve">
+    <value>组“{0}”为空。请至少添加一个节点。</value>
+  </data>
+  <data name="InvalidProperty" xml:space="preserve">
+    <value>{0}属性无效，请检查</value>
+  </data>
+  <data name="GroupSelfReference" xml:space="preserve">
+    <value>{0} 分组不能引用自身</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1587,4 +1587,7 @@
   <data name="GroupSelfReference" xml:space="preserve">
     <value>{0} 分组不能引用自身</value>
   </data>
+  <data name="NotSupportProtocol" xml:space="preserve">
+    <value>不支持协议 '{0}'。</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -1557,4 +1557,34 @@
   <data name="menuGenGroupMultipleServerXrayFallback" xml:space="preserve">
     <value>Multi-Configuration Fallback by Xray</value>
   </data>
+  <data name="CoreNotSupportNetwork" xml:space="preserve">
+    <value>Core '{0}' does not support network type '{1}'.</value>
+  </data>
+  <data name="CoreNotSupportProtocolTransport" xml:space="preserve">
+    <value>Core '{0}' does not support protocol '{1}' when using transport '{2}'.</value>
+  </data>
+  <data name="CoreNotSupportProtocol" xml:space="preserve">
+    <value>Core '{0}' does not support protocol '{1}'.</value>
+  </data>
+  <data name="ProxyChainedPrefix" xml:space="preserve">
+    <value>Proxy chained: </value>
+  </data>
+  <data name="RoutingRuleOutboundPrefix" xml:space="preserve">
+    <value>Routing rule outbound: </value>
+  </data>
+  <data name="PolicyGroupPrefix" xml:space="preserve">
+    <value>Policy group: </value>
+  </data>
+  <data name="NodeTagNotExist" xml:space="preserve">
+    <value>Node alias '{0}' does not exist.</value>
+  </data>
+  <data name="GroupEmpty" xml:space="preserve">
+    <value>Group '{0}' is empty. Please add at least one node.</value>
+  </data>
+  <data name="InvalidProperty" xml:space="preserve">
+    <value>The {0} property is invalid, please check.</value>
+  </data>
+  <data name="GroupSelfReference" xml:space="preserve">
+    <value>The group "{0}" cannot reference itself.</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -1587,4 +1587,7 @@
   <data name="GroupSelfReference" xml:space="preserve">
     <value>The group "{0}" cannot reference itself.</value>
   </data>
+  <data name="NotSupportProtocol" xml:space="preserve">
+    <value>Not support protocol '{0}'.</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Services/ActionPrecheckService.cs
+++ b/v2rayN/ServiceLib/Services/ActionPrecheckService.cs
@@ -57,13 +57,11 @@ public class ActionPrecheckService(Config config)
     {
         var errors = new List<string>();
         
-        // sing-box does not support xhttp / kcp
-        // sing-box does not support transports like ws/http/httpupgrade/etc. when the node is not vmess/trojan/vless
         coreType ??= AppManager.Instance.GetCoreType(item, item.ConfigType);
 
         if (item.ConfigType is EConfigType.Custom)
         {
-            errors.Add(string.Format(ResUI.CoreNotSupportProtocol, coreType.ToString(), item.ConfigType.ToString()));
+            errors.Add(string.Format(ResUI.NotSupportProtocol, item.ConfigType.ToString()));
             return errors;
         }
 
@@ -164,6 +162,8 @@ public class ActionPrecheckService(Config config)
 
         if (coreType == ECoreType.sing_box)
         {
+            // sing-box does not support xhttp / kcp
+            // sing-box does not support transports like ws/http/httpupgrade/etc. when the node is not vmess/trojan/vless
             if (net is nameof(ETransport.kcp) or nameof(ETransport.xhttp))
             {
                 errors.Add(string.Format(ResUI.CoreNotSupportNetwork, nameof(ECoreType.sing_box), net));
@@ -182,14 +182,15 @@ public class ActionPrecheckService(Config config)
         else if (coreType is ECoreType.Xray)
         {
             // Xray core does not support these protocols
-            if (item.ConfigType is EConfigType.Hysteria2 or EConfigType.TUIC or EConfigType.Anytls)
+            if (!Global.XraySupportConfigType.Contains(item.ConfigType)
+                && !item.IsComplex())
             {
                 errors.Add(string.Format(ResUI.CoreNotSupportProtocol, nameof(ECoreType.Xray), item.ConfigType.ToString()));
                 return errors;
             }
         }
 
-        return errors.Select(s => $"{item.Remarks}: {s}").ToList();
+        return errors;
     }
 
     private async Task<List<string>> ValidateRelatedNodesExistAndValid(ProfileItem? item)

--- a/v2rayN/ServiceLib/Services/ActionPrecheckService.cs
+++ b/v2rayN/ServiceLib/Services/ActionPrecheckService.cs
@@ -1,0 +1,284 @@
+using DynamicData;
+
+namespace ServiceLib.Services;
+
+/// <summary>
+/// Centralized pre-checks before sensitive actions (set active profile, generate config, etc.).
+/// </summary>
+public class ActionPrecheckService(Config config)
+{
+    private static readonly Lazy<ActionPrecheckService> _instance = new(() => new ActionPrecheckService(AppManager.Instance.Config));
+    public static ActionPrecheckService Instance => _instance.Value;
+
+    private readonly Config _config = config;
+
+    public async Task<List<string>> CheckBeforeSetActive(string? indexId)
+    {
+        if (indexId.IsNullOrEmpty())
+        {
+            return [ResUI.PleaseSelectServer];
+        }
+
+        var item = await AppManager.Instance.GetProfileItem(indexId);
+        if (item is null)
+        {
+            return [ResUI.PleaseSelectServer];
+        }
+
+        return await CheckBeforeGenerateConfig(item);
+    }
+
+    public async Task<List<string>> CheckBeforeGenerateConfig(ProfileItem? item)
+    {
+        if (item is null)
+        {
+            return [ResUI.PleaseSelectServer];
+        }
+
+        var errors = new List<string>();
+
+        errors.AddRange(await ValidateCurrentNodeAndCoreSupport(item));
+        errors.AddRange(await ValidateRelatedNodesExistAndValid(item));
+
+        return errors;
+    }
+
+    private async Task<List<string>> ValidateCurrentNodeAndCoreSupport(ProfileItem item)
+    {
+        if (item.ConfigType == EConfigType.Custom)
+        {
+            return [];
+        }
+        var coreType = AppManager.Instance.GetCoreType(item, item.ConfigType);
+        return await ValidateNodeAndCoreSupport(item, coreType);
+    }
+
+    private async Task<List<string>> ValidateNodeAndCoreSupport(ProfileItem item, ECoreType? coreType = null)
+    {
+        var errors = new List<string>();
+        
+        // sing-box does not support xhttp / kcp
+        // sing-box does not support transports like ws/http/httpupgrade/etc. when the node is not vmess/trojan/vless
+        coreType ??= AppManager.Instance.GetCoreType(item, item.ConfigType);
+
+        if (item.ConfigType is EConfigType.Custom)
+        {
+            errors.Add(string.Format(ResUI.CoreNotSupportProtocol, coreType.ToString(), item.ConfigType.ToString()));
+            return errors;
+        }
+
+        if (!item.IsComplex())
+        {
+            if (item.Address.IsNullOrEmpty())
+            {
+                errors.Add(string.Format(ResUI.InvalidProperty, "Address"));
+                return errors;
+            }
+
+            if (item.Port is <= 0 or >= 65536)
+            {
+                errors.Add(string.Format(ResUI.InvalidProperty, "Port"));
+                return errors;
+            }
+
+
+            switch (item.ConfigType)
+            {
+                case EConfigType.VMess:
+                    if (item.Id.IsNullOrEmpty() || !Utils.IsGuidByParse(item.Id))
+                        errors.Add(string.Format(ResUI.InvalidProperty, "Id"));
+                    break;
+
+                case EConfigType.VLESS:
+                    if (item.Id.IsNullOrEmpty() || (!Utils.IsGuidByParse(item.Id) && item.Id.Length > 30))
+                        errors.Add(string.Format(ResUI.InvalidProperty, "Id"));
+                    if (!Global.Flows.Contains(item.Flow))
+                        errors.Add(string.Format(ResUI.InvalidProperty, "Flow"));
+                    break;
+
+                case EConfigType.Shadowsocks:
+                    if (item.Id.IsNullOrEmpty())
+                        errors.Add(string.Format(ResUI.InvalidProperty, "Id"));
+                    if (string.IsNullOrEmpty(item.Security) || !Global.SsSecuritiesInSingbox.Contains(item.Security))
+                        errors.Add(string.Format(ResUI.InvalidProperty, "Security"));
+                    break;
+            }
+
+            if ((item.ConfigType is EConfigType.VLESS or EConfigType.Trojan)
+                && item.StreamSecurity == Global.StreamSecurityReality
+                && item.PublicKey.IsNullOrEmpty())
+            {
+                errors.Add(string.Format(ResUI.InvalidProperty, "PublicKey"));
+            }
+
+            if (errors.Count > 0)
+            {
+                return errors;
+            }
+        }
+
+        if (item.ConfigType is EConfigType.PolicyGroup or EConfigType.ProxyChain)
+        {
+            ProfileGroupItemManager.Instance.TryGet(item.IndexId, out var group);
+            if (group is null || group.ChildItems.IsNullOrEmpty())
+            {
+                errors.Add(string.Format(ResUI.GroupEmpty, item.Remarks));
+                return errors;
+            }
+
+            var hasCycle = ProfileGroupItemManager.HasCycle(item.IndexId);
+            if (hasCycle)
+            {
+                errors.Add(string.Format(ResUI.GroupSelfReference, item.Remarks));
+                return errors;
+            }
+
+            foreach (var child in Utils.String2List(group.ChildItems))
+            {
+                var childErrors = new List<string>();
+                if (child.IsNullOrEmpty())
+                {
+                    continue;
+                }
+                
+                var childItem = await AppManager.Instance.GetProfileItem(child);
+                if (childItem is null)
+                {
+                    childErrors.Add(string.Format(ResUI.NodeTagNotExist, child));
+                    continue;
+                }
+
+                if (childItem.ConfigType is EConfigType.Custom or EConfigType.ProxyChain)
+                {
+                    childErrors.Add(string.Format(ResUI.InvalidProperty, childItem.Remarks));
+                    continue;
+                }
+
+                childErrors.AddRange(await ValidateNodeAndCoreSupport(childItem, coreType));
+                errors.AddRange(childErrors);
+            }
+            return errors;
+        }
+
+        var net = item.GetNetwork() ?? item.Network;
+
+        if (coreType == ECoreType.sing_box)
+        {
+            if (net is nameof(ETransport.kcp) or nameof(ETransport.xhttp))
+            {
+                errors.Add(string.Format(ResUI.CoreNotSupportNetwork, nameof(ECoreType.sing_box), net));
+                return errors;
+            }
+
+            if (item.ConfigType is not (EConfigType.VMess or EConfigType.VLESS or EConfigType.Trojan))
+            {
+                if (net is nameof(ETransport.ws) or nameof(ETransport.http) or nameof(ETransport.h2) or nameof(ETransport.quic) or nameof(ETransport.httpupgrade))
+                {
+                    errors.Add(string.Format(ResUI.CoreNotSupportProtocolTransport, nameof(ECoreType.sing_box), item.ConfigType.ToString(), net));
+                    return errors;
+                }
+            }
+        }
+        else if (coreType is ECoreType.Xray)
+        {
+            // Xray core does not support these protocols
+            if (item.ConfigType is EConfigType.Hysteria2 or EConfigType.TUIC or EConfigType.Anytls)
+            {
+                errors.Add(string.Format(ResUI.CoreNotSupportProtocol, nameof(ECoreType.Xray), item.ConfigType.ToString()));
+                return errors;
+            }
+        }
+
+        return errors.Select(s => $"{item.Remarks}: {s}").ToList();
+    }
+
+    private async Task<List<string>> ValidateRelatedNodesExistAndValid(ProfileItem? item)
+    {
+        var errors = new List<string>();
+        errors.AddRange(await ValidateProxyChainedNodeExistAndValid(item));
+        errors.AddRange(await ValidateRoutingNodeExistAndValid(item));
+        return errors;
+    }
+
+    private async Task<List<string>> ValidateProxyChainedNodeExistAndValid(ProfileItem? item)
+    {
+        var errors = new List<string>();
+        if (item is null)
+        {
+            return errors;
+        }
+
+        // prev node and next node
+        var subItem = await AppManager.Instance.GetSubItem(item.Subid);
+        if (subItem is null)
+        {
+            return errors;
+        }
+
+        var prevNode = await AppManager.Instance.GetProfileItemViaRemarks(subItem.PrevProfile);
+        var nextNode = await AppManager.Instance.GetProfileItemViaRemarks(subItem.NextProfile);
+        var coreType = AppManager.Instance.GetCoreType(item, item.ConfigType);
+
+        await CollectProxyChainedNodeValidation(prevNode, subItem.PrevProfile, coreType, errors);
+        await CollectProxyChainedNodeValidation(nextNode, subItem.NextProfile, coreType, errors);
+
+        return errors;
+    }
+
+    private async Task CollectProxyChainedNodeValidation(ProfileItem? node, string tag, ECoreType coreType, List<string> errors)
+    {
+        if (node is not null)
+        {
+            var nodeErrors = await ValidateNodeAndCoreSupport(node, coreType);
+            errors.AddRange(nodeErrors.Select(s => ResUI.ProxyChainedPrefix + s));
+        }
+        else if (tag.IsNotEmpty())
+        {
+            errors.Add(ResUI.ProxyChainedPrefix + string.Format(ResUI.NodeTagNotExist, tag));
+        }
+    }
+
+    private async Task<List<string>> ValidateRoutingNodeExistAndValid(ProfileItem? item)
+    {
+        var errors = new List<string>();
+
+        if (item is null)
+        {
+            return errors;
+        }
+
+        var coreType = AppManager.Instance.GetCoreType(item, item.ConfigType);
+        var routing = await ConfigHandler.GetDefaultRouting(_config);
+        if (routing == null)
+        {
+            return errors;
+        }
+
+        var rules = JsonUtils.Deserialize<List<RulesItem>>(routing.RuleSet);
+        foreach (var ruleItem in rules ?? [])
+        {
+            if (!ruleItem.Enabled)
+            {
+                continue;
+            }
+
+            var outboundTag = ruleItem.OutboundTag;
+            if (outboundTag.IsNullOrEmpty() || Global.OutboundTags.Contains(outboundTag))
+            {
+                continue;
+            }
+
+            var tagItem = await AppManager.Instance.GetProfileItemViaRemarks(outboundTag);
+            if (tagItem is null)
+            {
+                errors.Add(ResUI.RoutingRuleOutboundPrefix + string.Format(ResUI.NodeTagNotExist, outboundTag));
+                continue;
+            }
+
+            var tagErrors = await ValidateNodeAndCoreSupport(tagItem, coreType);
+            errors.AddRange(tagErrors.Select(s => ResUI.RoutingRuleOutboundPrefix + s));
+        }
+
+        return errors;
+    }
+}

--- a/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
@@ -605,6 +605,16 @@ public class ProfilesViewModel : MyReactiveObject
             return;
         }
 
+        var msgs = await ActionPrecheckService.Instance.CheckBeforeSetActive(indexId);
+        foreach (var msg in msgs)
+        {
+            NoticeManager.Instance.SendMessage(msg);
+        }
+        if (msgs.Count > 0)
+        {
+            NoticeManager.Instance.Enqueue(msgs.First());
+        }
+
         if (await ConfigHandler.SetDefaultServerIndex(_config, indexId) == 0)
         {
             await RefreshServers();
@@ -767,6 +777,16 @@ public class ProfilesViewModel : MyReactiveObject
         {
             NoticeManager.Instance.Enqueue(ResUI.PleaseSelectServer);
             return;
+        }
+
+        var msgs = await ActionPrecheckService.Instance.CheckBeforeGenerateConfig(item);
+        foreach (var msg in msgs)
+        {
+            NoticeManager.Instance.SendMessage(msg);
+        }
+        if (msgs.Count > 0)
+        {
+            NoticeManager.Instance.Enqueue(msgs.First());
         }
         if (blClipboard)
         {


### PR DESCRIPTION
#7887

设为活动配置文件前检查，目前只在手动切换节点时检查

目前检查核心是否支持，以及节点分流和链式代理是否正确

检查核心是否支持包括：核心是否支持其协议，核心是否支持其传输层，如果检查不通过则停止切换节点

节点分流和链式代理是否正确：检查别名是否存在，以及核心是否支持，检查不通过仅提示