### PR TITLE
fix: 修正获取系统hosts

### DIFF
--- a/v2rayN/ServiceLib/Common/Utils.cs
+++ b/v2rayN/ServiceLib/Common/Utils.cs
@@ -582,9 +582,9 @@ public class Utils
                     if (host.StartsWith("#"))
                         continue;
                     var hostItem = host.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-                    if (hostItem.Length != 2)
+                    if (hostItem.Length < 2)
                         continue;
-                    systemHosts.Add(hostItem.Last(), hostItem.First());
+                    systemHosts.Add(hostItem[1], hostItem[0]);
                 }
             }
         }


### PR DESCRIPTION
- 修复当host的记录存在行尾注释时，无法将其添加到dns.host中

示例hosts
```
127.0.0.1 test1.com
127.0.0.1 test2.com # test
```
在之前仅仅会添加`127.0.0.1 test1.com`这条记录，而忽略另一条