### PR TITLE
Multi profile

### DIFF
--- a/v2rayN/ServiceLib/Enums/EConfigType.cs
+++ b/v2rayN/ServiceLib/Enums/EConfigType.cs
@@ -12,5 +12,9 @@ public enum EConfigType
     TUIC = 8,
     WireGuard = 9,
     HTTP = 10,
-    Anytls = 11
+    Anytls = 11,
+
+    Group = 1000,
+    PolicyGroup = 1001,
+    ProxyChain = 1002,
 }

--- a/v2rayN/ServiceLib/Enums/EMultipleLoad.cs
+++ b/v2rayN/ServiceLib/Enums/EMultipleLoad.cs
@@ -2,8 +2,8 @@ namespace ServiceLib.Enums;
 
 public enum EMultipleLoad
 {
+    LeastPing,
     Random,
     RoundRobin,
-    LeastPing,
     LeastLoad
 }

--- a/v2rayN/ServiceLib/Enums/EMultipleLoad.cs
+++ b/v2rayN/ServiceLib/Enums/EMultipleLoad.cs
@@ -3,6 +3,7 @@ namespace ServiceLib.Enums;
 public enum EMultipleLoad
 {
     LeastPing,
+    Fallback,
     Random,
     RoundRobin,
     LeastLoad

--- a/v2rayN/ServiceLib/Enums/EViewAction.cs
+++ b/v2rayN/ServiceLib/Enums/EViewAction.cs
@@ -23,6 +23,7 @@ public enum EViewAction
     RoutingRuleDetailsWindow,
     AddServerWindow,
     AddServer2Window,
+    AddGroupServerWindow,
     DNSSettingWindow,
     RoutingSettingWindow,
     OptionSettingWindow,

--- a/v2rayN/ServiceLib/Global.cs
+++ b/v2rayN/ServiceLib/Global.cs
@@ -50,6 +50,7 @@ public class Global
     public const string DirectTag = "direct";
     public const string BlockTag = "block";
     public const string DnsTag = "dns-module";
+    public const string BalancerTagSuffix = "-round";
     public const string StreamSecurity = "tls";
     public const string StreamSecurityReality = "reality";
     public const string Loopback = "127.0.0.1";

--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -1251,7 +1251,7 @@ public static class ConfigHandler
     public static async Task<ProfileItem?> GetPreSocksItem(Config config, ProfileItem node, ECoreType coreType)
     {
         ProfileItem? itemSocks = null;
-        if (node.ConfigType != EConfigType.Custom && node.ConfigType < EConfigType.Group && coreType != ECoreType.sing_box && config.TunModeItem.EnableTun)
+        if (node.ConfigType != EConfigType.Custom && coreType != ECoreType.sing_box && config.TunModeItem.EnableTun)
         {
             itemSocks = new ProfileItem()
             {
@@ -1262,7 +1262,7 @@ public static class ConfigHandler
                 Port = AppManager.Instance.GetLocalPort(EInboundProtocol.socks)
             };
         }
-        else if (node.ConfigType == EConfigType.Custom && node.ConfigType < EConfigType.Group && node.PreSocksPort > 0)
+        else if (node.ConfigType == EConfigType.Custom && node.PreSocksPort > 0)
         {
             var preCoreType = config.RunningCoreType = config.TunModeItem.EnableTun ? ECoreType.sing_box : ECoreType.Xray;
             itemSocks = new ProfileItem()

--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -1209,16 +1209,16 @@ public static class ConfigHandler
         {
             profileItem.Remarks = multipleLoad switch
             {
-                EMultipleLoad.Random => ResUI.menuSetDefaultMultipleServerXrayRandom,
-                EMultipleLoad.RoundRobin => ResUI.menuSetDefaultMultipleServerXrayRoundRobin,
-                EMultipleLoad.LeastPing => ResUI.menuSetDefaultMultipleServerXrayLeastPing,
-                EMultipleLoad.LeastLoad => ResUI.menuSetDefaultMultipleServerXrayLeastLoad,
-                _ => ResUI.menuSetDefaultMultipleServerXrayRoundRobin,
+                EMultipleLoad.Random => ResUI.menuGenGroupMultipleServerXrayRandom,
+                EMultipleLoad.RoundRobin => ResUI.menuGenGroupMultipleServerXrayRoundRobin,
+                EMultipleLoad.LeastPing => ResUI.menuGenGroupMultipleServerXrayLeastPing,
+                EMultipleLoad.LeastLoad => ResUI.menuGenGroupMultipleServerXrayLeastLoad,
+                _ => ResUI.menuGenGroupMultipleServerXrayRoundRobin,
             };
         }
         else if (coreType == ECoreType.sing_box)
         {
-            profileItem.Remarks = ResUI.menuSetDefaultMultipleServerSingBoxLeastPing;
+            profileItem.Remarks = ResUI.menuGenGroupMultipleServerSingBoxLeastPing;
         }
         profileItem.Address = Global.CoreMultipleLoadConfigFileName;
         profileItem.ConfigType = EConfigType.Custom;

--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -1199,16 +1199,22 @@ public static class ConfigHandler
         {
             remark = multipleLoad switch
             {
+                EMultipleLoad.LeastPing => ResUI.menuGenGroupMultipleServerXrayLeastPing,
+                EMultipleLoad.Fallback => ResUI.menuGenGroupMultipleServerXrayFallback,
                 EMultipleLoad.Random => ResUI.menuGenGroupMultipleServerXrayRandom,
                 EMultipleLoad.RoundRobin => ResUI.menuGenGroupMultipleServerXrayRoundRobin,
-                EMultipleLoad.LeastPing => ResUI.menuGenGroupMultipleServerXrayLeastPing,
                 EMultipleLoad.LeastLoad => ResUI.menuGenGroupMultipleServerXrayLeastLoad,
                 _ => ResUI.menuGenGroupMultipleServerXrayRoundRobin,
             };
         }
         else if (coreType == ECoreType.sing_box)
         {
-            remark = ResUI.menuGenGroupMultipleServerSingBoxLeastPing;
+            remark = multipleLoad switch
+            {
+                EMultipleLoad.LeastPing => ResUI.menuGenGroupMultipleServerSingBoxLeastPing,
+                EMultipleLoad.Fallback => ResUI.menuGenGroupMultipleServerSingBoxFallback,
+                _ => ResUI.menuGenGroupMultipleServerSingBoxLeastPing,
+            };
         }
         var profile = new ProfileItem
         {

--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -1087,6 +1087,8 @@ public static class ConfigHandler
             profileItem.IndexId = Utils.GetGuid(false);
             maxSort = ProfileExManager.Instance.GetMaxSort();
         }
+        var groupType = profileItem.ConfigType == EConfigType.ProxyChain ? EConfigType.ProxyChain.ToString() : profileGroupItem.MultipleLoad.ToString();
+        profileItem.Address = $"{profileItem.CoreType}-{groupType}";
         if (maxSort > 0)
         {
             ProfileExManager.Instance.SetSort(profileItem.IndexId, maxSort + 1);
@@ -1194,10 +1196,10 @@ public static class ConfigHandler
         var indexId = Utils.GetGuid(false);
         var childProfileIndexId = Utils.List2String(selecteds.Select(p => p.IndexId).ToList());
 
-        var remark = string.Empty;
+        var remark = subId.IsNullOrEmpty() ? string.Empty : $"{(await AppManager.Instance.GetSubItem(subId)).Remarks} ";
         if (coreType == ECoreType.Xray)
         {
-            remark = multipleLoad switch
+            remark += multipleLoad switch
             {
                 EMultipleLoad.LeastPing => ResUI.menuGenGroupMultipleServerXrayLeastPing,
                 EMultipleLoad.Fallback => ResUI.menuGenGroupMultipleServerXrayFallback,
@@ -1209,7 +1211,7 @@ public static class ConfigHandler
         }
         else if (coreType == ECoreType.sing_box)
         {
-            remark = multipleLoad switch
+            remark += multipleLoad switch
             {
                 EMultipleLoad.LeastPing => ResUI.menuGenGroupMultipleServerSingBoxLeastPing,
                 EMultipleLoad.Fallback => ResUI.menuGenGroupMultipleServerSingBoxFallback,
@@ -1222,7 +1224,6 @@ public static class ConfigHandler
             CoreType = coreType,
             ConfigType = EConfigType.PolicyGroup,
             Remarks = remark,
-            Address = childProfileIndexId,
         };
         if (!subId.IsNullOrEmpty())
         {

--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -1257,35 +1257,7 @@ public static class ConfigHandler
             var tun2SocksAddress = node.Address;
             if (node.ConfigType > EConfigType.Group)
             {
-                static async Task<List<string>> GetChildNodeAddressesAsync(string parentIndexId)
-                {
-                    var childAddresses = new List<string>();
-                    if (!ProfileGroupItemManager.Instance.TryGet(parentIndexId, out var groupItem) || groupItem.ChildItems.IsNullOrEmpty())
-                        return childAddresses;
-
-                    var childIds = Utils.String2List(groupItem.ChildItems);
-
-                    foreach (var childId in childIds)
-                    {
-                        var childNode = await AppManager.Instance.GetProfileItem(childId);
-                        if (childNode == null)
-                            continue;
-
-                        if (!childNode.IsComplex())
-                        {
-                            childAddresses.Add(childNode.Address);
-                        }
-                        else if (childNode.ConfigType > EConfigType.Group)
-                        {
-                            var subAddresses = await GetChildNodeAddressesAsync(childNode.IndexId);
-                            childAddresses.AddRange(subAddresses);
-                        }
-                    }
-
-                    return childAddresses;
-                }
-
-                var lstAddresses = await GetChildNodeAddressesAsync(node.IndexId);
+                var lstAddresses = (await ProfileGroupItemManager.GetAllChildDomainAddresses(node.IndexId)).ToList();
                 if (lstAddresses.Count > 0)
                 {
                     tun2SocksAddress = Utils.List2String(lstAddresses);

--- a/v2rayN/ServiceLib/Handler/CoreConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/CoreConfigHandler.cs
@@ -132,24 +132,4 @@ public static class CoreConfigHandler
         await File.WriteAllTextAsync(fileName, result.Data.ToString());
         return result;
     }
-
-    public static async Task<RetResult> GenerateClientMultipleLoadConfig(Config config, string fileName, List<ProfileItem> selecteds, ECoreType coreType, EMultipleLoad multipleLoad)
-    {
-        var result = new RetResult();
-        if (coreType == ECoreType.sing_box)
-        {
-            result = await new CoreConfigSingboxService(config).GenerateClientMultipleLoadConfig(selecteds);
-        }
-        else
-        {
-            result = await new CoreConfigV2rayService(config).GenerateClientMultipleLoadConfig(selecteds, multipleLoad);
-        }
-
-        if (result.Success != true)
-        {
-            return result;
-        }
-        await File.WriteAllTextAsync(fileName, result.Data.ToString());
-        return result;
-    }
 }

--- a/v2rayN/ServiceLib/Manager/AppManager.cs
+++ b/v2rayN/ServiceLib/Manager/AppManager.cs
@@ -99,7 +99,6 @@ public sealed class AppManager
 
             await ConfigHandler.SaveConfig(_config);
             await ProfileExManager.Instance.SaveTo();
-            await ProfileGroupItemManager.Instance.SaveTo();
             await StatisticsManager.Instance.SaveTo();
             await CoreManager.Instance.CoreStop();
             StatisticsManager.Instance.Close();

--- a/v2rayN/ServiceLib/Manager/AppManager.cs
+++ b/v2rayN/ServiceLib/Manager/AppManager.cs
@@ -64,6 +64,7 @@ public sealed class AppManager
         SQLiteHelper.Instance.CreateTable<ProfileExItem>();
         SQLiteHelper.Instance.CreateTable<DNSItem>();
         SQLiteHelper.Instance.CreateTable<FullConfigTemplateItem>();
+        SQLiteHelper.Instance.CreateTable<ProfileGroupItem>();
         return true;
     }
 
@@ -98,6 +99,7 @@ public sealed class AppManager
 
             await ConfigHandler.SaveConfig(_config);
             await ProfileExManager.Instance.SaveTo();
+            await ProfileGroupItemManager.Instance.SaveTo();
             await StatisticsManager.Instance.SaveTo();
             await CoreManager.Instance.CoreStop();
             StatisticsManager.Instance.Close();
@@ -205,6 +207,15 @@ public sealed class AppManager
             return null;
         }
         return await SQLiteHelper.Instance.TableAsync<ProfileItem>().FirstOrDefaultAsync(it => it.Remarks == remarks);
+    }
+
+    public async Task<ProfileGroupItem?> GetProfileGroupItem(string parentIndexId)
+    {
+        if (parentIndexId.IsNullOrEmpty())
+        {
+            return null;
+        }
+        return await SQLiteHelper.Instance.TableAsync<ProfileGroupItem>().FirstOrDefaultAsync(it => it.ParentIndexId == parentIndexId);
     }
 
     public async Task<List<RoutingItem>?> RoutingItems()

--- a/v2rayN/ServiceLib/Manager/ProfileGroupItemManager.cs
+++ b/v2rayN/ServiceLib/Manager/ProfileGroupItemManager.cs
@@ -19,10 +19,21 @@ public class ProfileGroupItemManager
         await InitData();
     }
 
-    public Task<ConcurrentBag<ProfileGroupItem>> GetProfileGroupItemList()
+    // Read-only getters: do not create or mark dirty
+    public bool TryGet(string indexId, out ProfileGroupItem? item)
     {
-        var bag = new ConcurrentBag<ProfileGroupItem>(_items.Values);
-        return Task.FromResult(bag);
+        item = null;
+        if (string.IsNullOrWhiteSpace(indexId))
+        {
+            return false;
+        }
+
+        return _items.TryGetValue(indexId, out item);
+    }
+
+    public ProfileGroupItem? GetOrDefault(string indexId)
+    {
+        return string.IsNullOrWhiteSpace(indexId) ? null : (_items.TryGetValue(indexId, out var v) ? v : null);
     }
 
     private async Task InitData()
@@ -50,7 +61,7 @@ public class ProfileGroupItemManager
     {
         if (string.IsNullOrEmpty(indexId))
         {
-            throw new ArgumentNullException(nameof(indexId));
+            indexId = Utils.GetGuid(false);
         }
 
         return _items.GetOrAdd(indexId, AddProfileGroupItem);

--- a/v2rayN/ServiceLib/Manager/ProfileGroupItemManager.cs
+++ b/v2rayN/ServiceLib/Manager/ProfileGroupItemManager.cs
@@ -1,0 +1,156 @@
+using System.Collections.Concurrent;
+
+namespace ServiceLib.Manager;
+
+public class ProfileGroupItemManager
+{
+    private static readonly Lazy<ProfileGroupItemManager> _instance = new(() => new());
+    private ConcurrentDictionary<string, ProfileGroupItem> _items = new();
+
+    public static ProfileGroupItemManager Instance => _instance.Value;
+    private static readonly string _tag = "ProfileGroupItemManager";
+
+    private ProfileGroupItemManager()
+    {
+    }
+
+    public async Task Init()
+    {
+        await InitData();
+    }
+
+    public Task<ConcurrentBag<ProfileGroupItem>> GetProfileGroupItemList()
+    {
+        var bag = new ConcurrentBag<ProfileGroupItem>(_items.Values);
+        return Task.FromResult(bag);
+    }
+
+    private async Task InitData()
+    {
+        await SQLiteHelper.Instance.ExecuteAsync($"delete from ProfileGroupItem where parentIndexId not in ( select indexId from ProfileItem )");
+
+        var list = await SQLiteHelper.Instance.TableAsync<ProfileGroupItem>().ToListAsync();
+        _items = new ConcurrentDictionary<string, ProfileGroupItem>(list.Where(t => !string.IsNullOrEmpty(t.ParentIndexId)).ToDictionary(t => t.ParentIndexId!));
+    }
+
+    private ProfileGroupItem AddProfileGroupItem(string indexId)
+    {
+        var profileGroupItem = new ProfileGroupItem()
+        {
+            ParentIndexId = indexId,
+            ChildItems = string.Empty,
+            MultipleLoad = EMultipleLoad.LeastPing
+        };
+
+        _items[indexId] = profileGroupItem;
+        return profileGroupItem;
+    }
+
+    private ProfileGroupItem GetProfileGroupItem(string indexId)
+    {
+        if (string.IsNullOrEmpty(indexId))
+        {
+            throw new ArgumentNullException(nameof(indexId));
+        }
+
+        return _items.GetOrAdd(indexId, AddProfileGroupItem);
+    }
+
+    public async Task ClearAll()
+    {
+        await SQLiteHelper.Instance.ExecuteAsync($"delete from ProfileGroupItem ");
+        _items.Clear();
+    }
+
+    public async Task SaveTo()
+    {
+        try
+        {
+            var lstExists = await SQLiteHelper.Instance.TableAsync<ProfileGroupItem>().ToListAsync();
+            var existsMap = lstExists.Where(t => !string.IsNullOrEmpty(t.ParentIndexId)).ToDictionary(t => t.ParentIndexId!);
+
+            var lstInserts = new List<ProfileGroupItem>();
+            var lstUpdates = new List<ProfileGroupItem>();
+
+            foreach (var item in _items.Values)
+            {
+                if (string.IsNullOrEmpty(item.ParentIndexId))
+                {
+                    continue;
+                }
+
+                if (existsMap.ContainsKey(item.ParentIndexId))
+                {
+                    lstUpdates.Add(item);
+                }
+                else
+                {
+                    lstInserts.Add(item);
+                }
+            }
+
+            try
+            {
+                if (lstInserts.Count > 0)
+                {
+                    await SQLiteHelper.Instance.InsertAllAsync(lstInserts);
+                }
+
+                if (lstUpdates.Count > 0)
+                {
+                    await SQLiteHelper.Instance.UpdateAllAsync(lstUpdates);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logging.SaveLog(_tag, ex);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logging.SaveLog(_tag, ex);
+        }
+    }
+
+    public ProfileGroupItem GetOrCreateAndMarkDirty(string indexId)
+    {
+        return GetProfileGroupItem(indexId);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await SaveTo();
+    }
+
+    public async Task SaveItemAsync(ProfileGroupItem item)
+    {
+        if (item is null)
+        {
+            throw new ArgumentNullException(nameof(item));
+        }
+
+        if (string.IsNullOrWhiteSpace(item.ParentIndexId))
+        {
+            throw new ArgumentException("ParentIndexId required", nameof(item));
+        }
+
+        _items[item.ParentIndexId] = item;
+
+        try
+        {
+            var lst = await SQLiteHelper.Instance.TableAsync<ProfileGroupItem>().Where(t => t.ParentIndexId == item.ParentIndexId).ToListAsync();
+            if (lst != null && lst.Count > 0)
+            {
+                await SQLiteHelper.Instance.UpdateAllAsync(new List<ProfileGroupItem> { item });
+            }
+            else
+            {
+                await SQLiteHelper.Instance.InsertAllAsync(new List<ProfileGroupItem> { item });
+            }
+        }
+        catch (Exception ex)
+        {
+            Logging.SaveLog(_tag, ex);
+        }
+    }
+}

--- a/v2rayN/ServiceLib/Manager/TaskManager.cs
+++ b/v2rayN/ServiceLib/Manager/TaskManager.cs
@@ -35,7 +35,6 @@ public class TaskManager
 
                 await ConfigHandler.SaveConfig(_config);
                 await ProfileExManager.Instance.SaveTo();
-                await ProfileGroupItemManager.Instance.SaveTo();
             }
 
             //Execute once 1 hour

--- a/v2rayN/ServiceLib/Manager/TaskManager.cs
+++ b/v2rayN/ServiceLib/Manager/TaskManager.cs
@@ -35,6 +35,7 @@ public class TaskManager
 
                 await ConfigHandler.SaveConfig(_config);
                 await ProfileExManager.Instance.SaveTo();
+                await ProfileGroupItemManager.Instance.SaveTo();
             }
 
             //Execute once 1 hour

--- a/v2rayN/ServiceLib/Models/ProfileGroupItem.cs
+++ b/v2rayN/ServiceLib/Models/ProfileGroupItem.cs
@@ -1,4 +1,5 @@
 using SQLite;
+
 namespace ServiceLib.Models;
 
 [Serializable]
@@ -10,4 +11,48 @@ public class ProfileGroupItem
     public string ChildItems { get; set; }
 
     public EMultipleLoad MultipleLoad { get; set; } = EMultipleLoad.LeastPing;
+
+    public bool HasCycle()
+    {
+        return HasCycle(new HashSet<string>(), new HashSet<string>());
+    }
+
+    public bool HasCycle(HashSet<string> visited, HashSet<string> stack)
+    {
+        if (string.IsNullOrEmpty(ParentIndexId))
+            return false;
+
+        if (stack.Contains(ParentIndexId))
+            return true;
+
+        if (visited.Contains(ParentIndexId))
+            return false;
+
+        visited.Add(ParentIndexId);
+        stack.Add(ParentIndexId);
+
+        if (string.IsNullOrEmpty(ChildItems))
+        {
+            return false;
+        }
+
+        var childIds = Utils.String2List(ChildItems)
+            .Where(p => !string.IsNullOrEmpty(p))
+            .ToList();
+
+        var childProfiles = childIds.Select(ProfileGroupItemManager.Instance.GetOrDefault)//这里是内存访问
+            .Where(p => p != null)
+            .ToList();
+
+        foreach (var child in childProfiles)
+        {
+            if (child.HasCycle(visited, stack))
+            {
+                return true;
+            }
+        }
+
+        stack.Remove(ParentIndexId);
+        return false;
+    }
 }

--- a/v2rayN/ServiceLib/Models/ProfileGroupItem.cs
+++ b/v2rayN/ServiceLib/Models/ProfileGroupItem.cs
@@ -11,48 +11,4 @@ public class ProfileGroupItem
     public string ChildItems { get; set; }
 
     public EMultipleLoad MultipleLoad { get; set; } = EMultipleLoad.LeastPing;
-
-    public bool HasCycle()
-    {
-        return HasCycle(new HashSet<string>(), new HashSet<string>());
-    }
-
-    public bool HasCycle(HashSet<string> visited, HashSet<string> stack)
-    {
-        if (string.IsNullOrEmpty(ParentIndexId))
-            return false;
-
-        if (stack.Contains(ParentIndexId))
-            return true;
-
-        if (visited.Contains(ParentIndexId))
-            return false;
-
-        visited.Add(ParentIndexId);
-        stack.Add(ParentIndexId);
-
-        if (string.IsNullOrEmpty(ChildItems))
-        {
-            return false;
-        }
-
-        var childIds = Utils.String2List(ChildItems)
-            .Where(p => !string.IsNullOrEmpty(p))
-            .ToList();
-
-        var childProfiles = childIds.Select(ProfileGroupItemManager.Instance.GetOrDefault)//这里是内存访问
-            .Where(p => p != null)
-            .ToList();
-
-        foreach (var child in childProfiles)
-        {
-            if (child.HasCycle(visited, stack))
-            {
-                return true;
-            }
-        }
-
-        stack.Remove(ParentIndexId);
-        return false;
-    }
 }

--- a/v2rayN/ServiceLib/Models/ProfileGroupItem.cs
+++ b/v2rayN/ServiceLib/Models/ProfileGroupItem.cs
@@ -1,0 +1,13 @@
+using SQLite;
+namespace ServiceLib.Models;
+
+[Serializable]
+public class ProfileGroupItem
+{
+    [PrimaryKey]
+    public string ParentIndexId { get; set; }
+
+    public string ChildItems { get; set; }
+
+    public EMultipleLoad MultipleLoad { get; set; } = EMultipleLoad.LeastPing;
+}

--- a/v2rayN/ServiceLib/Models/ProfileItem.cs
+++ b/v2rayN/ServiceLib/Models/ProfileItem.cs
@@ -109,42 +109,6 @@ public class ProfileItem : ReactiveObject
         return true;
     }
 
-    public async Task<bool> HasCycle(HashSet<string> visited, HashSet<string> stack)
-    {
-        if (ConfigType < EConfigType.Group)
-            return false;
-
-        if (stack.Contains(IndexId))
-            return true;
-
-        if (visited.Contains(IndexId))
-            return false;
-
-        visited.Add(IndexId);
-        stack.Add(IndexId);
-
-        if (ProfileGroupItemManager.Instance.TryGet(IndexId, out var group)
-            && !group.ChildItems.IsNullOrEmpty())
-        {
-            var childProfiles = (await Task.WhenAll(
-                    Utils.String2List(group.ChildItems)
-                        .Where(p => !p.IsNullOrEmpty())
-                        .Select(AppManager.Instance.GetProfileItem)
-                ))
-                .Where(p => p != null)
-                .ToList();
-
-            foreach (var child in childProfiles)
-            {
-                if (await child.HasCycle(visited, stack))
-                    return true;
-            }
-        }
-
-        stack.Remove(IndexId);
-        return false;
-    }
-
     #endregion function
 
     [PrimaryKey]

--- a/v2rayN/ServiceLib/Models/ProfileItem.cs
+++ b/v2rayN/ServiceLib/Models/ProfileItem.cs
@@ -32,19 +32,19 @@ public class ProfileItem : ReactiveObject
     public string GetSummary()
     {
         var summary = $"[{(ConfigType).ToString()}] ";
-        var arrAddr = Address.Contains(':') ? Address.Split(':') : Address.Split('.');
-        var addr = arrAddr.Length switch
-        {
-            > 2 => $"{arrAddr.First()}***{arrAddr.Last()}",
-            > 1 => $"***{arrAddr.Last()}",
-            _ => Address
-        };
-        if (ConfigType is EConfigType.Custom or > EConfigType.Group)
+        if (IsComplex())
         {
             summary += $"[{CoreType.ToString()}]{Remarks}";
         }
         else
         {
+            var arrAddr = Address.Contains(':') ? Address.Split(':') : Address.Split('.');
+            var addr = arrAddr.Length switch
+            {
+                > 2 => $"{arrAddr.First()}***{arrAddr.Last()}",
+                > 1 => $"***{arrAddr.Last()}",
+                _ => Address
+            };
             summary += $"{Remarks}({addr}:{Port})";
         }
         return summary;

--- a/v2rayN/ServiceLib/Models/ProfileItem.cs
+++ b/v2rayN/ServiceLib/Models/ProfileItem.cs
@@ -64,6 +64,51 @@ public class ProfileItem : ReactiveObject
         return Network.TrimEx();
     }
 
+    public bool IsComplex()
+    {
+        return ConfigType is EConfigType.Custom or > EConfigType.Group;
+    }
+
+    public bool IsValid()
+    {
+        if (IsComplex())
+            return true;
+
+        if (Address.IsNullOrEmpty() || Port is <= 0 or >= 65536)
+            return false;
+
+        switch (ConfigType)
+        {
+            case EConfigType.VMess:
+                if (Id.IsNullOrEmpty() || !Utils.IsGuidByParse(Id))
+                    return false;
+                break;
+
+            case EConfigType.VLESS:
+                if (Id.IsNullOrEmpty() || (!Utils.IsGuidByParse(Id) && Id.Length > 30))
+                    return false;
+                if (!Global.Flows.Contains(Flow))
+                    return false;
+                break;
+
+            case EConfigType.Shadowsocks:
+                if (Id.IsNullOrEmpty())
+                    return false;
+                if (string.IsNullOrEmpty(Security) || !Global.SsSecuritiesInSingbox.Contains(Security))
+                    return false;
+                break;
+        }
+
+        if ((ConfigType is EConfigType.VLESS or EConfigType.Trojan)
+            && StreamSecurity == Global.StreamSecurityReality
+            && PublicKey.IsNullOrEmpty())
+        {
+            return false;
+        }
+
+        return true;
+    }
+
     #endregion function
 
     [PrimaryKey]

--- a/v2rayN/ServiceLib/Models/ProfileItem.cs
+++ b/v2rayN/ServiceLib/Models/ProfileItem.cs
@@ -39,11 +39,14 @@ public class ProfileItem : ReactiveObject
             > 1 => $"***{arrAddr.Last()}",
             _ => Address
         };
-        summary += ConfigType switch
+        if (ConfigType is EConfigType.Custom or > EConfigType.Group)
         {
-            EConfigType.Custom => $"[{CoreType.ToString()}]{Remarks}",
-            _ => $"{Remarks}({addr}:{Port})"
-        };
+            summary += $"[{CoreType.ToString()}]{Remarks}";
+        }
+        else
+        {
+            summary += $"{Remarks}({addr}:{Port})";
+        }
         return summary;
     }
 

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -145,6 +145,7 @@ public class Outbound4Sbox : BaseServer4Sbox
     public string? plugin_opts { get; set; }
     public List<string>? outbounds { get; set; }
     public bool? interrupt_exist_connections { get; set; }
+    public int? tolerance { get; set; }
 }
 
 public class Endpoints4Sbox : BaseServer4Sbox

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -979,6 +979,60 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Generate Policy Group from Multiple Profiles 的本地化字符串。
+        /// </summary>
+        public static string menuGenGroupMultipleServer {
+            get {
+                return ResourceManager.GetString("menuGenGroupMultipleServer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Multi-Configuration LeastPing by sing-box 的本地化字符串。
+        /// </summary>
+        public static string menuGenGroupMultipleServerSingBoxLeastPing {
+            get {
+                return ResourceManager.GetString("menuGenGroupMultipleServerSingBoxLeastPing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Multi-Configuration LeastLoad by Xray 的本地化字符串。
+        /// </summary>
+        public static string menuGenGroupMultipleServerXrayLeastLoad {
+            get {
+                return ResourceManager.GetString("menuGenGroupMultipleServerXrayLeastLoad", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Multi-Configuration LeastPing by Xray 的本地化字符串。
+        /// </summary>
+        public static string menuGenGroupMultipleServerXrayLeastPing {
+            get {
+                return ResourceManager.GetString("menuGenGroupMultipleServerXrayLeastPing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Multi-Configuration Random by Xray 的本地化字符串。
+        /// </summary>
+        public static string menuGenGroupMultipleServerXrayRandom {
+            get {
+                return ResourceManager.GetString("menuGenGroupMultipleServerXrayRandom", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Multi-Configuration RoundRobin by Xray 的本地化字符串。
+        /// </summary>
+        public static string menuGenGroupMultipleServerXrayRoundRobin {
+            get {
+                return ResourceManager.GetString("menuGenGroupMultipleServerXrayRoundRobin", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Global Hotkey Setting 的本地化字符串。
         /// </summary>
         public static string menuGlobalHotkeySetting {
@@ -1515,60 +1569,6 @@ namespace ServiceLib.Resx {
         public static string menuServers {
             get {
                 return ResourceManager.GetString("menuServers", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   查找类似 Multi-Configuration to custom configuration 的本地化字符串。
-        /// </summary>
-        public static string menuSetDefaultMultipleServer {
-            get {
-                return ResourceManager.GetString("menuSetDefaultMultipleServer", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   查找类似 Multi-Configuration LeastPing by sing-box 的本地化字符串。
-        /// </summary>
-        public static string menuSetDefaultMultipleServerSingBoxLeastPing {
-            get {
-                return ResourceManager.GetString("menuSetDefaultMultipleServerSingBoxLeastPing", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   查找类似 Multi-Configuration LeastLoad by Xray 的本地化字符串。
-        /// </summary>
-        public static string menuSetDefaultMultipleServerXrayLeastLoad {
-            get {
-                return ResourceManager.GetString("menuSetDefaultMultipleServerXrayLeastLoad", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   查找类似 Multi-Configuration LeastPing by Xray 的本地化字符串。
-        /// </summary>
-        public static string menuSetDefaultMultipleServerXrayLeastPing {
-            get {
-                return ResourceManager.GetString("menuSetDefaultMultipleServerXrayLeastPing", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   查找类似 Multi-Configuration Random by Xray 的本地化字符串。
-        /// </summary>
-        public static string menuSetDefaultMultipleServerXrayRandom {
-            get {
-                return ResourceManager.GetString("menuSetDefaultMultipleServerXrayRandom", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   查找类似 Multi-Configuration RoundRobin by Xray 的本地化字符串。
-        /// </summary>
-        public static string menuSetDefaultMultipleServerXrayRoundRobin {
-            get {
-                return ResourceManager.GetString("menuSetDefaultMultipleServerXrayRoundRobin", resourceCulture);
             }
         }
         

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -1564,6 +1564,15 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Server List 的本地化字符串。
+        /// </summary>
+        public static string menuServerList {
+            get {
+                return ResourceManager.GetString("menuServerList", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Configurations 的本地化字符串。
         /// </summary>
         public static string menuServers {

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -988,11 +988,29 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Multi-Configuration Fallback by sing-box 的本地化字符串。
+        /// </summary>
+        public static string menuGenGroupMultipleServerSingBoxFallback {
+            get {
+                return ResourceManager.GetString("menuGenGroupMultipleServerSingBoxFallback", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Multi-Configuration LeastPing by sing-box 的本地化字符串。
         /// </summary>
         public static string menuGenGroupMultipleServerSingBoxLeastPing {
             get {
                 return ResourceManager.GetString("menuGenGroupMultipleServerSingBoxLeastPing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Multi-Configuration Fallback by Xray 的本地化字符串。
+        /// </summary>
+        public static string menuGenGroupMultipleServerXrayFallback {
+            get {
+                return ResourceManager.GetString("menuGenGroupMultipleServerXrayFallback", resourceCulture);
             }
         }
         
@@ -2595,6 +2613,15 @@ namespace ServiceLib.Resx {
         public static string TbFakeIPTips {
             get {
                 return ResourceManager.GetString("TbFakeIPTips", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Fallback 的本地化字符串。
+        /// </summary>
+        public static string TbFallback {
+            get {
+                return ResourceManager.GetString("TbFallback", resourceCulture);
             }
         }
         

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -673,6 +673,15 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Add Child Configuration 的本地化字符串。
+        /// </summary>
+        public static string menuAddChildServer {
+            get {
+                return ResourceManager.GetString("menuAddChildServer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Add a custom configuration Configuration 的本地化字符串。
         /// </summary>
         public static string menuAddCustomServer {
@@ -696,6 +705,24 @@ namespace ServiceLib.Resx {
         public static string menuAddHysteria2Server {
             get {
                 return ResourceManager.GetString("menuAddHysteria2Server", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Add Policy Group Configuration 的本地化字符串。
+        /// </summary>
+        public static string menuAddPolicyGroupServer {
+            get {
+                return ResourceManager.GetString("menuAddPolicyGroupServer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Add Proxy Chain Configuration 的本地化字符串。
+        /// </summary>
+        public static string menuAddProxyChainServer {
+            get {
+                return ResourceManager.GetString("menuAddProxyChainServer", resourceCulture);
             }
         }
         
@@ -1317,6 +1344,15 @@ namespace ServiceLib.Resx {
         public static string menuRemoteRestore {
             get {
                 return ResourceManager.GetString("menuRemoteRestore", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Remove Child Configuration 的本地化字符串。
+        /// </summary>
+        public static string menuRemoveChildServer {
+            get {
+                return ResourceManager.GetString("menuRemoveChildServer", resourceCulture);
             }
         }
         
@@ -1996,6 +2032,15 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Please Add At Least One Configuration 的本地化字符串。
+        /// </summary>
+        public static string PleaseAddAtLeastOneServer {
+            get {
+                return ResourceManager.GetString("PleaseAddAtLeastOneServer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Please fill Remarks 的本地化字符串。
         /// </summary>
         public static string PleaseFillRemarks {
@@ -2374,6 +2419,24 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Policy Group 的本地化字符串。
+        /// </summary>
+        public static string TbConfigTypePolicyGroup {
+            get {
+                return ResourceManager.GetString("TbConfigTypePolicyGroup", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Proxy Chain 的本地化字符串。
+        /// </summary>
+        public static string TbConfigTypeProxyChain {
+            get {
+                return ResourceManager.GetString("TbConfigTypeProxyChain", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Confirm 的本地化字符串。
         /// </summary>
         public static string TbConfirm {
@@ -2644,6 +2707,24 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Most Stable 的本地化字符串。
+        /// </summary>
+        public static string TbLeastLoad {
+            get {
+                return ResourceManager.GetString("TbLeastLoad", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Lowest Latency 的本地化字符串。
+        /// </summary>
+        public static string TbLeastPing {
+            get {
+                return ResourceManager.GetString("TbLeastPing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Address (IPv4, IPv6) 的本地化字符串。
         /// </summary>
         public static string TbLocalAddress {
@@ -2694,6 +2775,15 @@ namespace ServiceLib.Resx {
         public static string TbPath7 {
             get {
                 return ResourceManager.GetString("TbPath7", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Policy Group Type 的本地化字符串。
+        /// </summary>
+        public static string TbPolicyGroupType {
+            get {
+                return ResourceManager.GetString("TbPolicyGroupType", resourceCulture);
             }
         }
         
@@ -2770,6 +2860,15 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Random 的本地化字符串。
+        /// </summary>
+        public static string TbRandom {
+            get {
+                return ResourceManager.GetString("TbRandom", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 v2ray Full Config Template 的本地化字符串。
         /// </summary>
         public static string TbRayFullConfigTemplate {
@@ -2829,6 +2928,15 @@ namespace ServiceLib.Resx {
         public static string TbReset {
             get {
                 return ResourceManager.GetString("TbReset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Round Robin 的本地化字符串。
+        /// </summary>
+        public static string TbRoundRobin {
+            get {
+                return ResourceManager.GetString("TbRoundRobin", resourceCulture);
             }
         }
         

--- a/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
@@ -1551,4 +1551,13 @@
   <data name="menuServerList" xml:space="preserve">
     <value>Server List</value>
   </data>
+  <data name="TbFallback" xml:space="preserve">
+    <value>Fallback</value>
+  </data>
+  <data name="menuGenGroupMultipleServerSingBoxFallback" xml:space="preserve">
+    <value>Multi-Configuration Fallback by sing-box</value>
+  </data>
+  <data name="menuGenGroupMultipleServerXrayFallback" xml:space="preserve">
+    <value>Multi-Configuration Fallback by Xray</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
@@ -1377,22 +1377,22 @@
   <data name="TbPorts7Tips" xml:space="preserve">
     <value>مخفی و پورت می شود، با کاما (،) جدا می شود</value>
   </data>
-  <data name="menuSetDefaultMultipleServer" xml:space="preserve">
-    <value>چند سرور به پیکربندی سفارشی</value>
+  <data name="menuGenGroupMultipleServer" xml:space="preserve">
+    <value>Generate Policy Group from Multiple Profiles</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayRandom" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayRandom" xml:space="preserve">
     <value>چند سرور تصادفی توسط Xray</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayRoundRobin" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayRoundRobin" xml:space="preserve">
     <value>چند سرور RoundRobin توسط Xray</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayLeastPing" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayLeastPing" xml:space="preserve">
     <value>چند سرور LeastPing توسط Xray</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayLeastLoad" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayLeastLoad" xml:space="preserve">
     <value>چند سرور LeastLoad توسط Xray</value>
   </data>
-  <data name="menuSetDefaultMultipleServerSingBoxLeastPing" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerSingBoxLeastPing" xml:space="preserve">
     <value>LeastPing چند سرور توسط sing-box</value>
   </data>
   <data name="menuExportConfig" xml:space="preserve">

--- a/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
@@ -1548,4 +1548,7 @@
   <data name="menuRemoveChildServer" xml:space="preserve">
     <value>Remove Child Configuration</value>
   </data>
+  <data name="menuServerList" xml:space="preserve">
+    <value>Server List</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
@@ -1512,4 +1512,40 @@
   <data name="TbFakeIPTips" xml:space="preserve">
     <value>Applies globally by default, with built-in FakeIP filtering (sing-box only).</value>
   </data>
+  <data name="PleaseAddAtLeastOneServer" xml:space="preserve">
+    <value>Please Add At Least One Configuration</value>
+  </data>
+  <data name="TbConfigTypePolicyGroup" xml:space="preserve">
+    <value>Policy Group</value>
+  </data>
+  <data name="TbConfigTypeProxyChain" xml:space="preserve">
+    <value>Proxy Chain</value>
+  </data>
+  <data name="TbLeastPing" xml:space="preserve">
+    <value>Lowest Latency</value>
+  </data>
+  <data name="TbRandom" xml:space="preserve">
+    <value>Random</value>
+  </data>
+  <data name="TbRoundRobin" xml:space="preserve">
+    <value>Round Robin</value>
+  </data>
+  <data name="TbLeastLoad" xml:space="preserve">
+    <value>Most Stable</value>
+  </data>
+  <data name="TbPolicyGroupType" xml:space="preserve">
+    <value>Policy Group Type</value>
+  </data>
+  <data name="menuAddPolicyGroupServer" xml:space="preserve">
+    <value>Add Policy Group Configuration</value>
+  </data>
+  <data name="menuAddProxyChainServer" xml:space="preserve">
+    <value>Add Proxy Chain Configuration</value>
+  </data>
+  <data name="menuAddChildServer" xml:space="preserve">
+    <value>Add Child Configuration</value>
+  </data>
+  <data name="menuRemoveChildServer" xml:space="preserve">
+    <value>Remove Child Configuration</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.hu.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.hu.resx
@@ -1551,4 +1551,13 @@
   <data name="menuServerList" xml:space="preserve">
     <value>Server List</value>
   </data>
+  <data name="TbFallback" xml:space="preserve">
+    <value>Fallback</value>
+  </data>
+  <data name="menuGenGroupMultipleServerSingBoxFallback" xml:space="preserve">
+    <value>Multi-Configuration Fallback by sing-box</value>
+  </data>
+  <data name="menuGenGroupMultipleServerXrayFallback" xml:space="preserve">
+    <value>Multi-Configuration Fallback by Xray</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.hu.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.hu.resx
@@ -1377,22 +1377,22 @@
   <data name="TbPorts7Tips" xml:space="preserve">
     <value>A portot lefedi, vesszővel (,) elválasztva</value>
   </data>
-  <data name="menuSetDefaultMultipleServer" xml:space="preserve">
-    <value>Több konfiguráció egyéni konfigurációra</value>
+  <data name="menuGenGroupMultipleServer" xml:space="preserve">
+    <value>Generate Policy Group from Multiple Profiles</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayRandom" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayRandom" xml:space="preserve">
     <value>Több konfiguráció véletlenszerűen Xray szerint</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayRoundRobin" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayRoundRobin" xml:space="preserve">
     <value>Több konfiguráció RoundRobin Xray szerint</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayLeastPing" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayLeastPing" xml:space="preserve">
     <value>Több konfiguráció legkisebb pinggel Xray szerint</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayLeastLoad" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayLeastLoad" xml:space="preserve">
     <value>Több konfiguráció legkisebb terheléssel Xray szerint</value>
   </data>
-  <data name="menuSetDefaultMultipleServerSingBoxLeastPing" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerSingBoxLeastPing" xml:space="preserve">
     <value>Több konfiguráció legkisebb pinggel sing-box szerint</value>
   </data>
   <data name="menuExportConfig" xml:space="preserve">

--- a/v2rayN/ServiceLib/Resx/ResUI.hu.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.hu.resx
@@ -1548,4 +1548,7 @@
   <data name="menuRemoveChildServer" xml:space="preserve">
     <value>Remove Child Configuration</value>
   </data>
+  <data name="menuServerList" xml:space="preserve">
+    <value>Server List</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.hu.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.hu.resx
@@ -1512,4 +1512,40 @@
   <data name="TbFakeIPTips" xml:space="preserve">
     <value>Applies globally by default, with built-in FakeIP filtering (sing-box only).</value>
   </data>
+  <data name="PleaseAddAtLeastOneServer" xml:space="preserve">
+    <value>Please Add At Least One Configuration</value>
+  </data>
+  <data name="TbConfigTypePolicyGroup" xml:space="preserve">
+    <value>Policy Group</value>
+  </data>
+  <data name="TbConfigTypeProxyChain" xml:space="preserve">
+    <value>Proxy Chain</value>
+  </data>
+  <data name="TbLeastPing" xml:space="preserve">
+    <value>Lowest Latency</value>
+  </data>
+  <data name="TbRandom" xml:space="preserve">
+    <value>Random</value>
+  </data>
+  <data name="TbRoundRobin" xml:space="preserve">
+    <value>Round Robin</value>
+  </data>
+  <data name="TbLeastLoad" xml:space="preserve">
+    <value>Most Stable</value>
+  </data>
+  <data name="TbPolicyGroupType" xml:space="preserve">
+    <value>Policy Group Type</value>
+  </data>
+  <data name="menuAddPolicyGroupServer" xml:space="preserve">
+    <value>Add Policy Group Configuration</value>
+  </data>
+  <data name="menuAddProxyChainServer" xml:space="preserve">
+    <value>Add Proxy Chain Configuration</value>
+  </data>
+  <data name="menuAddChildServer" xml:space="preserve">
+    <value>Add Child Configuration</value>
+  </data>
+  <data name="menuRemoveChildServer" xml:space="preserve">
+    <value>Remove Child Configuration</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1551,4 +1551,13 @@
   <data name="menuServerList" xml:space="preserve">
     <value>Server List</value>
   </data>
+  <data name="TbFallback" xml:space="preserve">
+    <value>Fallback</value>
+  </data>
+  <data name="menuGenGroupMultipleServerSingBoxFallback" xml:space="preserve">
+    <value>Multi-Configuration Fallback by sing-box</value>
+  </data>
+  <data name="menuGenGroupMultipleServerXrayFallback" xml:space="preserve">
+    <value>Multi-Configuration Fallback by Xray</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1377,22 +1377,22 @@
   <data name="TbPorts7Tips" xml:space="preserve">
     <value>Will cover the port, separate with commas (,)</value>
   </data>
-  <data name="menuSetDefaultMultipleServer" xml:space="preserve">
-    <value>Multi-Configuration to custom configuration</value>
+  <data name="menuGenGroupMultipleServer" xml:space="preserve">
+    <value>Generate Policy Group from Multiple Profiles</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayRandom" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayRandom" xml:space="preserve">
     <value>Multi-Configuration Random by Xray</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayRoundRobin" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayRoundRobin" xml:space="preserve">
     <value>Multi-Configuration RoundRobin by Xray</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayLeastPing" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayLeastPing" xml:space="preserve">
     <value>Multi-Configuration LeastPing by Xray</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayLeastLoad" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayLeastLoad" xml:space="preserve">
     <value>Multi-Configuration LeastLoad by Xray</value>
   </data>
-  <data name="menuSetDefaultMultipleServerSingBoxLeastPing" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerSingBoxLeastPing" xml:space="preserve">
     <value>Multi-Configuration LeastPing by sing-box</value>
   </data>
   <data name="menuExportConfig" xml:space="preserve">

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1548,4 +1548,7 @@
   <data name="menuRemoveChildServer" xml:space="preserve">
     <value>Remove Child Configuration</value>
   </data>
+  <data name="menuServerList" xml:space="preserve">
+    <value>Server List</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1512,4 +1512,40 @@
   <data name="TbFakeIPTips" xml:space="preserve">
     <value>Applies globally by default, with built-in FakeIP filtering (sing-box only).</value>
   </data>
+  <data name="PleaseAddAtLeastOneServer" xml:space="preserve">
+    <value>Please Add At Least One Configuration</value>
+  </data>
+  <data name="TbConfigTypePolicyGroup" xml:space="preserve">
+    <value>Policy Group</value>
+  </data>
+  <data name="TbConfigTypeProxyChain" xml:space="preserve">
+    <value>Proxy Chain</value>
+  </data>
+  <data name="TbLeastPing" xml:space="preserve">
+    <value>Lowest Latency</value>
+  </data>
+  <data name="TbRandom" xml:space="preserve">
+    <value>Random</value>
+  </data>
+  <data name="TbRoundRobin" xml:space="preserve">
+    <value>Round Robin</value>
+  </data>
+  <data name="TbLeastLoad" xml:space="preserve">
+    <value>Most Stable</value>
+  </data>
+  <data name="TbPolicyGroupType" xml:space="preserve">
+    <value>Policy Group Type</value>
+  </data>
+  <data name="menuAddPolicyGroupServer" xml:space="preserve">
+    <value>Add Policy Group Configuration</value>
+  </data>
+  <data name="menuAddProxyChainServer" xml:space="preserve">
+    <value>Add Proxy Chain Configuration</value>
+  </data>
+  <data name="menuAddChildServer" xml:space="preserve">
+    <value>Add Child Configuration</value>
+  </data>
+  <data name="menuRemoveChildServer" xml:space="preserve">
+    <value>Remove Child Configuration</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1551,4 +1551,13 @@
   <data name="menuServerList" xml:space="preserve">
     <value>Server List</value>
   </data>
+  <data name="TbFallback" xml:space="preserve">
+    <value>Fallback</value>
+  </data>
+  <data name="menuGenGroupMultipleServerSingBoxFallback" xml:space="preserve">
+    <value>Multi-Configuration Fallback by sing-box</value>
+  </data>
+  <data name="menuGenGroupMultipleServerXrayFallback" xml:space="preserve">
+    <value>Multi-Configuration Fallback by Xray</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1548,4 +1548,7 @@
   <data name="menuRemoveChildServer" xml:space="preserve">
     <value>Remove Child Configuration</value>
   </data>
+  <data name="menuServerList" xml:space="preserve">
+    <value>Server List</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1377,22 +1377,22 @@
   <data name="TbPorts7Tips" xml:space="preserve">
     <value>Заменит указанный порт, перечисляйте через запятую (,)</value>
   </data>
-  <data name="menuSetDefaultMultipleServer" xml:space="preserve">
-    <value>От мультиконфигурации к пользовательской конфигурации</value>
+  <data name="menuGenGroupMultipleServer" xml:space="preserve">
+    <value>Generate Policy Group from Multiple Profiles</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayRandom" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayRandom" xml:space="preserve">
     <value>Случайный (Xray)</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayRoundRobin" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayRoundRobin" xml:space="preserve">
     <value>Круговой (Xray)</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayLeastPing" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayLeastPing" xml:space="preserve">
     <value>Минимальное RTT (минимальное время туда-обратно) (Xray)</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayLeastLoad" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayLeastLoad" xml:space="preserve">
     <value>Минимальная нагрузка (Xray)</value>
   </data>
-  <data name="menuSetDefaultMultipleServerSingBoxLeastPing" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerSingBoxLeastPing" xml:space="preserve">
     <value>Минимальное RTT (минимальное время туда-обратно) (sing-box)</value>
   </data>
   <data name="menuExportConfig" xml:space="preserve">

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1512,4 +1512,40 @@
   <data name="TbFakeIPTips" xml:space="preserve">
     <value>Applies globally by default, with built-in FakeIP filtering (sing-box only).</value>
   </data>
+  <data name="PleaseAddAtLeastOneServer" xml:space="preserve">
+    <value>Please Add At Least One Configuration</value>
+  </data>
+  <data name="TbConfigTypePolicyGroup" xml:space="preserve">
+    <value>Policy Group</value>
+  </data>
+  <data name="TbConfigTypeProxyChain" xml:space="preserve">
+    <value>Proxy Chain</value>
+  </data>
+  <data name="TbLeastPing" xml:space="preserve">
+    <value>Lowest Latency</value>
+  </data>
+  <data name="TbRandom" xml:space="preserve">
+    <value>Random</value>
+  </data>
+  <data name="TbRoundRobin" xml:space="preserve">
+    <value>Round Robin</value>
+  </data>
+  <data name="TbLeastLoad" xml:space="preserve">
+    <value>Most Stable</value>
+  </data>
+  <data name="TbPolicyGroupType" xml:space="preserve">
+    <value>Policy Group Type</value>
+  </data>
+  <data name="menuAddPolicyGroupServer" xml:space="preserve">
+    <value>Add Policy Group Configuration</value>
+  </data>
+  <data name="menuAddProxyChainServer" xml:space="preserve">
+    <value>Add Proxy Chain Configuration</value>
+  </data>
+  <data name="menuAddChildServer" xml:space="preserve">
+    <value>Add Child Configuration</value>
+  </data>
+  <data name="menuRemoveChildServer" xml:space="preserve">
+    <value>Remove Child Configuration</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1545,4 +1545,7 @@
   <data name="menuRemoveChildServer" xml:space="preserve">
     <value>删除子配置文件</value>
   </data>
+  <data name="menuServerList" xml:space="preserve">
+    <value>服务器列表</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1374,22 +1374,22 @@
   <data name="TbPorts7Tips" xml:space="preserve">
     <value>会覆盖端口，多组时用逗号 (,) 隔开</value>
   </data>
-  <data name="menuSetDefaultMultipleServer" xml:space="preserve">
-    <value>多配置文件产生自定义配置 (多选)</value>
+  <data name="menuGenGroupMultipleServer" xml:space="preserve">
+    <value>多配置文件生成策略组</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayRandom" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayRandom" xml:space="preserve">
     <value>多配置文件随机 Xray</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayRoundRobin" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayRoundRobin" xml:space="preserve">
     <value>多配置文件负载均衡 Xray</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayLeastPing" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayLeastPing" xml:space="preserve">
     <value>多配置文件最低延迟 Xray</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayLeastLoad" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayLeastLoad" xml:space="preserve">
     <value>多配置文件最稳定 Xray</value>
   </data>
-  <data name="menuSetDefaultMultipleServerSingBoxLeastPing" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerSingBoxLeastPing" xml:space="preserve">
     <value>多配置文件最低延迟 sing-box</value>
   </data>
   <data name="menuExportConfig" xml:space="preserve">

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1548,4 +1548,13 @@
   <data name="menuServerList" xml:space="preserve">
     <value>服务器列表</value>
   </data>
+  <data name="TbFallback" xml:space="preserve">
+    <value>故障转移</value>
+  </data>
+  <data name="menuGenGroupMultipleServerSingBoxFallback" xml:space="preserve">
+    <value>多配置文件故障转移 sing-box</value>
+  </data>
+  <data name="menuGenGroupMultipleServerXrayFallback" xml:space="preserve">
+    <value>多配置文件故障转移 Xray</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1509,4 +1509,40 @@
   <data name="TbFakeIPTips" xml:space="preserve">
     <value>默认全局生效，内置 FakeIP 过滤，仅在 sing-box 中生效</value>
   </data>
+  <data name="PleaseAddAtLeastOneServer" xml:space="preserve">
+    <value>请至少添加一个配置文件</value>
+  </data>
+  <data name="TbConfigTypePolicyGroup" xml:space="preserve">
+    <value>策略组</value>
+  </data>
+  <data name="TbConfigTypeProxyChain" xml:space="preserve">
+    <value>链式代理</value>
+  </data>
+  <data name="TbLeastPing" xml:space="preserve">
+    <value>最低延迟</value>
+  </data>
+  <data name="TbRandom" xml:space="preserve">
+    <value>随机</value>
+  </data>
+  <data name="TbRoundRobin" xml:space="preserve">
+    <value>负载均衡</value>
+  </data>
+  <data name="TbLeastLoad" xml:space="preserve">
+    <value>最稳定</value>
+  </data>
+  <data name="TbPolicyGroupType" xml:space="preserve">
+    <value>策略组类型</value>
+  </data>
+  <data name="menuAddPolicyGroupServer" xml:space="preserve">
+    <value>添加策略组配置文件</value>
+  </data>
+  <data name="menuAddProxyChainServer" xml:space="preserve">
+    <value>添加链式代理配置文件</value>
+  </data>
+  <data name="menuAddChildServer" xml:space="preserve">
+    <value>添加子配置文件</value>
+  </data>
+  <data name="menuRemoveChildServer" xml:space="preserve">
+    <value>删除子配置文件</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -1374,22 +1374,22 @@
   <data name="TbPorts7Tips" xml:space="preserve">
     <value>會覆蓋埠，多組時用逗號 (,) 隔開</value>
   </data>
-  <data name="menuSetDefaultMultipleServer" xml:space="preserve">
-    <value>多設定檔產生自訂配置 (多選)</value>
+  <data name="menuGenGroupMultipleServer" xml:space="preserve">
+    <value>Generate Policy Group from Multiple Profiles</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayRandom" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayRandom" xml:space="preserve">
     <value>多設定檔隨機 Xray</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayRoundRobin" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayRoundRobin" xml:space="preserve">
     <value>多設定檔負載平衡 Xray</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayLeastPing" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayLeastPing" xml:space="preserve">
     <value>多設定檔最低延遲 Xray</value>
   </data>
-  <data name="menuSetDefaultMultipleServerXrayLeastLoad" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerXrayLeastLoad" xml:space="preserve">
     <value>多設定檔最穩定 Xray</value>
   </data>
-  <data name="menuSetDefaultMultipleServerSingBoxLeastPing" xml:space="preserve">
+  <data name="menuGenGroupMultipleServerSingBoxLeastPing" xml:space="preserve">
     <value>多設定檔最低延遲 sing-box</value>
   </data>
   <data name="menuExportConfig" xml:space="preserve">

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -1545,4 +1545,7 @@
   <data name="menuRemoveChildServer" xml:space="preserve">
     <value>Remove Child Configuration</value>
   </data>
+  <data name="menuServerList" xml:space="preserve">
+    <value>Server List</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -1509,4 +1509,40 @@
   <data name="TbFakeIPTips" xml:space="preserve">
     <value>Applies globally by default, with built-in FakeIP filtering (sing-box only).</value>
   </data>
+  <data name="PleaseAddAtLeastOneServer" xml:space="preserve">
+    <value>Please Add At Least One Configuration</value>
+  </data>
+  <data name="TbConfigTypePolicyGroup" xml:space="preserve">
+    <value>Policy Group</value>
+  </data>
+  <data name="TbConfigTypeProxyChain" xml:space="preserve">
+    <value>Proxy Chain</value>
+  </data>
+  <data name="TbLeastPing" xml:space="preserve">
+    <value>Lowest Latency</value>
+  </data>
+  <data name="TbRandom" xml:space="preserve">
+    <value>Random</value>
+  </data>
+  <data name="TbRoundRobin" xml:space="preserve">
+    <value>Round Robin</value>
+  </data>
+  <data name="TbLeastLoad" xml:space="preserve">
+    <value>Most Stable</value>
+  </data>
+  <data name="TbPolicyGroupType" xml:space="preserve">
+    <value>Policy Group Type</value>
+  </data>
+  <data name="menuAddPolicyGroupServer" xml:space="preserve">
+    <value>Add Policy Group Configuration</value>
+  </data>
+  <data name="menuAddProxyChainServer" xml:space="preserve">
+    <value>Add Proxy Chain Configuration</value>
+  </data>
+  <data name="menuAddChildServer" xml:space="preserve">
+    <value>Add Child Configuration</value>
+  </data>
+  <data name="menuRemoveChildServer" xml:space="preserve">
+    <value>Remove Child Configuration</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -1548,4 +1548,13 @@
   <data name="menuServerList" xml:space="preserve">
     <value>Server List</value>
   </data>
+  <data name="TbFallback" xml:space="preserve">
+    <value>Fallback</value>
+  </data>
+  <data name="menuGenGroupMultipleServerSingBoxFallback" xml:space="preserve">
+    <value>Multi-Configuration Fallback by sing-box</value>
+  </data>
+  <data name="menuGenGroupMultipleServerXrayFallback" xml:space="preserve">
+    <value>Multi-Configuration Fallback by Xray</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/CoreConfigSingboxService.cs
@@ -451,7 +451,7 @@ public partial class CoreConfigSingboxService(Config config)
                 ret.Msg = ResUI.FailedGenDefaultConfiguration;
                 return ret;
             }
-            await GenOutboundsList(proxyProfiles, singboxConfig, multipleLoad);
+            await GenOutboundsListWithChain(proxyProfiles, singboxConfig, multipleLoad);
 
             await GenDns(null, singboxConfig);
             await ConvertGeo2Ruleset(singboxConfig);

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/CoreConfigSingboxService.cs
@@ -408,6 +408,11 @@ public partial class CoreConfigSingboxService(Config config)
             var proxyProfiles = new List<ProfileItem>();
             foreach (var it in selecteds)
             {
+                if (it.ConfigType is EConfigType.PolicyGroup or EConfigType.ProxyChain)
+                {
+                    var itemGroup = await AppManager.Instance.GetProfileItem(it.IndexId);
+                    proxyProfiles.Add(itemGroup);
+                }
                 if (!Global.SingboxSupportConfigType.Contains(it.ConfigType))
                 {
                     continue;

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/CoreConfigSingboxService.cs
@@ -363,8 +363,6 @@ public partial class CoreConfigSingboxService(Config config)
 
             await GenLog(singboxConfig);
             await GenInbounds(singboxConfig);
-            await GenRouting(singboxConfig);
-            await GenExperimental(singboxConfig);
 
             var groupRet = await GenGroupOutbound(parentNode, singboxConfig);
             if (groupRet != 0)
@@ -373,6 +371,8 @@ public partial class CoreConfigSingboxService(Config config)
                 return ret;
             }
 
+            await GenRouting(singboxConfig);
+            await GenExperimental(singboxConfig);
             await GenDns(null, singboxConfig);
             await ConvertGeo2Ruleset(singboxConfig);
 
@@ -416,12 +416,10 @@ public partial class CoreConfigSingboxService(Config config)
                 ret.Msg = ResUI.FailedGenDefaultConfiguration;
                 return ret;
             }
+            singboxConfig.outbounds.RemoveAt(0);
 
             await GenLog(singboxConfig);
             await GenInbounds(singboxConfig);
-            await GenRouting(singboxConfig);
-            await GenExperimental(singboxConfig);
-            singboxConfig.outbounds.RemoveAt(0);
 
             var groupRet = await GenGroupOutbound(parentNode, singboxConfig);
             if (groupRet != 0)
@@ -430,6 +428,8 @@ public partial class CoreConfigSingboxService(Config config)
                 return ret;
             }
 
+            await GenRouting(singboxConfig);
+            await GenExperimental(singboxConfig);
             await GenDns(null, singboxConfig);
             await ConvertGeo2Ruleset(singboxConfig);
 

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/CoreConfigSingboxService.cs
@@ -398,12 +398,12 @@ public partial class CoreConfigSingboxService(Config config)
                 ret.Msg = ResUI.FailedGenDefaultConfiguration;
                 return ret;
             }
+            singboxConfig.outbounds.RemoveAt(0);
 
             await GenLog(singboxConfig);
             await GenInbounds(singboxConfig);
             await GenRouting(singboxConfig);
             await GenExperimental(singboxConfig);
-            singboxConfig.outbounds.RemoveAt(0);
 
             var proxyProfiles = new List<ProfileItem>();
             foreach (var it in selecteds)

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/CoreConfigSingboxService.cs
@@ -36,7 +36,7 @@ public partial class CoreConfigSingboxService(Config config)
                 switch (node.ConfigType)
                 {
                     case EConfigType.PolicyGroup:
-                        return await GenerateClientMultipleLoadConfig(childProfiles);
+                        return await GenerateClientMultipleLoadConfig(childProfiles, profileGroupItem.MultipleLoad);
                     case EConfigType.ProxyChain:
                         return await GenerateClientChainConfig(childProfiles);
                 }
@@ -371,7 +371,7 @@ public partial class CoreConfigSingboxService(Config config)
         }
     }
 
-    public async Task<RetResult> GenerateClientMultipleLoadConfig(List<ProfileItem> selecteds)
+    public async Task<RetResult> GenerateClientMultipleLoadConfig(List<ProfileItem> selecteds, EMultipleLoad multipleLoad)
     {
         var ret = new RetResult();
         try
@@ -446,7 +446,7 @@ public partial class CoreConfigSingboxService(Config config)
                 ret.Msg = ResUI.FailedGenDefaultConfiguration;
                 return ret;
             }
-            await GenOutboundsList(proxyProfiles, singboxConfig);
+            await GenOutboundsList(proxyProfiles, singboxConfig, multipleLoad);
 
             await GenDns(null, singboxConfig);
             await ConvertGeo2Ruleset(singboxConfig);

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/CoreConfigSingboxService.cs
@@ -15,6 +15,26 @@ public partial class CoreConfigSingboxService(Config config)
         var ret = new RetResult();
         try
         {
+            if (node?.ConfigType is EConfigType.PolicyGroup or EConfigType.ProxyChain)
+            {
+                ProfileGroupItemManager.Instance.TryGet(node.IndexId, out var profileGroupItem);
+                if (profileGroupItem == null || profileGroupItem.ChildItems.IsNullOrEmpty())
+                {
+                    ret.Msg = ResUI.CheckServerSettings;
+                    return ret;
+                }
+                if (node.ConfigType is EConfigType.PolicyGroup)
+                {
+                    var childProfiles = (await Task.WhenAll(
+                            Utils.String2List(profileGroupItem.ChildItems)
+                            .Where(p => !p.IsNullOrEmpty())
+                            .Select(AppManager.Instance.GetProfileItem)
+                        )).Where(p => p != null).ToList();
+                    return await GenerateClientMultipleLoadConfig(childProfiles);
+                }
+                // TODO proxy chain
+            }
+
             if (node == null
                 || node.Port <= 0)
             {

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxDnsService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxDnsService.cs
@@ -414,16 +414,19 @@ public partial class CoreConfigSingboxService
             return 0;
         }
 
-        var domain = string.Empty;
+        List<string> domain = new();
         if (Utils.IsDomain(node.Address)) // normal outbound
         {
-            domain = node.Address;
+            domain.Add(node.Address);
         }
-        else if (node.Address == Global.Loopback && node.SpiderX.IsNotEmpty() && Utils.IsDomain(node.SpiderX)) // Tun2SocksAddress
+        if (node.Address == Global.Loopback && node.SpiderX.IsNotEmpty()) // Tun2SocksAddress
         {
-            domain = node.SpiderX;
+            domain.AddRange(Utils.String2List(node.SpiderX)
+                .Where(Utils.IsDomain)
+                .Distinct()
+                .ToList());
         }
-        if (domain.IsNullOrEmpty())
+        if (domain.Count == 0)
         {
             return 0;
         }
@@ -432,7 +435,7 @@ public partial class CoreConfigSingboxService
         singboxConfig.dns.rules.Insert(0, new Rule4Sbox
         {
             server = server,
-            domain = [domain],
+            domain = domain,
         });
 
         return await Task.FromResult(0);

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -574,4 +574,52 @@ public partial class CoreConfigSingboxService
         }
         return null;
     }
+
+    private async Task<int> GenChainOutboundsList(List<ProfileItem> nodes, SingboxConfig singboxConfig)
+    {
+        var resultOutbounds = new List<Outbound4Sbox>();
+        var resultEndpoints = new List<Endpoints4Sbox>(); // For endpoints
+        for (var i = 0; i < nodes.Count; i++)
+        {
+            var node = nodes[i];
+            var server = await GenServer(node);
+
+            if (server is null)
+            {
+                break;
+            }
+
+            if (i == 0)
+            {
+                server.tag = Global.ProxyTag;
+            }
+            else
+            {
+                server.tag = Global.ProxyTag + i.ToString();
+            }
+
+            if (i != nodes.Count - 1)
+            {
+                server.detour = Global.ProxyTag + (i + 1).ToString();
+            }
+
+            if (server is Endpoints4Sbox endpoint)
+            {
+                resultEndpoints.Add(endpoint);
+            }
+            else if (server is Outbound4Sbox outbound)
+            {
+                resultOutbounds.Add(outbound);
+            }
+        }
+        singboxConfig.outbounds ??= new();
+        resultOutbounds.AddRange(singboxConfig.outbounds);
+        singboxConfig.outbounds = resultOutbounds;
+
+        singboxConfig.endpoints ??= new();
+        resultEndpoints.AddRange(singboxConfig.endpoints);
+        singboxConfig.endpoints = resultEndpoints;
+
+        return await Task.FromResult(0);
+    }
 }

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -494,12 +494,6 @@ public partial class CoreConfigSingboxService
 
                 if (node.ConfigType is EConfigType.PolicyGroup or EConfigType.ProxyChain)
                 {
-                    var hasCycle = ProfileGroupItemManager.HasCycle(node.IndexId);
-                    if (hasCycle)
-                    {
-                        return -1;
-                    }
-
                     var (childProfiles, profileGroupItem) = await ProfileGroupItemManager.GetChildProfileItems(node.IndexId);
                     if (childProfiles.Count <= 0)
                     {
@@ -675,12 +669,6 @@ public partial class CoreConfigSingboxService
                 continue;
             if (node.ConfigType is EConfigType.PolicyGroup or EConfigType.ProxyChain)
             {
-                var hasCycle = ProfileGroupItemManager.HasCycle(node.IndexId);
-                if (hasCycle)
-                {
-                    return -1;
-                }
-
                 var (childProfiles, profileGroupItem) = await ProfileGroupItemManager.GetChildProfileItems(node.IndexId);
                 if (childProfiles.Count <= 0)
                 {

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -682,11 +682,13 @@ public partial class CoreConfigSingboxService
 
     private async Task<int> GenChainOutboundsList(List<ProfileItem> nodes, SingboxConfig singboxConfig, string baseTagName = Global.ProxyTag)
     {
+        // Based on actual network flow instead of data packets
+        var nodesReverse = nodes.AsEnumerable().Reverse().ToList();
         var resultOutbounds = new List<Outbound4Sbox>();
         var resultEndpoints = new List<Endpoints4Sbox>(); // For endpoints
-        for (var i = 0; i < nodes.Count; i++)
+        for (var i = 0; i < nodesReverse.Count; i++)
         {
-            var node = nodes[i];
+            var node = nodesReverse[i];
             var server = await GenServer(node);
 
             if (server is null)
@@ -703,7 +705,7 @@ public partial class CoreConfigSingboxService
                 server.tag = baseTagName + i.ToString();
             }
 
-            if (i != nodes.Count - 1)
+            if (i != nodesReverse.Count - 1)
             {
                 server.detour = baseTagName + (i + 1).ToString();
             }

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -410,7 +410,7 @@ public partial class CoreConfigSingboxService
         return 0;
     }
 
-    private async Task<int> GenOutboundsList(List<ProfileItem> nodes, SingboxConfig singboxConfig)
+    private async Task<int> GenOutboundsList(List<ProfileItem> nodes, SingboxConfig singboxConfig, EMultipleLoad multipleLoad)
     {
         try
         {
@@ -512,6 +512,11 @@ public partial class CoreConfigSingboxService
                     outbounds = proxyTags,
                     interrupt_exist_connections = false,
                 };
+
+                if (multipleLoad == EMultipleLoad.Fallback)
+                {
+                    outUrltest.tolerance = 5000;
+                }
 
                 // Add selector outbound (manual selection)
                 var outSelector = new Outbound4Sbox

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -204,7 +204,7 @@ public partial class CoreConfigSingboxService
         return await Task.FromResult<BaseServer4Sbox?>(null);
     }
 
-    private async Task<int> GenGroupOutbound(ProfileItem node, SingboxConfig singboxConfig, string baseTagName = Global.ProxyTag)
+    private async Task<int> GenGroupOutbound(ProfileItem node, SingboxConfig singboxConfig, string baseTagName = Global.ProxyTag, bool ignoreOriginChain = false)
     {
         try
         {
@@ -239,7 +239,15 @@ public partial class CoreConfigSingboxService
             switch (node.ConfigType)
             {
                 case EConfigType.PolicyGroup:
-                    await GenOutboundsListWithChain(childProfiles, singboxConfig, profileGroupItem.MultipleLoad, baseTagName);
+                    if (ignoreOriginChain)
+                    {
+                        await GenOutboundsList(childProfiles, singboxConfig, profileGroupItem.MultipleLoad, baseTagName);
+                    }
+                    else
+                    {
+                        await GenOutboundsListWithChain(childProfiles, singboxConfig, profileGroupItem.MultipleLoad, baseTagName);
+                    }
+
                     break;
                 case EConfigType.ProxyChain:
                     await GenChainOutboundsList(childProfiles, singboxConfig, baseTagName);

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -217,9 +217,15 @@ public partial class CoreConfigSingboxService
             {
                 return -1;
             }
+
+            var hasCycle = await node.HasCycle(new HashSet<string>(), new HashSet<string>());
+            if (hasCycle)
+            {
+                return -1;
+            }
+
             // remove custom nodes
             // remove group nodes for proxy chain
-            // avoid self-reference
             var childProfiles = (await Task.WhenAll(
                     Utils.String2List(profileGroupItem.ChildItems)
                         .Where(p => !p.IsNullOrEmpty())
@@ -230,7 +236,6 @@ public partial class CoreConfigSingboxService
                     && p.IsValid()
                     && p.ConfigType != EConfigType.Custom
                     && (node.ConfigType == EConfigType.PolicyGroup || p.ConfigType < EConfigType.Group)
-                    && p.IndexId != node.IndexId
                 )
                 .ToList();
 

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -212,33 +212,13 @@ public partial class CoreConfigSingboxService
             {
                 return -1;
             }
-            ProfileGroupItemManager.Instance.TryGet(node.IndexId, out var profileGroupItem);
-            if (profileGroupItem is null || profileGroupItem.ChildItems.IsNullOrEmpty())
-            {
-                return -1;
-            }
-
-            var hasCycle = await node.HasCycle(new HashSet<string>(), new HashSet<string>());
+            var hasCycle = ProfileGroupItemManager.HasCycle(node.IndexId);
             if (hasCycle)
             {
                 return -1;
             }
 
-            // remove custom nodes
-            // remove group nodes for proxy chain
-            var childProfiles = (await Task.WhenAll(
-                    Utils.String2List(profileGroupItem.ChildItems)
-                        .Where(p => !p.IsNullOrEmpty())
-                        .Select(AppManager.Instance.GetProfileItem)
-                ))
-                .Where(p =>
-                    p != null
-                    && p.IsValid()
-                    && p.ConfigType != EConfigType.Custom
-                    && (node.ConfigType == EConfigType.PolicyGroup || p.ConfigType < EConfigType.Group)
-                )
-                .ToList();
-
+            var (childProfiles, profileGroupItem) = await ProfileGroupItemManager.GetChildProfileItems(node.IndexId);
             if (childProfiles.Count <= 0)
             {
                 return -1;
@@ -514,16 +494,13 @@ public partial class CoreConfigSingboxService
 
                 if (node.ConfigType is EConfigType.PolicyGroup or EConfigType.ProxyChain)
                 {
-                    ProfileGroupItemManager.Instance.TryGet(node.IndexId, out var profileGroupItem);
-                    if (profileGroupItem == null || profileGroupItem.ChildItems.IsNullOrEmpty())
+                    var hasCycle = ProfileGroupItemManager.HasCycle(node.IndexId);
+                    if (hasCycle)
                     {
-                        continue;
+                        return -1;
                     }
-                    var childProfiles = (await Task.WhenAll(
-                            Utils.String2List(profileGroupItem.ChildItems)
-                            .Where(p => !p.IsNullOrEmpty())
-                            .Select(AppManager.Instance.GetProfileItem)
-                        )).Where(p => p != null).ToList();
+
+                    var (childProfiles, profileGroupItem) = await ProfileGroupItemManager.GetChildProfileItems(node.IndexId);
                     if (childProfiles.Count <= 0)
                     {
                         continue;
@@ -698,16 +675,13 @@ public partial class CoreConfigSingboxService
                 continue;
             if (node.ConfigType is EConfigType.PolicyGroup or EConfigType.ProxyChain)
             {
-                ProfileGroupItemManager.Instance.TryGet(node.IndexId, out var profileGroupItem);
-                if (profileGroupItem == null || profileGroupItem.ChildItems.IsNullOrEmpty())
+                var hasCycle = ProfileGroupItemManager.HasCycle(node.IndexId);
+                if (hasCycle)
                 {
-                    continue;
+                    return -1;
                 }
-                var childProfiles = (await Task.WhenAll(
-                        Utils.String2List(profileGroupItem.ChildItems)
-                        .Where(p => !p.IsNullOrEmpty())
-                        .Select(AppManager.Instance.GetProfileItem)
-                    )).Where(p => p != null).ToList();
+
+                var (childProfiles, profileGroupItem) = await ProfileGroupItemManager.GetChildProfileItems(node.IndexId);
                 if (childProfiles.Count <= 0)
                 {
                     continue;

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -219,16 +219,18 @@ public partial class CoreConfigSingboxService
             }
             // remove custom nodes
             // remove group nodes for proxy chain
+            // avoid self-reference
             var childProfiles = (await Task.WhenAll(
                     Utils.String2List(profileGroupItem.ChildItems)
                         .Where(p => !p.IsNullOrEmpty())
                         .Select(AppManager.Instance.GetProfileItem)
                 ))
                 .Where(p =>
-                    p != null &&
-                    p.IsValid() &&
-                    p.ConfigType != EConfigType.Custom &&
-                    (node.ConfigType == EConfigType.PolicyGroup || p.ConfigType < EConfigType.Group)
+                    p != null
+                    && p.IsValid()
+                    && p.ConfigType != EConfigType.Custom
+                    && (node.ConfigType == EConfigType.PolicyGroup || p.ConfigType < EConfigType.Group)
+                    && p.IndexId != node.IndexId
                 )
                 .ToList();
 

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -217,11 +217,21 @@ public partial class CoreConfigSingboxService
             {
                 return -1;
             }
+            // remove custom nodes
+            // remove group nodes for proxy chain
             var childProfiles = (await Task.WhenAll(
                     Utils.String2List(profileGroupItem.ChildItems)
-                    .Where(p => !p.IsNullOrEmpty())
-                    .Select(AppManager.Instance.GetProfileItem)
-                )).Where(p => p != null && p.IsValid()).ToList();
+                        .Where(p => !p.IsNullOrEmpty())
+                        .Select(AppManager.Instance.GetProfileItem)
+                ))
+                .Where(p =>
+                    p != null &&
+                    p.IsValid() &&
+                    p.ConfigType != EConfigType.Custom &&
+                    (node.ConfigType == EConfigType.PolicyGroup || p.ConfigType < EConfigType.Group)
+                )
+                .ToList();
+
             if (childProfiles.Count <= 0)
             {
                 return -1;

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
@@ -403,7 +403,7 @@ public partial class CoreConfigSingboxService
             var ret = node.ConfigType switch
             {
                 EConfigType.PolicyGroup =>
-                    await GenOutboundsList(childProfiles, singboxConfig, profileGroupItem.MultipleLoad, childBaseTagName),
+                    await GenOutboundsListWithChain(childProfiles, singboxConfig, profileGroupItem.MultipleLoad, childBaseTagName),
                 EConfigType.ProxyChain =>
                     await GenChainOutboundsList(childProfiles, singboxConfig, childBaseTagName),
                 _ => throw new NotImplementedException()

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
@@ -385,29 +385,8 @@ public partial class CoreConfigSingboxService
 
         if (node.ConfigType is EConfigType.PolicyGroup or EConfigType.ProxyChain)
         {
-            ProfileGroupItemManager.Instance.TryGet(node.IndexId, out var profileGroupItem);
-            if (profileGroupItem == null || profileGroupItem.ChildItems.IsNullOrEmpty())
-            {
-                return Global.ProxyTag;
-            }
-            var childProfiles = (await Task.WhenAll(
-                    Utils.String2List(profileGroupItem.ChildItems)
-                    .Where(p => !p.IsNullOrEmpty())
-                    .Select(AppManager.Instance.GetProfileItem)
-                )).Where(p => p != null).ToList();
-            if (childProfiles.Count <= 0)
-            {
-                return Global.ProxyTag;
-            }
             var childBaseTagName = $"{Global.ProxyTag}-{node.IndexId}";
-            var ret = node.ConfigType switch
-            {
-                EConfigType.PolicyGroup =>
-                    await GenOutboundsListWithChain(childProfiles, singboxConfig, profileGroupItem.MultipleLoad, childBaseTagName),
-                EConfigType.ProxyChain =>
-                    await GenChainOutboundsList(childProfiles, singboxConfig, childBaseTagName),
-                _ => throw new NotImplementedException()
-            };
+            var ret = await GenGroupOutbound(node, singboxConfig, childBaseTagName);
             if (ret == 0)
             {
                 return childBaseTagName;

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
@@ -376,7 +376,7 @@ public partial class CoreConfigSingboxService
             return Global.ProxyTag;
         }
 
-        var tag = Global.ProxyTag + node.IndexId.ToString();
+        var tag = $"{node.IndexId}-{Global.ProxyTag}";
         if (singboxConfig.outbounds.Any(o => o.tag == tag)
             || (singboxConfig.endpoints != null && singboxConfig.endpoints.Any(e => e.tag == tag)))
         {
@@ -385,11 +385,10 @@ public partial class CoreConfigSingboxService
 
         if (node.ConfigType is EConfigType.PolicyGroup or EConfigType.ProxyChain)
         {
-            var childBaseTagName = $"{Global.ProxyTag}-{node.IndexId}";
-            var ret = await GenGroupOutbound(node, singboxConfig, childBaseTagName);
+            var ret = await GenGroupOutbound(node, singboxConfig, tag);
             if (ret == 0)
             {
-                return childBaseTagName;
+                return tag;
             }
             return Global.ProxyTag;
         }

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
@@ -137,6 +137,11 @@ public partial class CoreConfigV2rayService(Config config)
             var proxyProfiles = new List<ProfileItem>();
             foreach (var it in selecteds)
             {
+                if (it.ConfigType is EConfigType.PolicyGroup or EConfigType.ProxyChain)
+                {
+                    var itemGroup = await AppManager.Instance.GetProfileItem(it.IndexId);
+                    proxyProfiles.Add(itemGroup);
+                }
                 if (!Global.XraySupportConfigType.Contains(it.ConfigType))
                 {
                     continue;

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
@@ -180,7 +180,7 @@ public partial class CoreConfigV2rayService(Config config)
                 ret.Msg = ResUI.FailedGenDefaultConfiguration;
                 return ret;
             }
-            await GenOutboundsList(proxyProfiles, v2rayConfig);
+            await GenOutboundsListWithChain(proxyProfiles, v2rayConfig);
 
             //add balancers
             await GenObservatory(v2rayConfig, multipleLoad);

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
@@ -114,9 +114,6 @@ public partial class CoreConfigV2rayService(Config config)
 
             await GenLog(v2rayConfig);
             await GenInbounds(v2rayConfig);
-            await GenRouting(v2rayConfig);
-            await GenDns(null, v2rayConfig);
-            await GenStatistic(v2rayConfig);
 
             var groupRet = await GenGroupOutbound(parentNode, v2rayConfig);
             if (groupRet != 0)
@@ -125,11 +122,15 @@ public partial class CoreConfigV2rayService(Config config)
                 return ret;
             }
 
+            await GenRouting(v2rayConfig);
+            await GenDns(null, v2rayConfig);
+            await GenStatistic(v2rayConfig);
+
             var defaultBalancerTag = $"{Global.ProxyTag}{Global.BalancerTagSuffix}";
 
             //add rule
             var rules = v2rayConfig.routing.rules;
-            if (rules?.Count > 0)
+            if (rules?.Count > 0 && ((v2rayConfig.routing.balancers?.Count ?? 0) > 0))
             {
                 var balancerTagSet = v2rayConfig.routing.balancers
                     .Select(b => b.tag)
@@ -215,13 +216,10 @@ public partial class CoreConfigV2rayService(Config config)
                 ret.Msg = ResUI.FailedGenDefaultConfiguration;
                 return ret;
             }
+            v2rayConfig.outbounds.RemoveAt(0);
 
             await GenLog(v2rayConfig);
             await GenInbounds(v2rayConfig);
-            await GenRouting(v2rayConfig);
-            await GenDns(null, v2rayConfig);
-            await GenStatistic(v2rayConfig);
-            v2rayConfig.outbounds.RemoveAt(0);
 
             var groupRet = await GenGroupOutbound(parentNode, v2rayConfig);
             if (groupRet != 0)
@@ -229,6 +227,10 @@ public partial class CoreConfigV2rayService(Config config)
                 ret.Msg = ResUI.FailedGenDefaultConfiguration;
                 return ret;
             }
+
+            await GenRouting(v2rayConfig);
+            await GenDns(null, v2rayConfig);
+            await GenStatistic(v2rayConfig);
 
             ret.Success = true;
 

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayBalancerService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayBalancerService.cs
@@ -15,7 +15,7 @@ public partial class CoreConfigV2rayService
             };
             v2rayConfig.observatory = observatory;
         }
-        else if (multipleLoad == EMultipleLoad.LeastLoad)
+        else if (multipleLoad is EMultipleLoad.LeastLoad or EMultipleLoad.Fallback)
         {
             var burstObservatory = new BurstObservatory4Ray
             {
@@ -41,7 +41,14 @@ public partial class CoreConfigV2rayService
         var balancer = new BalancersItem4Ray
         {
             selector = [Global.ProxyTag],
-            strategy = new() { type = strategyType },
+            strategy = new()
+            {
+                type = strategyType,
+                settings = new()
+                {
+                    expected = 1,
+                },
+            },
             tag = $"{Global.ProxyTag}-round",
         };
         v2rayConfig.routing.balancers = [balancer];

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayBalancerService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayBalancerService.cs
@@ -2,13 +2,13 @@ namespace ServiceLib.Services.CoreConfig;
 
 public partial class CoreConfigV2rayService
 {
-    private async Task<int> GenObservatory(V2rayConfig v2rayConfig, EMultipleLoad multipleLoad)
+    private async Task<int> GenObservatory(V2rayConfig v2rayConfig, EMultipleLoad multipleLoad, string baseTagName = Global.ProxyTag)
     {
         if (multipleLoad == EMultipleLoad.LeastPing)
         {
             var observatory = new Observatory4Ray
             {
-                subjectSelector = [Global.ProxyTag],
+                subjectSelector = [baseTagName],
                 probeUrl = AppManager.Instance.Config.SpeedTestItem.SpeedPingTestUrl,
                 probeInterval = "3m",
                 enableConcurrency = true,
@@ -19,7 +19,7 @@ public partial class CoreConfigV2rayService
         {
             var burstObservatory = new BurstObservatory4Ray
             {
-                subjectSelector = [Global.ProxyTag],
+                subjectSelector = [baseTagName],
                 pingConfig = new()
                 {
                     destination = AppManager.Instance.Config.SpeedTestItem.SpeedPingTestUrl,

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayBalancerService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayBalancerService.cs
@@ -2,7 +2,7 @@ namespace ServiceLib.Services.CoreConfig;
 
 public partial class CoreConfigV2rayService
 {
-    private async Task<int> GenBalancer(V2rayConfig v2rayConfig, EMultipleLoad multipleLoad)
+    private async Task<int> GenObservatory(V2rayConfig v2rayConfig, EMultipleLoad multipleLoad)
     {
         if (multipleLoad == EMultipleLoad.LeastPing)
         {
@@ -30,6 +30,11 @@ public partial class CoreConfigV2rayService
             };
             v2rayConfig.burstObservatory = burstObservatory;
         }
+        return await Task.FromResult(0);
+    }
+
+    private async Task<string> GenBalancer(V2rayConfig v2rayConfig, EMultipleLoad multipleLoad, string selector = Global.ProxyTag)
+    {
         var strategyType = multipleLoad switch
         {
             EMultipleLoad.Random => "random",
@@ -38,9 +43,10 @@ public partial class CoreConfigV2rayService
             EMultipleLoad.LeastLoad => "leastLoad",
             _ => "roundRobin",
         };
+        var balancerTag = $"{selector}{Global.BalancerTagSuffix}";
         var balancer = new BalancersItem4Ray
         {
-            selector = [Global.ProxyTag],
+            selector = [selector],
             strategy = new()
             {
                 type = strategyType,
@@ -49,9 +55,10 @@ public partial class CoreConfigV2rayService
                     expected = 1,
                 },
             },
-            tag = $"{Global.ProxyTag}-round",
+            tag = balancerTag,
         };
-        v2rayConfig.routing.balancers = [balancer];
-        return await Task.FromResult(0);
+        v2rayConfig.routing.balancers ??= new();
+        v2rayConfig.routing.balancers.Add(balancer);
+        return await Task.FromResult(balancerTag);
     }
 }

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayBalancerService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayBalancerService.cs
@@ -4,32 +4,80 @@ public partial class CoreConfigV2rayService
 {
     private async Task<int> GenObservatory(V2rayConfig v2rayConfig, EMultipleLoad multipleLoad, string baseTagName = Global.ProxyTag)
     {
-        if (multipleLoad == EMultipleLoad.LeastPing)
+        // Collect all existing subject selectors from both observatories
+        var subjectSelectors = new List<string>();
+        subjectSelectors.AddRange(v2rayConfig.burstObservatory?.subjectSelector ?? []);
+        subjectSelectors.AddRange(v2rayConfig.observatory?.subjectSelector ?? []);
+
+        // Case 1: exact match already exists -> nothing to do
+        if (subjectSelectors.Any(baseTagName.StartsWith))
+            return await Task.FromResult(0);
+
+        // Case 2: prefix match exists -> reuse it and move to the first position
+        var matched = subjectSelectors.FirstOrDefault(s => s.StartsWith(baseTagName));
+        if (matched is not null)
         {
-            var observatory = new Observatory4Ray
+            baseTagName = matched;
+
+            if (v2rayConfig.burstObservatory?.subjectSelector?.Contains(baseTagName) == true)
             {
-                subjectSelector = [baseTagName],
-                probeUrl = AppManager.Instance.Config.SpeedTestItem.SpeedPingTestUrl,
-                probeInterval = "3m",
-                enableConcurrency = true,
-            };
-            v2rayConfig.observatory = observatory;
+                v2rayConfig.burstObservatory.subjectSelector.Remove(baseTagName);
+                v2rayConfig.burstObservatory.subjectSelector.Insert(0, baseTagName);
+            }
+
+            if (v2rayConfig.observatory?.subjectSelector?.Contains(baseTagName) == true)
+            {
+                v2rayConfig.observatory.subjectSelector.Remove(baseTagName);
+                v2rayConfig.observatory.subjectSelector.Insert(0, baseTagName);
+            }
+
+            return await Task.FromResult(0);
         }
-        else if (multipleLoad is EMultipleLoad.LeastLoad or EMultipleLoad.Fallback)
+
+        // Case 3: need to create or insert based on multipleLoad type
+        if (multipleLoad is EMultipleLoad.LeastLoad or EMultipleLoad.Fallback)
         {
-            var burstObservatory = new BurstObservatory4Ray
+            if (v2rayConfig.burstObservatory is null)
             {
-                subjectSelector = [baseTagName],
-                pingConfig = new()
+                // Create new burst observatory with default ping config
+                v2rayConfig.burstObservatory = new BurstObservatory4Ray
                 {
-                    destination = AppManager.Instance.Config.SpeedTestItem.SpeedPingTestUrl,
-                    interval = "5m",
-                    timeout = "30s",
-                    sampling = 2,
-                }
-            };
-            v2rayConfig.burstObservatory = burstObservatory;
+                    subjectSelector = [baseTagName],
+                    pingConfig = new()
+                    {
+                        destination = AppManager.Instance.Config.SpeedTestItem.SpeedPingTestUrl,
+                        interval = "5m",
+                        timeout = "30s",
+                        sampling = 2,
+                    }
+                };
+            }
+            else
+            {
+                v2rayConfig.burstObservatory.subjectSelector ??= new();
+                v2rayConfig.burstObservatory.subjectSelector.Add(baseTagName);
+            }
         }
+        else if (multipleLoad is EMultipleLoad.LeastPing)
+        {
+            if (v2rayConfig.observatory is null)
+            {
+                // Create new observatory with default probe config
+                v2rayConfig.observatory = new Observatory4Ray
+                {
+                    subjectSelector = [baseTagName],
+                    probeUrl = AppManager.Instance.Config.SpeedTestItem.SpeedPingTestUrl,
+                    probeInterval = "3m",
+                    enableConcurrency = true,
+                };
+            }
+            else
+            {
+                v2rayConfig.observatory.subjectSelector ??= new();
+                v2rayConfig.observatory.subjectSelector.Add(baseTagName);
+            }
+        }
+
         return await Task.FromResult(0);
     }
 

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
@@ -746,14 +746,15 @@ public partial class CoreConfigV2rayService
             }
             else
             {
-                outbound.tag = baseTagName + i.ToString();
+                // avoid v2ray observe
+                outbound.tag = "chain-" + baseTagName + i.ToString();
             }
 
             if (i != nodes.Count - 1)
             {
                 outbound.streamSettings.sockopt = new()
                 {
-                    dialerProxy = baseTagName + (i + 1).ToString()
+                    dialerProxy = "chain-" + baseTagName + (i + 1).ToString()
                 };
             }
 

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
@@ -1,3 +1,5 @@
+using ServiceLib.Models;
+
 namespace ServiceLib.Services.CoreConfig;
 
 public partial class CoreConfigV2rayService
@@ -728,9 +730,17 @@ public partial class CoreConfigV2rayService
             }
 
             // Merge results: first the main chain outbounds, then other outbounds, and finally utility outbounds
-            resultOutbounds.AddRange(prevOutbounds);
-            resultOutbounds.AddRange(v2rayConfig.outbounds);
-            v2rayConfig.outbounds = resultOutbounds;
+            if (baseTagName == Global.ProxyTag)
+            {
+                resultOutbounds.AddRange(prevOutbounds);
+                resultOutbounds.AddRange(v2rayConfig.outbounds);
+                v2rayConfig.outbounds = resultOutbounds;
+            }
+            else
+            {
+                v2rayConfig.outbounds.AddRange(prevOutbounds);
+                v2rayConfig.outbounds.AddRange(resultOutbounds);
+            }
         }
         catch (Exception ex)
         {
@@ -842,13 +852,19 @@ public partial class CoreConfigV2rayService
             outbound.tag = baseTagName + (i + 1).ToString();
             resultOutbounds.Add(outbound);
         }
-        v2rayConfig.outbounds ??= new();
-        resultOutbounds.AddRange(v2rayConfig.outbounds);
-        v2rayConfig.outbounds = resultOutbounds;
+        if (baseTagName == Global.ProxyTag)
+        {
+            resultOutbounds.AddRange(v2rayConfig.outbounds);
+            v2rayConfig.outbounds = resultOutbounds;
+        }
+        else
+        {
+            v2rayConfig.outbounds.AddRange(resultOutbounds);
+        }
         return await Task.FromResult(0);
     }
 
-    private async Task<int> GenChainOutboundsList(List<ProfileItem> nodes, V2rayConfig v2RayConfig, string baseTagName = Global.ProxyTag)
+    private async Task<int> GenChainOutboundsList(List<ProfileItem> nodes, V2rayConfig v2rayConfig, string baseTagName = Global.ProxyTag)
     {
         // Based on actual network flow instead of data packets
         var nodesReverse = nodes.AsEnumerable().Reverse().ToList();
@@ -889,9 +905,15 @@ public partial class CoreConfigV2rayService
 
             resultOutbounds.Add(outbound);
         }
-        v2RayConfig.outbounds ??= new();
-        resultOutbounds.AddRange(v2RayConfig.outbounds);
-        v2RayConfig.outbounds = resultOutbounds;
+        if (baseTagName == Global.ProxyTag)
+        {
+            resultOutbounds.AddRange(v2rayConfig.outbounds);
+            v2rayConfig.outbounds = resultOutbounds;
+        }
+        else
+        {
+            v2rayConfig.outbounds.AddRange(resultOutbounds);
+        }
 
         return await Task.FromResult(0);
     }

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
@@ -493,6 +493,13 @@ public partial class CoreConfigV2rayService
             {
                 return -1;
             }
+
+            var hasCycle = await node.HasCycle(new HashSet<string>(), new HashSet<string>());
+            if (hasCycle)
+            {
+                return -1;
+            }
+
             // remove custom nodes
             // remove group nodes for proxy chain
             var childProfiles = (await Task.WhenAll(

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
@@ -480,7 +480,7 @@ public partial class CoreConfigV2rayService
         return 0;
     }
 
-    private async Task<int> GenGroupOutbound(ProfileItem node, V2rayConfig v2rayConfig, string baseTagName = Global.ProxyTag)
+    private async Task<int> GenGroupOutbound(ProfileItem node, V2rayConfig v2rayConfig, string baseTagName = Global.ProxyTag, bool ignoreOriginChain = false)
     {
         try
         {
@@ -515,7 +515,14 @@ public partial class CoreConfigV2rayService
             switch (node.ConfigType)
             {
                 case EConfigType.PolicyGroup:
-                    await GenOutboundsListWithChain(childProfiles, v2rayConfig, baseTagName);
+                    if (ignoreOriginChain)
+                    {
+                        await GenOutboundsList(childProfiles, v2rayConfig, baseTagName);
+                    }
+                    else
+                    {
+                        await GenOutboundsListWithChain(childProfiles, v2rayConfig, baseTagName);
+                    }
                     break;
                 case EConfigType.ProxyChain:
                     await GenChainOutboundsList(childProfiles, v2rayConfig, baseTagName);

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
@@ -692,4 +692,49 @@ public partial class CoreConfigV2rayService
         }
         return null;
     }
+
+    private async Task<int> GenChainOutboundsList(List<ProfileItem> nodes, V2rayConfig v2RayConfig)
+    {
+        var resultOutbounds = new List<Outbounds4Ray>();
+        for (var i = 0; i < nodes.Count; i++)
+        {
+            var node = nodes[i];
+            var txtOutbound = EmbedUtils.GetEmbedText(Global.V2raySampleOutbound);
+            if (txtOutbound.IsNullOrEmpty())
+            {
+                break;
+            }
+            var outbound = JsonUtils.Deserialize<Outbounds4Ray>(txtOutbound);
+            var result = await GenOutbound(node, outbound);
+
+            if (result != 0)
+            {
+                break;
+            }
+
+            if (i == 0)
+            {
+                outbound.tag = Global.ProxyTag;
+            }
+            else
+            {
+                outbound.tag = Global.ProxyTag + i.ToString();
+            }
+
+            if (i != nodes.Count - 1)
+            {
+                outbound.streamSettings.sockopt = new()
+                {
+                    dialerProxy = Global.ProxyTag + (i + 1).ToString()
+                };
+            }
+
+            resultOutbounds.Add(outbound);
+        }
+        v2RayConfig.outbounds ??= new();
+        resultOutbounds.AddRange(v2RayConfig.outbounds);
+        v2RayConfig.outbounds = resultOutbounds;
+
+        return await Task.FromResult(0);
+    }
 }

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
@@ -749,10 +749,12 @@ public partial class CoreConfigV2rayService
 
     private async Task<int> GenChainOutboundsList(List<ProfileItem> nodes, V2rayConfig v2RayConfig, string baseTagName = Global.ProxyTag)
     {
+        // Based on actual network flow instead of data packets
+        var nodesReverse = nodes.AsEnumerable().Reverse().ToList();
         var resultOutbounds = new List<Outbounds4Ray>();
-        for (var i = 0; i < nodes.Count; i++)
+        for (var i = 0; i < nodesReverse.Count; i++)
         {
-            var node = nodes[i];
+            var node = nodesReverse[i];
             var txtOutbound = EmbedUtils.GetEmbedText(Global.V2raySampleOutbound);
             if (txtOutbound.IsNullOrEmpty())
             {
@@ -776,7 +778,7 @@ public partial class CoreConfigV2rayService
                 outbound.tag = "chain-" + baseTagName + i.ToString();
             }
 
-            if (i != nodes.Count - 1)
+            if (i != nodesReverse.Count - 1)
             {
                 outbound.streamSettings.sockopt = new()
                 {

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
@@ -631,12 +631,6 @@ public partial class CoreConfigV2rayService
 
                 if (node.ConfigType is EConfigType.PolicyGroup or EConfigType.ProxyChain)
                 {
-                    var hasCycle = ProfileGroupItemManager.HasCycle(node.IndexId);
-                    if (hasCycle)
-                    {
-                        return -1;
-                    }
-
                     var (childProfiles, _) = await ProfileGroupItemManager.GetChildProfileItems(node.IndexId);
                     if (childProfiles.Count <= 0)
                     {
@@ -788,12 +782,6 @@ public partial class CoreConfigV2rayService
                 continue;
             if (node.ConfigType is EConfigType.PolicyGroup or EConfigType.ProxyChain)
             {
-                var hasCycle = ProfileGroupItemManager.HasCycle(node.IndexId);
-                if (hasCycle)
-                {
-                    return -1;
-                }
-
                 var (childProfiles, _) = await ProfileGroupItemManager.GetChildProfileItems(node.IndexId);
                 if (childProfiles.Count <= 0)
                 {

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
@@ -496,7 +496,8 @@ public partial class CoreConfigV2rayService
                 return -1;
             }
 
-            var hasCycle = await node.HasCycle(new HashSet<string>(), new HashSet<string>());
+            var hasCycle = profileGroupItem.HasCycle();
+            //var hasCycle = await node.HasCycle(new HashSet<string>(), new HashSet<string>());
             if (hasCycle)
             {
                 return -1;

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayRoutingService.cs
@@ -133,7 +133,7 @@ public partial class CoreConfigV2rayService
             return Global.ProxyTag;
         }
 
-        var tag = Global.ProxyTag + node.IndexId.ToString();
+        var tag = $"{node.IndexId}-{Global.ProxyTag}";
         if (v2rayConfig.outbounds.Any(p => p.tag == tag))
         {
             return tag;
@@ -141,11 +141,10 @@ public partial class CoreConfigV2rayService
 
         if (node.ConfigType is EConfigType.PolicyGroup or EConfigType.ProxyChain)
         {
-            var childBaseTagName = $"{Global.ProxyTag}-{node.IndexId}";
-            var ret = await GenGroupOutbound(node, v2rayConfig, childBaseTagName);
+            var ret = await GenGroupOutbound(node, v2rayConfig, tag);
             if (ret == 0)
             {
-                return childBaseTagName;
+                return tag;
             }
             return Global.ProxyTag;
         }

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayRoutingService.cs
@@ -159,7 +159,7 @@ public partial class CoreConfigV2rayService
             var ret = node.ConfigType switch
             {
                 EConfigType.PolicyGroup =>
-                    await GenOutboundsList(childProfiles, v2rayConfig, childBaseTagName),
+                    await GenOutboundsListWithChain(childProfiles, v2rayConfig, childBaseTagName),
                 EConfigType.ProxyChain =>
                     await GenChainOutboundsList(childProfiles, v2rayConfig, childBaseTagName),
                 _ => throw new NotImplementedException()

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayRoutingService.cs
@@ -125,6 +125,43 @@ public partial class CoreConfigV2rayService
         }
 
         var node = await AppManager.Instance.GetProfileItemViaRemarks(outboundTag);
+
+        if (node.ConfigType is EConfigType.PolicyGroup or EConfigType.ProxyChain)
+        {
+            ProfileGroupItemManager.Instance.TryGet(node.IndexId, out var profileGroupItem);
+            if (profileGroupItem == null || profileGroupItem.ChildItems.IsNullOrEmpty())
+            {
+                return Global.ProxyTag;
+            }
+            var childProfiles = (await Task.WhenAll(
+                    Utils.String2List(profileGroupItem.ChildItems)
+                    .Where(p => !p.IsNullOrEmpty())
+                    .Select(AppManager.Instance.GetProfileItem)
+                )).Where(p => p != null).ToList();
+            if (childProfiles.Count <= 0)
+            {
+                return Global.ProxyTag;
+            }
+            var childBaseTagName = $"{Global.ProxyTag}-{node.IndexId}";
+            var ret = node.ConfigType switch
+            {
+                EConfigType.PolicyGroup =>
+                    await GenOutboundsList(childProfiles, v2rayConfig, childBaseTagName),
+                EConfigType.ProxyChain =>
+                    await GenChainOutboundsList(childProfiles, v2rayConfig, childBaseTagName),
+                _ => throw new NotImplementedException()
+            };
+            if (node.ConfigType == EConfigType.PolicyGroup)
+            {
+                await GenBalancer(v2rayConfig, profileGroupItem.MultipleLoad, childBaseTagName);
+            }
+            if (ret == 0)
+            {
+                return childBaseTagName;
+            }
+            return Global.ProxyTag;
+        }
+
         if (node == null
             || !Global.XraySupportConfigType.Contains(node.ConfigType))
         {

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayRoutingService.cs
@@ -126,6 +126,19 @@ public partial class CoreConfigV2rayService
 
         var node = await AppManager.Instance.GetProfileItemViaRemarks(outboundTag);
 
+        if (node == null
+            || (!Global.XraySupportConfigType.Contains(node.ConfigType)
+            && node.ConfigType is not (EConfigType.PolicyGroup or EConfigType.ProxyChain)))
+        {
+            return Global.ProxyTag;
+        }
+
+        var tag = Global.ProxyTag + node.IndexId.ToString();
+        if (v2rayConfig.outbounds.Any(p => p.tag == tag))
+        {
+            return tag;
+        }
+
         if (node.ConfigType is EConfigType.PolicyGroup or EConfigType.ProxyChain)
         {
             ProfileGroupItemManager.Instance.TryGet(node.IndexId, out var profileGroupItem);
@@ -160,18 +173,6 @@ public partial class CoreConfigV2rayService
                 return childBaseTagName;
             }
             return Global.ProxyTag;
-        }
-
-        if (node == null
-            || !Global.XraySupportConfigType.Contains(node.ConfigType))
-        {
-            return Global.ProxyTag;
-        }
-
-        var tag = Global.ProxyTag + node.IndexId.ToString();
-        if (v2rayConfig.outbounds.Any(p => p.tag == tag))
-        {
-            return tag;
         }
 
         var txtOutbound = EmbedUtils.GetEmbedText(Global.V2raySampleOutbound);

--- a/v2rayN/ServiceLib/ViewModels/AddGroupServerViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/AddGroupServerViewModel.cs
@@ -76,6 +76,7 @@ public class AddGroupServerViewModel : MyReactiveObject
         PolicyGroupType = (profileGroup?.MultipleLoad ?? EMultipleLoad.LeastPing) switch
         {
             EMultipleLoad.LeastPing => ResUI.TbLeastPing,
+            EMultipleLoad.Fallback => ResUI.TbFallback,
             EMultipleLoad.Random => ResUI.TbRandom,
             EMultipleLoad.RoundRobin => ResUI.TbRoundRobin,
             EMultipleLoad.LeastLoad => ResUI.TbLeastLoad,
@@ -206,6 +207,7 @@ public class AddGroupServerViewModel : MyReactiveObject
         profileGroup.MultipleLoad = PolicyGroupType switch
         {
             var s when s == ResUI.TbLeastPing => EMultipleLoad.LeastPing,
+            var s when s == ResUI.TbFallback => EMultipleLoad.Fallback,
             var s when s == ResUI.TbRandom => EMultipleLoad.Random,
             var s when s == ResUI.TbRoundRobin => EMultipleLoad.RoundRobin,
             var s when s == ResUI.TbLeastLoad => EMultipleLoad.LeastLoad,

--- a/v2rayN/ServiceLib/ViewModels/AddGroupServerViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/AddGroupServerViewModel.cs
@@ -1,0 +1,17 @@
+using System.Reactive;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+
+namespace ServiceLib.ViewModels;
+
+public class AddGroupServerViewModel : MyReactiveObject
+{
+    [Reactive]
+    public ProfileItem SelectedSource { get; set; }
+
+    [Reactive]
+    public IList<ProfileItem> SelectedChildren { get; set; }
+
+    //[Reactive]
+    //public 
+}

--- a/v2rayN/ServiceLib/ViewModels/AddGroupServerViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/AddGroupServerViewModel.cs
@@ -195,12 +195,12 @@ public class AddGroupServerViewModel : MyReactiveObject
         var childIndexIds = new List<string>();
         foreach (var item in ChildItemsObs)
         {
-            if (!item.IndexId.IsNullOrEmpty())
+            if (item.IndexId.IsNullOrEmpty())
             {
-                childIndexIds.Add(item.IndexId);
+                continue;
             }
+            childIndexIds.Add(item.IndexId);
         }
-        SelectedSource.Address = Utils.List2String(childIndexIds);
         var profileGroup = ProfileGroupItemManager.Instance.GetOrCreateAndMarkDirty(SelectedSource.IndexId);
         profileGroup.ChildItems = Utils.List2String(childIndexIds);
         profileGroup.MultipleLoad = PolicyGroupType switch

--- a/v2rayN/ServiceLib/ViewModels/AddGroupServerViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/AddGroupServerViewModel.cs
@@ -1,4 +1,3 @@
-using System.Data;
 using System.Reactive;
 using DynamicData.Binding;
 using ReactiveUI;

--- a/v2rayN/ServiceLib/ViewModels/AddGroupServerViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/AddGroupServerViewModel.cs
@@ -1,4 +1,5 @@
 using System.Reactive;
+using DynamicData.Binding;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 
@@ -10,8 +11,202 @@ public class AddGroupServerViewModel : MyReactiveObject
     public ProfileItem SelectedSource { get; set; }
 
     [Reactive]
+    public ProfileItem SelectedChild { get; set; }
+
+    [Reactive]
     public IList<ProfileItem> SelectedChildren { get; set; }
 
-    //[Reactive]
-    //public 
+    [Reactive]
+    public string? CoreType { get; set; }
+
+    [Reactive]
+    public string? PolicyGroupType { get; set; }
+
+    public IObservableCollection<ProfileItem> ChildItemsObs { get; } = new ObservableCollectionExtended<ProfileItem>();
+
+    //public ReactiveCommand<Unit, Unit> AddCmd { get; }
+    public ReactiveCommand<Unit, Unit> RemoveCmd { get; }
+    public ReactiveCommand<Unit, Unit> MoveTopCmd { get; }
+    public ReactiveCommand<Unit, Unit> MoveUpCmd { get; }
+    public ReactiveCommand<Unit, Unit> MoveDownCmd { get; }
+    public ReactiveCommand<Unit, Unit> MoveBottomCmd { get; }
+
+    public ReactiveCommand<Unit, Unit> SaveCmd { get; }
+
+    public AddGroupServerViewModel(ProfileItem profileItem, Func<EViewAction, object?, Task<bool>>? updateView)
+    {
+        _config = AppManager.Instance.Config;
+        _updateView = updateView;
+
+        RemoveCmd = ReactiveCommand.CreateFromTask(async () =>
+        {
+            await ChildRemoveAsync();
+        });
+        MoveTopCmd = ReactiveCommand.CreateFromTask(async () =>
+        {
+            await MoveServer(EMove.Top);
+        });
+        MoveUpCmd = ReactiveCommand.CreateFromTask(async () =>
+        {
+            await MoveServer(EMove.Up);
+        });
+        MoveDownCmd = ReactiveCommand.CreateFromTask(async () =>
+        {
+            await MoveServer(EMove.Down);
+        });
+        MoveBottomCmd = ReactiveCommand.CreateFromTask(async () =>
+        {
+            await MoveServer(EMove.Bottom);
+        });
+        SaveCmd = ReactiveCommand.CreateFromTask(async () =>
+        {
+            await SaveServerAsync();
+        });
+
+        SelectedSource = profileItem.IndexId.IsNullOrEmpty() ? profileItem : JsonUtils.DeepCopy(profileItem);
+
+        CoreType = (SelectedSource?.CoreType ?? ECoreType.Xray).ToString();
+
+        ProfileGroupItemManager.Instance.TryGet(profileItem.IndexId, out var profileGroup);
+        PolicyGroupType = (profileGroup?.MultipleLoad ?? EMultipleLoad.LeastPing) switch
+        {
+            EMultipleLoad.LeastPing => ResUI.TbLeastPing,
+            EMultipleLoad.Random => ResUI.TbRandom,
+            EMultipleLoad.RoundRobin => ResUI.TbRoundRobin,
+            EMultipleLoad.LeastLoad => ResUI.TbLeastLoad,
+            _ => ResUI.TbLeastPing,
+        };
+
+        _ = Init();
+    }
+
+    public async Task Init()
+    {
+        var childItemMulti = ProfileGroupItemManager.Instance.GetOrCreateAndMarkDirty(SelectedSource?.IndexId);
+        if (childItemMulti != null)
+        {
+            var childIndexIds = childItemMulti.ChildItems.IsNullOrEmpty() ? new List<string>() : Utils.String2List(childItemMulti.ChildItems);
+            foreach (var item in childIndexIds)
+            {
+                var child = await AppManager.Instance.GetProfileItem(item);
+                if (child == null)
+                {
+                    continue;
+                }
+                ChildItemsObs.Add(child);
+            }
+        }
+    }
+
+    public async Task ChildRemoveAsync()
+    {
+        if (SelectedChild == null || SelectedChild.IndexId.IsNullOrEmpty())
+        {
+            NoticeManager.Instance.Enqueue(ResUI.PleaseSelectServer);
+            return;
+        }
+        ChildItemsObs.Remove(SelectedChild);
+        await Task.CompletedTask;
+    }
+
+    public async Task MoveServer(EMove eMove)
+    {
+        if (SelectedChild == null || SelectedChild.IndexId.IsNullOrEmpty())
+        {
+            NoticeManager.Instance.Enqueue(ResUI.PleaseSelectServer);
+            return;
+        }
+        var index = ChildItemsObs.IndexOf(SelectedChild);
+        if (index < 0)
+        {
+            return;
+        }
+        switch (eMove)
+        {
+            case EMove.Top:
+                if (index == 0)
+                {
+                    return;
+                }
+                ChildItemsObs.RemoveAt(index);
+                ChildItemsObs.Insert(0, SelectedChild);
+                break;
+            case EMove.Up:
+                if (index == 0)
+                {
+                    return;
+                }
+                ChildItemsObs.RemoveAt(index);
+                ChildItemsObs.Insert(index - 1, SelectedChild);
+                break;
+            case EMove.Down:
+                if (index == ChildItemsObs.Count - 1)
+                {
+                    return;
+                }
+                ChildItemsObs.RemoveAt(index);
+                ChildItemsObs.Insert(index + 1, SelectedChild);
+                break;
+            case EMove.Bottom:
+                if (index == ChildItemsObs.Count - 1)
+                {
+                    return;
+                }
+                ChildItemsObs.RemoveAt(index);
+                ChildItemsObs.Add(SelectedChild);
+                break;
+            default:
+                break;
+        }
+        await Task.CompletedTask;
+    }
+
+    private async Task SaveServerAsync()
+    {
+        var remarks = SelectedSource.Remarks;
+        if (remarks.IsNullOrEmpty())
+        {
+            NoticeManager.Instance.Enqueue(ResUI.PleaseFillRemarks);
+            return;
+        }
+        if (ChildItemsObs.Count == 0)
+        {
+            NoticeManager.Instance.Enqueue(ResUI.PleaseAddAtLeastOneServer);
+            return;
+        }
+        SelectedSource.CoreType = CoreType.IsNullOrEmpty() ? ECoreType.Xray : (ECoreType)Enum.Parse(typeof(ECoreType), CoreType);
+        if (SelectedSource.CoreType is not (ECoreType.Xray or ECoreType.sing_box) ||
+            SelectedSource.ConfigType is not (EConfigType.ProxyChain or EConfigType.PolicyGroup))
+        {
+            return;
+        }
+        var childIndexIds = new List<string>();
+        foreach (var item in ChildItemsObs)
+        {
+            if (item.IndexId.IsNotEmpty())
+            {
+                childIndexIds.Add(item.IndexId);
+            }
+        }
+        SelectedSource.Address = Utils.List2String(childIndexIds);
+        var profileGroup = ProfileGroupItemManager.Instance.GetOrCreateAndMarkDirty(SelectedSource.IndexId);
+        profileGroup.ChildItems = Utils.List2String(childIndexIds);
+        profileGroup.MultipleLoad = PolicyGroupType switch
+        {
+            var s when s == ResUI.TbLeastPing => EMultipleLoad.LeastPing,
+            var s when s == ResUI.TbRandom => EMultipleLoad.Random,
+            var s when s == ResUI.TbRoundRobin => EMultipleLoad.RoundRobin,
+            var s when s == ResUI.TbLeastLoad => EMultipleLoad.LeastLoad,
+            _ => EMultipleLoad.LeastPing,
+        };
+        if (await ConfigHandler.AddGroupServerCommon(_config, SelectedSource, profileGroup, true) == 0)
+        {
+            NoticeManager.Instance.Enqueue(ResUI.OperationSuccess);
+            _updateView?.Invoke(EViewAction.CloseWindow, null);
+        }
+        else
+        {
+            NoticeManager.Instance.Enqueue(ResUI.OperationFailed);
+        }
+    }
 }

--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -252,6 +252,7 @@ public class MainWindowViewModel : MyReactiveObject
         await ConfigHandler.InitBuiltinDNS(_config);
         await ConfigHandler.InitBuiltinFullConfigTemplate(_config);
         await ProfileExManager.Instance.Init();
+        await ProfileGroupItemManager.Instance.Init();
         await CoreManager.Instance.Init(_config, UpdateHandler);
         TaskManager.Instance.RegUpdateTask(_config, UpdateTaskHandler);
 

--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -23,6 +23,8 @@ public class MainWindowViewModel : MyReactiveObject
     public ReactiveCommand<Unit, Unit> AddWireguardServerCmd { get; }
     public ReactiveCommand<Unit, Unit> AddAnytlsServerCmd { get; }
     public ReactiveCommand<Unit, Unit> AddCustomServerCmd { get; }
+    public ReactiveCommand<Unit, Unit> AddPolicyGroupServerCmd { get; }
+    public ReactiveCommand<Unit, Unit> AddProxyChainServerCmd { get; }
     public ReactiveCommand<Unit, Unit> AddServerViaClipboardCmd { get; }
     public ReactiveCommand<Unit, Unit> AddServerViaScanCmd { get; }
     public ReactiveCommand<Unit, Unit> AddServerViaImageCmd { get; }
@@ -121,6 +123,14 @@ public class MainWindowViewModel : MyReactiveObject
         AddCustomServerCmd = ReactiveCommand.CreateFromTask(async () =>
         {
             await AddServerAsync(true, EConfigType.Custom);
+        });
+        AddPolicyGroupServerCmd = ReactiveCommand.CreateFromTask(async () =>
+        {
+            await AddServerAsync(true, EConfigType.PolicyGroup);
+        });
+        AddProxyChainServerCmd = ReactiveCommand.CreateFromTask(async () =>
+        {
+            await AddServerAsync(true, EConfigType.ProxyChain);
         });
         AddServerViaClipboardCmd = ReactiveCommand.CreateFromTask(async () =>
         {
@@ -340,6 +350,10 @@ public class MainWindowViewModel : MyReactiveObject
         if (eConfigType == EConfigType.Custom)
         {
             ret = await _updateView?.Invoke(EViewAction.AddServer2Window, item);
+        }
+        else if (eConfigType is EConfigType.PolicyGroup or EConfigType.ProxyChain)
+        {
+            ret = await _updateView?.Invoke(EViewAction.AddGroupServerWindow, item);
         }
         else
         {

--- a/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
@@ -56,7 +56,9 @@ public class ProfilesViewModel : MyReactiveObject
     public ReactiveCommand<Unit, Unit> GenGroupMultipleServerXrayRoundRobinCmd { get; }
     public ReactiveCommand<Unit, Unit> GenGroupMultipleServerXrayLeastPingCmd { get; }
     public ReactiveCommand<Unit, Unit> GenGroupMultipleServerXrayLeastLoadCmd { get; }
+    public ReactiveCommand<Unit, Unit> GenGroupMultipleServerXrayFallbackCmd { get; }
     public ReactiveCommand<Unit, Unit> GenGroupMultipleServerSingBoxLeastPingCmd { get; }
+    public ReactiveCommand<Unit, Unit> GenGroupMultipleServerSingBoxFallbackCmd { get; }
 
     //servers move
     public ReactiveCommand<Unit, Unit> MoveTopCmd { get; }
@@ -154,9 +156,17 @@ public class ProfilesViewModel : MyReactiveObject
         {
             await GenGroupMultipleServer(ECoreType.Xray, EMultipleLoad.LeastLoad);
         }, canEditRemove);
+        GenGroupMultipleServerXrayFallbackCmd = ReactiveCommand.CreateFromTask(async () =>
+        {
+            await GenGroupMultipleServer(ECoreType.Xray, EMultipleLoad.Fallback);
+        }, canEditRemove);
         GenGroupMultipleServerSingBoxLeastPingCmd = ReactiveCommand.CreateFromTask(async () =>
         {
             await GenGroupMultipleServer(ECoreType.sing_box, EMultipleLoad.LeastPing);
+        }, canEditRemove);
+        GenGroupMultipleServerSingBoxFallbackCmd = ReactiveCommand.CreateFromTask(async () =>
+        {
+            await GenGroupMultipleServer(ECoreType.sing_box, EMultipleLoad.Fallback);
         }, canEditRemove);
 
         //servers move

--- a/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
@@ -52,11 +52,11 @@ public class ProfilesViewModel : MyReactiveObject
     public ReactiveCommand<Unit, Unit> CopyServerCmd { get; }
     public ReactiveCommand<Unit, Unit> SetDefaultServerCmd { get; }
     public ReactiveCommand<Unit, Unit> ShareServerCmd { get; }
-    public ReactiveCommand<Unit, Unit> SetDefaultMultipleServerXrayRandomCmd { get; }
-    public ReactiveCommand<Unit, Unit> SetDefaultMultipleServerXrayRoundRobinCmd { get; }
-    public ReactiveCommand<Unit, Unit> SetDefaultMultipleServerXrayLeastPingCmd { get; }
-    public ReactiveCommand<Unit, Unit> SetDefaultMultipleServerXrayLeastLoadCmd { get; }
-    public ReactiveCommand<Unit, Unit> SetDefaultMultipleServerSingBoxLeastPingCmd { get; }
+    public ReactiveCommand<Unit, Unit> GenGroupMultipleServerXrayRandomCmd { get; }
+    public ReactiveCommand<Unit, Unit> GenGroupMultipleServerXrayRoundRobinCmd { get; }
+    public ReactiveCommand<Unit, Unit> GenGroupMultipleServerXrayLeastPingCmd { get; }
+    public ReactiveCommand<Unit, Unit> GenGroupMultipleServerXrayLeastLoadCmd { get; }
+    public ReactiveCommand<Unit, Unit> GenGroupMultipleServerSingBoxLeastPingCmd { get; }
 
     //servers move
     public ReactiveCommand<Unit, Unit> MoveTopCmd { get; }
@@ -138,25 +138,25 @@ public class ProfilesViewModel : MyReactiveObject
         {
             await ShareServerAsync();
         }, canEditRemove);
-        SetDefaultMultipleServerXrayRandomCmd = ReactiveCommand.CreateFromTask(async () =>
+        GenGroupMultipleServerXrayRandomCmd = ReactiveCommand.CreateFromTask(async () =>
         {
-            await SetDefaultMultipleServer(ECoreType.Xray, EMultipleLoad.Random);
+            await GenGroupMultipleServer(ECoreType.Xray, EMultipleLoad.Random);
         }, canEditRemove);
-        SetDefaultMultipleServerXrayRoundRobinCmd = ReactiveCommand.CreateFromTask(async () =>
+        GenGroupMultipleServerXrayRoundRobinCmd = ReactiveCommand.CreateFromTask(async () =>
         {
-            await SetDefaultMultipleServer(ECoreType.Xray, EMultipleLoad.RoundRobin);
+            await GenGroupMultipleServer(ECoreType.Xray, EMultipleLoad.RoundRobin);
         }, canEditRemove);
-        SetDefaultMultipleServerXrayLeastPingCmd = ReactiveCommand.CreateFromTask(async () =>
+        GenGroupMultipleServerXrayLeastPingCmd = ReactiveCommand.CreateFromTask(async () =>
         {
-            await SetDefaultMultipleServer(ECoreType.Xray, EMultipleLoad.LeastPing);
+            await GenGroupMultipleServer(ECoreType.Xray, EMultipleLoad.LeastPing);
         }, canEditRemove);
-        SetDefaultMultipleServerXrayLeastLoadCmd = ReactiveCommand.CreateFromTask(async () =>
+        GenGroupMultipleServerXrayLeastLoadCmd = ReactiveCommand.CreateFromTask(async () =>
         {
-            await SetDefaultMultipleServer(ECoreType.Xray, EMultipleLoad.LeastLoad);
+            await GenGroupMultipleServer(ECoreType.Xray, EMultipleLoad.LeastLoad);
         }, canEditRemove);
-        SetDefaultMultipleServerSingBoxLeastPingCmd = ReactiveCommand.CreateFromTask(async () =>
+        GenGroupMultipleServerSingBoxLeastPingCmd = ReactiveCommand.CreateFromTask(async () =>
         {
-            await SetDefaultMultipleServer(ECoreType.sing_box, EMultipleLoad.LeastPing);
+            await GenGroupMultipleServer(ECoreType.sing_box, EMultipleLoad.LeastPing);
         }, canEditRemove);
 
         //servers move
@@ -619,7 +619,7 @@ public class ProfilesViewModel : MyReactiveObject
         await _updateView?.Invoke(EViewAction.ShareServer, url);
     }
 
-    private async Task SetDefaultMultipleServer(ECoreType coreType, EMultipleLoad multipleLoad)
+    private async Task GenGroupMultipleServer(ECoreType coreType, EMultipleLoad multipleLoad)
     {
         var lstSelected = await GetProfileItems(true);
         if (lstSelected == null)

--- a/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
@@ -627,7 +627,7 @@ public class ProfilesViewModel : MyReactiveObject
             return;
         }
 
-        var ret = await ConfigHandler.AddCustomServer4Multiple(_config, lstSelected, coreType, multipleLoad);
+        var ret = await ConfigHandler.AddGroupServer4Multiple(_config, lstSelected, coreType, multipleLoad, SelectedSub?.Id);
         if (ret.Success != true)
         {
             NoticeManager.Instance.Enqueue(ResUI.OperationFailed);

--- a/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
@@ -500,6 +500,10 @@ public class ProfilesViewModel : MyReactiveObject
         {
             ret = await _updateView?.Invoke(EViewAction.AddServer2Window, item);
         }
+        else if (eConfigType is EConfigType.PolicyGroup or EConfigType.ProxyChain)
+        {
+            ret = await _updateView?.Invoke(EViewAction.AddGroupServerWindow, item);
+        }
         else
         {
             ret = await _updateView?.Invoke(EViewAction.AddServerWindow, item);

--- a/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml
@@ -95,6 +95,7 @@
                     x:Name="lstChild"
                     Grid.Row="1"
                     AutoGenerateColumns="False"
+                    Background="Transparent"
                     BorderThickness="1"
                     CanUserReorderColumns="False"
                     CanUserResizeColumns="True"

--- a/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml
@@ -1,0 +1,149 @@
+<Window
+    x:Class="v2rayN.Desktop.Views.AddGroupServerWindow"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:resx="clr-namespace:ServiceLib.Resx;assembly=ServiceLib"
+    xmlns:vms="clr-namespace:ServiceLib.ViewModels;assembly=ServiceLib"
+    Title="{x:Static resx:ResUI.menuServers}"
+    Width="900"
+    Height="700"
+    x:DataType="vms:AddGroupServerViewModel"
+    ShowInTaskbar="False"
+    WindowStartupLocation="CenterScreen"
+    mc:Ignorable="d">
+
+    <DockPanel Margin="{StaticResource Margin8}">
+        <StackPanel
+            Margin="{StaticResource Margin4}"
+            HorizontalAlignment="Center"
+            DockPanel.Dock="Bottom"
+            Orientation="Horizontal">
+            <Button
+                x:Name="btnSave"
+                Width="100"
+                Content="{x:Static resx:ResUI.TbConfirm}"
+                IsDefault="True" />
+            <Button
+                x:Name="btnCancel"
+                Width="100"
+                Margin="{StaticResource MarginLr8}"
+                Content="{x:Static resx:ResUI.TbCancel}"
+                IsCancel="True" />
+        </StackPanel>
+
+        <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+            <Grid RowDefinitions="Auto,*,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+
+                <Grid
+                    Grid.Row="0"
+                    ColumnDefinitions="180,Auto,Auto"
+                    RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+                    <TextBlock
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        Margin="{StaticResource Margin4}"
+                        Text="{x:Static resx:ResUI.menuServers}" />
+
+                    <TextBlock
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        Margin="{StaticResource Margin4}"
+                        VerticalAlignment="Center"
+                        Text="{x:Static resx:ResUI.TbRemarks}" />
+                    <TextBox
+                        x:Name="txtRemarks"
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        Width="400"
+                        Margin="{StaticResource Margin4}" />
+
+                    <TextBlock
+                        Grid.Row="2"
+                        Grid.Column="0"
+                        Margin="{StaticResource Margin4}"
+                        VerticalAlignment="Center"
+                        Text="{x:Static resx:ResUI.TbCoreType}" />
+                    <ComboBox
+                        x:Name="cmbCoreType"
+                        Grid.Row="2"
+                        Grid.Column="1"
+                        Width="200"
+                        Margin="{StaticResource Margin4}" />
+
+                    <Grid
+                        x:Name="gridPolicyGroup"
+                        Grid.Row="3"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="3"
+                        ColumnDefinitions="180,Auto,Auto">
+                        <TextBlock
+                            Grid.Column="0"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            Text="{x:Static resx:ResUI.TbPolicyGroupType}" />
+                        <ComboBox
+                            x:Name="cmbPolicyGroupType"
+                            Grid.Column="1"
+                            Width="200"
+                            Margin="{StaticResource Margin4}" />
+                    </Grid>
+                </Grid>
+
+                <DataGrid
+                    x:Name="lstChild"
+                    Grid.Row="1"
+                    AutoGenerateColumns="False"
+                    BorderThickness="1"
+                    CanUserReorderColumns="False"
+                    CanUserResizeColumns="True"
+                    CanUserSortColumns="False"
+                    GridLinesVisibility="All"
+                    HeadersVisibility="Column"
+                    IsReadOnly="True"
+                    ItemsSource="{Binding ChildItemsObs}"
+                    SelectionMode="Extended">
+                    <DataGrid.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem x:Name="menuAddChildServer" Header="{x:Static resx:ResUI.menuAddChildServer}" />
+                            <MenuItem x:Name="menuRemoveChildServer" Header="{x:Static resx:ResUI.menuRemoveChildServer}" />
+                            <MenuItem x:Name="menuSelectAllChild" Header="{x:Static resx:ResUI.menuSelectAll}" />
+                            <Separator />
+                            <MenuItem x:Name="menuMoveTop" Header="{x:Static resx:ResUI.menuMoveTop}" />
+                            <MenuItem x:Name="menuMoveUp" Header="{x:Static resx:ResUI.menuMoveUp}" />
+                            <MenuItem x:Name="menuMoveDown" Header="{x:Static resx:ResUI.menuMoveDown}" />
+                            <MenuItem x:Name="menuMoveBottom" Header="{x:Static resx:ResUI.menuMoveBottom}" />
+                        </ContextMenu>
+                    </DataGrid.ContextMenu>
+                    <DataGrid.Columns>
+                        <DataGridTextColumn
+                            Width="150"
+                            Binding="{Binding ConfigType}"
+                            Header="{x:Static resx:ResUI.LvServiceType}" />
+                        <DataGridTextColumn
+                            Width="150"
+                            Binding="{Binding Remarks}"
+                            Header="{x:Static resx:ResUI.LvRemarks}" />
+                        <DataGridTextColumn
+                            Width="120"
+                            Binding="{Binding Address}"
+                            Header="{x:Static resx:ResUI.LvAddress}" />
+                        <DataGridTextColumn
+                            Width="100"
+                            Binding="{Binding Port}"
+                            Header="{x:Static resx:ResUI.LvPort}" />
+                        <DataGridTextColumn
+                            Width="100"
+                            Binding="{Binding Network}"
+                            Header="{x:Static resx:ResUI.LvTransportProtocol}" />
+                        <DataGridTextColumn
+                            Width="100"
+                            Binding="{Binding StreamSecurity}"
+                            Header="{x:Static resx:ResUI.LvTLS}" />
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Grid>
+        </ScrollViewer>
+    </DockPanel>
+</Window>

--- a/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml
@@ -33,64 +33,65 @@
                 IsCancel="True" />
         </StackPanel>
 
-        <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
-            <Grid RowDefinitions="Auto,*,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+        <Grid DockPanel.Dock="Top" RowDefinitions="Auto,*,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+
+            <Grid
+                Grid.Row="0"
+                ColumnDefinitions="180,Auto,Auto"
+                RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+                <TextBlock
+                    Grid.Row="0"
+                    Grid.Column="0"
+                    Margin="{StaticResource Margin4}"
+                    Text="{x:Static resx:ResUI.menuServers}" />
+
+                <TextBlock
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    Margin="{StaticResource Margin4}"
+                    VerticalAlignment="Center"
+                    Text="{x:Static resx:ResUI.TbRemarks}" />
+                <TextBox
+                    x:Name="txtRemarks"
+                    Grid.Row="1"
+                    Grid.Column="1"
+                    Width="400"
+                    Margin="{StaticResource Margin4}" />
+
+                <TextBlock
+                    Grid.Row="2"
+                    Grid.Column="0"
+                    Margin="{StaticResource Margin4}"
+                    VerticalAlignment="Center"
+                    Text="{x:Static resx:ResUI.TbCoreType}" />
+                <ComboBox
+                    x:Name="cmbCoreType"
+                    Grid.Row="2"
+                    Grid.Column="1"
+                    Width="200"
+                    Margin="{StaticResource Margin4}" />
 
                 <Grid
-                    Grid.Row="0"
-                    ColumnDefinitions="180,Auto,Auto"
-                    RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+                    x:Name="gridPolicyGroup"
+                    Grid.Row="3"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="3"
+                    ColumnDefinitions="180,Auto,Auto">
                     <TextBlock
-                        Grid.Row="0"
-                        Grid.Column="0"
-                        Margin="{StaticResource Margin4}"
-                        Text="{x:Static resx:ResUI.menuServers}" />
-
-                    <TextBlock
-                        Grid.Row="1"
                         Grid.Column="0"
                         Margin="{StaticResource Margin4}"
                         VerticalAlignment="Center"
-                        Text="{x:Static resx:ResUI.TbRemarks}" />
-                    <TextBox
-                        x:Name="txtRemarks"
-                        Grid.Row="1"
-                        Grid.Column="1"
-                        Width="400"
-                        Margin="{StaticResource Margin4}" />
-
-                    <TextBlock
-                        Grid.Row="2"
-                        Grid.Column="0"
-                        Margin="{StaticResource Margin4}"
-                        VerticalAlignment="Center"
-                        Text="{x:Static resx:ResUI.TbCoreType}" />
+                        Text="{x:Static resx:ResUI.TbPolicyGroupType}" />
                     <ComboBox
-                        x:Name="cmbCoreType"
-                        Grid.Row="2"
+                        x:Name="cmbPolicyGroupType"
                         Grid.Column="1"
                         Width="200"
                         Margin="{StaticResource Margin4}" />
-
-                    <Grid
-                        x:Name="gridPolicyGroup"
-                        Grid.Row="3"
-                        Grid.Column="0"
-                        Grid.ColumnSpan="3"
-                        ColumnDefinitions="180,Auto,Auto">
-                        <TextBlock
-                            Grid.Column="0"
-                            Margin="{StaticResource Margin4}"
-                            VerticalAlignment="Center"
-                            Text="{x:Static resx:ResUI.TbPolicyGroupType}" />
-                        <ComboBox
-                            x:Name="cmbPolicyGroupType"
-                            Grid.Column="1"
-                            Width="200"
-                            Margin="{StaticResource Margin4}" />
-                    </Grid>
                 </Grid>
-
+            </Grid>
+        </Grid>
+        <TabControl>
+            <TabItem HorizontalAlignment="Left" Header="{x:Static resx:ResUI.menuServerList}">
                 <DataGrid
                     x:Name="lstChild"
                     Grid.Row="1"
@@ -144,7 +145,7 @@
                             Header="{x:Static resx:ResUI.LvTLS}" />
                     </DataGrid.Columns>
                 </DataGrid>
-            </Grid>
-        </ScrollViewer>
+            </TabItem>
+        </TabControl>
     </DockPanel>
 </Window>

--- a/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml.cs
@@ -29,6 +29,7 @@ public partial class AddGroupServerWindow : WindowBase<AddGroupServerViewModel>
         cmbPolicyGroupType.ItemsSource = new List<string>
         {
             ResUI.TbLeastPing,
+            ResUI.TbFallback,
             ResUI.TbRandom,
             ResUI.TbRoundRobin,
             ResUI.TbLeastLoad,

--- a/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml.cs
@@ -21,6 +21,7 @@ public partial class AddGroupServerWindow : WindowBase<AddGroupServerViewModel>
 
         this.Loaded += Window_Loaded;
         btnCancel.Click += (s, e) => this.Close();
+        lstChild.SelectionChanged += LstChild_SelectionChanged;
 
         ViewModel = new AddGroupServerViewModel(profileItem, UpdateViewHandler);
 
@@ -145,4 +146,13 @@ public partial class AddGroupServerWindow : WindowBase<AddGroupServerViewModel>
             ViewModel?.ChildItemsObs.AddRange(profiles);
         }
     }
+
+    private void LstChild_SelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (ViewModel != null)
+        {
+            ViewModel.SelectedChildren = lstChild.SelectedItems.Cast<ProfileItem>().ToList();
+        }
+    }
+
 }

--- a/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml.cs
@@ -1,0 +1,149 @@
+using System.Reactive.Disposables;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using ReactiveUI;
+using v2rayN.Desktop.Base;
+
+namespace v2rayN.Desktop.Views;
+
+public partial class AddGroupServerWindow : WindowBase<AddGroupServerViewModel>
+{
+    public AddGroupServerWindow()
+    {
+        InitializeComponent();
+    }
+
+    public AddGroupServerWindow(ProfileItem profileItem)
+    {
+        InitializeComponent();
+
+        this.Loaded += Window_Loaded;
+        btnCancel.Click += (s, e) => this.Close();
+
+        ViewModel = new AddGroupServerViewModel(profileItem, UpdateViewHandler);
+
+        cmbCoreType.ItemsSource = Global.CoreTypes;
+        cmbPolicyGroupType.ItemsSource = new List<string>
+        {
+            ResUI.TbLeastPing,
+            ResUI.TbRandom,
+            ResUI.TbRoundRobin,
+            ResUI.TbLeastLoad,
+        };
+
+        switch (profileItem.ConfigType)
+        {
+            case EConfigType.PolicyGroup:
+                this.Title = ResUI.TbConfigTypePolicyGroup;
+                break;
+            case EConfigType.ProxyChain:
+                this.Title = ResUI.TbConfigTypeProxyChain;
+                gridPolicyGroup.IsVisible = false;
+                break;
+        }
+
+        this.WhenActivated(disposables =>
+        {
+            this.Bind(ViewModel, vm => vm.SelectedSource.Remarks, v => v.txtRemarks.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.CoreType, v => v.cmbCoreType.SelectedValue).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.PolicyGroupType, v => v.cmbPolicyGroupType.SelectedValue).DisposeWith(disposables);
+
+            this.OneWayBind(ViewModel, vm => vm.ChildItemsObs, v => v.lstChild.ItemsSource).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SelectedChild, v => v.lstChild.SelectedItem).DisposeWith(disposables);
+
+            this.BindCommand(ViewModel, vm => vm.RemoveCmd, v => v.menuRemoveChildServer).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.MoveTopCmd, v => v.menuMoveTop).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.MoveUpCmd, v => v.menuMoveUp).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.MoveDownCmd, v => v.menuMoveDown).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.MoveBottomCmd, v => v.menuMoveBottom).DisposeWith(disposables);
+
+            this.BindCommand(ViewModel, vm => vm.SaveCmd, v => v.btnSave).DisposeWith(disposables);
+        });
+
+        // Context menu actions that require custom logic (Add, SelectAll)
+        menuAddChildServer.Click += MenuAddChild_Click;
+        menuSelectAllChild.Click += (s, e) => lstChild.SelectAll();
+
+        // Keyboard shortcuts when focus is within grid
+        this.AddHandler(KeyDownEvent, AddGroupServerWindow_KeyDown, RoutingStrategies.Tunnel);
+        lstChild.LoadingRow += LstChild_LoadingRow;
+    }
+
+    private void LstChild_LoadingRow(object? sender, DataGridRowEventArgs e)
+    {
+        e.Row.Header = $" {e.Row.Index + 1}";
+    }
+
+    private async Task<bool> UpdateViewHandler(EViewAction action, object? obj)
+    {
+        switch (action)
+        {
+            case EViewAction.CloseWindow:
+                this.Close(true);
+                break;
+        }
+        return await Task.FromResult(true);
+    }
+
+    private void Window_Loaded(object? sender, RoutedEventArgs e)
+    {
+        txtRemarks.Focus();
+    }
+
+    private void AddGroupServerWindow_KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (!lstChild.IsKeyboardFocusWithin)
+            return;
+
+        if ((e.KeyModifiers & (KeyModifiers.Control | KeyModifiers.Meta)) != 0)
+        {
+            if (e.Key == Key.A)
+            {
+                lstChild.SelectAll();
+                e.Handled = true;
+            }
+        }
+        else
+        {
+            switch (e.Key)
+            {
+                case Key.T:
+                    ViewModel?.MoveServer(EMove.Top);
+                    e.Handled = true;
+                    break;
+                case Key.U:
+                    ViewModel?.MoveServer(EMove.Up);
+                    e.Handled = true;
+                    break;
+                case Key.D:
+                    ViewModel?.MoveServer(EMove.Down);
+                    e.Handled = true;
+                    break;
+                case Key.B:
+                    ViewModel?.MoveServer(EMove.Bottom);
+                    e.Handled = true;
+                    break;
+                case Key.Delete:
+                    ViewModel?.ChildRemoveAsync();
+                    e.Handled = true;
+                    break;
+            }
+        }
+    }
+
+    private async void MenuAddChild_Click(object? sender, RoutedEventArgs e)
+    {
+        var selectWindow = new ProfilesSelectWindow();
+        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom }, exclude: true);
+        var result = await selectWindow.ShowDialog<bool?>(this);
+        if (result == true)
+        {
+            var profile = await selectWindow.ProfileItem;
+            if (profile != null && ViewModel != null)
+            {
+                ViewModel.ChildItemsObs.Add(profile);
+            }
+        }
+    }
+}

--- a/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml.cs
@@ -138,7 +138,14 @@ public partial class AddGroupServerWindow : WindowBase<AddGroupServerViewModel>
     private async void MenuAddChild_Click(object? sender, RoutedEventArgs e)
     {
         var selectWindow = new ProfilesSelectWindow();
-        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
+        if (ViewModel?.SelectedSource?.ConfigType == EConfigType.PolicyGroup)
+        {
+            selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom }, exclude: true);
+        }
+        else
+        {
+            selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
+        }
         selectWindow.AllowMultiSelect(true);
         var result = await selectWindow.ShowDialog<bool?>(this);
         if (result == true)

--- a/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml.cs
@@ -2,6 +2,7 @@ using System.Reactive.Disposables;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using DynamicData;
 using ReactiveUI;
 using v2rayN.Desktop.Base;
 
@@ -135,15 +136,13 @@ public partial class AddGroupServerWindow : WindowBase<AddGroupServerViewModel>
     private async void MenuAddChild_Click(object? sender, RoutedEventArgs e)
     {
         var selectWindow = new ProfilesSelectWindow();
-        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom }, exclude: true);
+        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
+        selectWindow.AllowMultiSelect(true);
         var result = await selectWindow.ShowDialog<bool?>(this);
         if (result == true)
         {
-            var profile = await selectWindow.ProfileItem;
-            if (profile != null && ViewModel != null)
-            {
-                ViewModel.ChildItemsObs.Add(profile);
-            }
+            var profiles = await selectWindow.ProfileItems;
+            ViewModel?.ChildItemsObs.AddRange(profiles);
         }
     }
 }

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml
@@ -35,6 +35,8 @@
                         <MenuItem x:Name="menuAddServerViaScan" Header="{x:Static resx:ResUI.menuAddServerViaScan}" />
                         <MenuItem x:Name="menuAddServerViaImage" Header="{x:Static resx:ResUI.menuAddServerViaImage}" />
                         <MenuItem x:Name="menuAddCustomServer" Header="{x:Static resx:ResUI.menuAddCustomServer}" />
+                        <MenuItem x:Name="menuAddPolicyGroupServer" Header="{x:Static resx:ResUI.menuAddPolicyGroupServer}" />
+                        <MenuItem x:Name="menuAddProxyChainServer" Header="{x:Static resx:ResUI.menuAddProxyChainServer}" />
                         <Separator />
                         <MenuItem x:Name="menuAddVmessServer" Header="{x:Static resx:ResUI.menuAddVmessServer}" />
                         <MenuItem x:Name="menuAddVlessServer" Header="{x:Static resx:ResUI.menuAddVlessServer}" />

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
@@ -83,6 +83,8 @@ public partial class MainWindow : WindowBase<MainWindowViewModel>
             this.BindCommand(ViewModel, vm => vm.AddWireguardServerCmd, v => v.menuAddWireguardServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddAnytlsServerCmd, v => v.menuAddAnytlsServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddCustomServerCmd, v => v.menuAddCustomServer).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.AddPolicyGroupServerCmd, v => v.menuAddPolicyGroupServer).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.AddProxyChainServerCmd, v => v.menuAddProxyChainServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddServerViaClipboardCmd, v => v.menuAddServerViaClipboard).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddServerViaScanCmd, v => v.menuAddServerViaScan).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddServerViaImageCmd, v => v.menuAddServerViaImage).DisposeWith(disposables);
@@ -206,6 +208,11 @@ public partial class MainWindow : WindowBase<MainWindowViewModel>
                 if (obj is null)
                     return false;
                 return await new AddServer2Window((ProfileItem)obj).ShowDialog<bool>(this);
+
+            case EViewAction.AddGroupServerWindow:
+                if (obj is null)
+                    return false;
+                return await new AddGroupServerWindow((ProfileItem)obj).ShowDialog<bool>(this);
 
             case EViewAction.DNSSettingWindow:
                 return await new DNSSettingWindow().ShowDialog<bool>(this);

--- a/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml
@@ -99,13 +99,13 @@
                         <MenuItem x:Name="menuCopyServer" Header="{x:Static resx:ResUI.menuCopyServer}" />
                         <MenuItem x:Name="menuShareServer" Header="{x:Static resx:ResUI.menuShareServer}" />
                         <Separator />
-                        <MenuItem Header="{x:Static resx:ResUI.menuSetDefaultMultipleServer}">
-                            <MenuItem x:Name="menuSetDefaultMultipleServerXrayRandom" Header="{x:Static resx:ResUI.menuSetDefaultMultipleServerXrayRandom}" />
-                            <MenuItem x:Name="menuSetDefaultMultipleServerXrayRoundRobin" Header="{x:Static resx:ResUI.menuSetDefaultMultipleServerXrayRoundRobin}" />
-                            <MenuItem x:Name="menuSetDefaultMultipleServerXrayLeastPing" Header="{x:Static resx:ResUI.menuSetDefaultMultipleServerXrayLeastPing}" />
-                            <MenuItem x:Name="menuSetDefaultMultipleServerXrayLeastLoad" Header="{x:Static resx:ResUI.menuSetDefaultMultipleServerXrayLeastLoad}" />
+                        <MenuItem Header="{x:Static resx:ResUI.menuGenGroupMultipleServer}">
+                            <MenuItem x:Name="menuGenGroupMultipleServerXrayRandom" Header="{x:Static resx:ResUI.menuGenGroupMultipleServerXrayRandom}" />
+                            <MenuItem x:Name="menuGenGroupMultipleServerXrayRoundRobin" Header="{x:Static resx:ResUI.menuGenGroupMultipleServerXrayRoundRobin}" />
+                            <MenuItem x:Name="menuGenGroupMultipleServerXrayLeastPing" Header="{x:Static resx:ResUI.menuGenGroupMultipleServerXrayLeastPing}" />
+                            <MenuItem x:Name="menuGenGroupMultipleServerXrayLeastLoad" Header="{x:Static resx:ResUI.menuGenGroupMultipleServerXrayLeastLoad}" />
                             <Separator />
-                            <MenuItem x:Name="menuSetDefaultMultipleServerSingBoxLeastPing" Header="{x:Static resx:ResUI.menuSetDefaultMultipleServerSingBoxLeastPing}" />
+                            <MenuItem x:Name="menuGenGroupMultipleServerSingBoxLeastPing" Header="{x:Static resx:ResUI.menuGenGroupMultipleServerSingBoxLeastPing}" />
                         </MenuItem>
                         <Separator />
                         <MenuItem x:Name="menuMixedTestServer" Header="{x:Static resx:ResUI.menuMixedTestServer}" />

--- a/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml
@@ -106,6 +106,7 @@
                             <MenuItem x:Name="menuGenGroupMultipleServerXrayLeastLoad" Header="{x:Static resx:ResUI.menuGenGroupMultipleServerXrayLeastLoad}" />
                             <Separator />
                             <MenuItem x:Name="menuGenGroupMultipleServerSingBoxLeastPing" Header="{x:Static resx:ResUI.menuGenGroupMultipleServerSingBoxLeastPing}" />
+                            <MenuItem x:Name="menuGenGroupMultipleServerSingBoxFallback" Header="{x:Static resx:ResUI.menuGenGroupMultipleServerSingBoxFallback}" />
                         </MenuItem>
                         <Separator />
                         <MenuItem x:Name="menuMixedTestServer" Header="{x:Static resx:ResUI.menuMixedTestServer}" />

--- a/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml.cs
@@ -167,6 +167,11 @@ public partial class ProfilesView : ReactiveUserControl<ProfilesViewModel>
                     return false;
                 return await new AddServer2Window((ProfileItem)obj).ShowDialog<bool>(_window);
 
+            case EViewAction.AddGroupServerWindow:
+                if (obj is null)
+                    return false;
+                return await new AddGroupServerWindow((ProfileItem)obj).ShowDialog<bool>(_window);
+
             case EViewAction.ShareServer:
                 if (obj is null)
                     return false;

--- a/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml.cs
@@ -71,6 +71,7 @@ public partial class ProfilesView : ReactiveUserControl<ProfilesViewModel>
             this.BindCommand(ViewModel, vm => vm.GenGroupMultipleServerXrayLeastPingCmd, v => v.menuGenGroupMultipleServerXrayLeastPing).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.GenGroupMultipleServerXrayLeastLoadCmd, v => v.menuGenGroupMultipleServerXrayLeastLoad).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.GenGroupMultipleServerSingBoxLeastPingCmd, v => v.menuGenGroupMultipleServerSingBoxLeastPing).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.GenGroupMultipleServerSingBoxFallbackCmd, v => v.menuGenGroupMultipleServerSingBoxFallback).DisposeWith(disposables);
 
             //servers move
             //this.OneWayBind(ViewModel, vm => vm.SubItems, v => v.cmbMoveToGroup.ItemsSource).DisposeWith(disposables);

--- a/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml.cs
@@ -66,11 +66,11 @@ public partial class ProfilesView : ReactiveUserControl<ProfilesViewModel>
             this.BindCommand(ViewModel, vm => vm.CopyServerCmd, v => v.menuCopyServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.SetDefaultServerCmd, v => v.menuSetDefaultServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.ShareServerCmd, v => v.menuShareServer).DisposeWith(disposables);
-            this.BindCommand(ViewModel, vm => vm.SetDefaultMultipleServerXrayRandomCmd, v => v.menuSetDefaultMultipleServerXrayRandom).DisposeWith(disposables);
-            this.BindCommand(ViewModel, vm => vm.SetDefaultMultipleServerXrayRoundRobinCmd, v => v.menuSetDefaultMultipleServerXrayRoundRobin).DisposeWith(disposables);
-            this.BindCommand(ViewModel, vm => vm.SetDefaultMultipleServerXrayLeastPingCmd, v => v.menuSetDefaultMultipleServerXrayLeastPing).DisposeWith(disposables);
-            this.BindCommand(ViewModel, vm => vm.SetDefaultMultipleServerXrayLeastLoadCmd, v => v.menuSetDefaultMultipleServerXrayLeastLoad).DisposeWith(disposables);
-            this.BindCommand(ViewModel, vm => vm.SetDefaultMultipleServerSingBoxLeastPingCmd, v => v.menuSetDefaultMultipleServerSingBoxLeastPing).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.GenGroupMultipleServerXrayRandomCmd, v => v.menuGenGroupMultipleServerXrayRandom).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.GenGroupMultipleServerXrayRoundRobinCmd, v => v.menuGenGroupMultipleServerXrayRoundRobin).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.GenGroupMultipleServerXrayLeastPingCmd, v => v.menuGenGroupMultipleServerXrayLeastPing).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.GenGroupMultipleServerXrayLeastLoadCmd, v => v.menuGenGroupMultipleServerXrayLeastLoad).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.GenGroupMultipleServerSingBoxLeastPingCmd, v => v.menuGenGroupMultipleServerSingBoxLeastPing).DisposeWith(disposables);
 
             //servers move
             //this.OneWayBind(ViewModel, vm => vm.SubItems, v => v.cmbMoveToGroup.ItemsSource).DisposeWith(disposables);

--- a/v2rayN/v2rayN.Desktop/Views/RoutingRuleDetailsWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/RoutingRuleDetailsWindow.axaml.cs
@@ -98,7 +98,7 @@ public partial class RoutingRuleDetailsWindow : WindowBase<RoutingRuleDetailsVie
     private async void BtnSelectProfile_Click(object? sender, RoutedEventArgs e)
     {
         var selectWindow = new ProfilesSelectWindow();
-        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom }, exclude: true);
+        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
         var result = await selectWindow.ShowDialog<bool?>(this);
         if (result == true)
         {

--- a/v2rayN/v2rayN.Desktop/Views/RoutingRuleDetailsWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/RoutingRuleDetailsWindow.axaml.cs
@@ -98,7 +98,7 @@ public partial class RoutingRuleDetailsWindow : WindowBase<RoutingRuleDetailsVie
     private async void BtnSelectProfile_Click(object? sender, RoutedEventArgs e)
     {
         var selectWindow = new ProfilesSelectWindow();
-        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
+        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom }, exclude: true);
         var result = await selectWindow.ShowDialog<bool?>(this);
         if (result == true)
         {

--- a/v2rayN/v2rayN.Desktop/Views/SubEditWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/SubEditWindow.axaml.cs
@@ -63,7 +63,7 @@ public partial class SubEditWindow : WindowBase<SubEditViewModel>
     private async void BtnSelectPrevProfile_Click(object? sender, RoutedEventArgs e)
     {
         var selectWindow = new ProfilesSelectWindow();
-        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom }, exclude: true);
+        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
         var result = await selectWindow.ShowDialog<bool?>(this);
         if (result == true)
         {
@@ -78,7 +78,7 @@ public partial class SubEditWindow : WindowBase<SubEditViewModel>
     private async void BtnSelectNextProfile_Click(object? sender, RoutedEventArgs e)
     {
         var selectWindow = new ProfilesSelectWindow();
-        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom }, exclude: true);
+        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
         var result = await selectWindow.ShowDialog<bool?>(this);
         if (result == true)
         {

--- a/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml
+++ b/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml
@@ -13,6 +13,7 @@
     Width="900"
     Height="700"
     x:TypeArguments="vms:AddGroupServerViewModel"
+    ResizeMode="CanResize"
     ShowInTaskbar="False"
     Style="{StaticResource WindowGlobal}"
     WindowStartupLocation="CenterScreen"
@@ -38,107 +39,104 @@
                 IsCancel="true"
                 Style="{StaticResource DefButton}" />
         </StackPanel>
-        <ScrollViewer
-            materialDesign:ScrollViewerAssist.IsAutoHideEnabled="True"
-            HorizontalScrollBarVisibility="Auto"
-            VerticalScrollBarVisibility="Auto">
-            <Grid>
+        <Grid DockPanel.Dock="Top">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <Grid Grid.Row="0">
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="180" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
 
-                <Grid Grid.Row="0">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
+                <TextBlock
+                    Grid.Row="0"
+                    Grid.Column="0"
+                    Margin="{StaticResource Margin4}"
+                    Style="{StaticResource ModuleTitle}"
+                    Text="{x:Static resx:ResUI.menuServers}" />
+
+
+                <TextBlock
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    Margin="{StaticResource Margin4}"
+                    VerticalAlignment="Center"
+                    Style="{StaticResource ToolbarTextBlock}"
+                    Text="{x:Static resx:ResUI.TbRemarks}" />
+                <TextBox
+                    x:Name="txtRemarks"
+                    Grid.Row="1"
+                    Grid.Column="1"
+                    Width="400"
+                    Margin="{StaticResource Margin4}"
+                    Style="{StaticResource DefTextBox}" />
+
+                <TextBlock
+                    Grid.Row="2"
+                    Grid.Column="0"
+                    Margin="{StaticResource Margin4}"
+                    VerticalAlignment="Center"
+                    Style="{StaticResource ToolbarTextBlock}"
+                    Text="{x:Static resx:ResUI.TbCoreType}" />
+                <ComboBox
+                    x:Name="cmbCoreType"
+                    Grid.Row="2"
+                    Grid.Column="1"
+                    Width="200"
+                    Margin="{StaticResource Margin4}"
+                    materialDesign:HintAssist.Hint="{x:Static resx:ResUI.TbCoreType}"
+                    Style="{StaticResource DefComboBox}" />
+
+                <Grid
+                    x:Name="gridPolicyGroup"
+                    Grid.Row="3"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="3">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="180" />
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
-
                     <TextBlock
-                        Grid.Row="0"
-                        Grid.Column="0"
-                        Margin="{StaticResource Margin4}"
-                        Style="{StaticResource ModuleTitle}"
-                        Text="{x:Static resx:ResUI.menuServers}" />
-
-
-                    <TextBlock
-                        Grid.Row="1"
+                        Grid.Row="3"
                         Grid.Column="0"
                         Margin="{StaticResource Margin4}"
                         VerticalAlignment="Center"
                         Style="{StaticResource ToolbarTextBlock}"
-                        Text="{x:Static resx:ResUI.TbRemarks}" />
-                    <TextBox
-                        x:Name="txtRemarks"
-                        Grid.Row="1"
-                        Grid.Column="1"
-                        Width="400"
-                        Margin="{StaticResource Margin4}"
-                        Style="{StaticResource DefTextBox}" />
-
-                    <TextBlock
-                        Grid.Row="2"
-                        Grid.Column="0"
-                        Margin="{StaticResource Margin4}"
-                        VerticalAlignment="Center"
-                        Style="{StaticResource ToolbarTextBlock}"
-                        Text="{x:Static resx:ResUI.TbCoreType}" />
+                        Text="{x:Static resx:ResUI.TbPolicyGroupType}" />
                     <ComboBox
-                        x:Name="cmbCoreType"
-                        Grid.Row="2"
+                        x:Name="cmbPolicyGroupType"
+                        Grid.Row="3"
                         Grid.Column="1"
                         Width="200"
                         Margin="{StaticResource Margin4}"
-                        materialDesign:HintAssist.Hint="{x:Static resx:ResUI.TbCoreType}"
+                        materialDesign:HintAssist.Hint="{x:Static resx:ResUI.TbPolicyGroupType}"
                         Style="{StaticResource DefComboBox}" />
-
-                    <Grid
-                        x:Name="gridPolicyGroup"
-                        Grid.Row="3"
-                        Grid.Column="0"
-                        Grid.ColumnSpan="3">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="180" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock
-                            Grid.Row="3"
-                            Grid.Column="0"
-                            Margin="{StaticResource Margin4}"
-                            VerticalAlignment="Center"
-                            Style="{StaticResource ToolbarTextBlock}"
-                            Text="{x:Static resx:ResUI.TbPolicyGroupType}" />
-                        <ComboBox
-                            x:Name="cmbPolicyGroupType"
-                            Grid.Row="3"
-                            Grid.Column="1"
-                            Width="200"
-                            Margin="{StaticResource Margin4}"
-                            materialDesign:HintAssist.Hint="{x:Static resx:ResUI.TbPolicyGroupType}"
-                            Style="{StaticResource DefComboBox}" />
-                    </Grid>
                 </Grid>
-
+            </Grid>
+        </Grid>
+        <TabControl>
+            <TabItem HorizontalAlignment="Left" Header="{x:Static resx:ResUI.menuServerList}">
                 <DataGrid
                     x:Name="lstChild"
-                    Grid.Row="1"
                     AutoGenerateColumns="False"
                     BorderThickness="1"
                     CanUserAddRows="False"
@@ -210,7 +208,7 @@
                             Header="{x:Static resx:ResUI.LvTLS}" />
                     </DataGrid.Columns>
                 </DataGrid>
-            </Grid>
-        </ScrollViewer>
+            </TabItem>
+        </TabControl>
     </DockPanel>
 </base:WindowBase>

--- a/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml
+++ b/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml
@@ -73,7 +73,6 @@
                     Style="{StaticResource ModuleTitle}"
                     Text="{x:Static resx:ResUI.menuServers}" />
 
-
                 <TextBlock
                     Grid.Row="1"
                     Grid.Column="0"

--- a/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml
+++ b/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml
@@ -1,0 +1,216 @@
+<base:WindowBase
+    x:Class="v2rayN.Views.AddGroupServerWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:base="clr-namespace:v2rayN.Base"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:reactiveui="http://reactiveui.net"
+    xmlns:resx="clr-namespace:ServiceLib.Resx;assembly=ServiceLib"
+    xmlns:vms="clr-namespace:ServiceLib.ViewModels;assembly=ServiceLib"
+    Title="{x:Static resx:ResUI.menuServers}"
+    Width="900"
+    Height="700"
+    x:TypeArguments="vms:AddGroupServerViewModel"
+    ShowInTaskbar="False"
+    Style="{StaticResource WindowGlobal}"
+    WindowStartupLocation="CenterScreen"
+    mc:Ignorable="d">
+
+    <DockPanel Margin="{StaticResource Margin8}">
+        <StackPanel
+            Margin="{StaticResource Margin4}"
+            HorizontalAlignment="Center"
+            DockPanel.Dock="Bottom"
+            Orientation="Horizontal">
+            <Button
+                x:Name="btnSave"
+                Width="100"
+                Content="{x:Static resx:ResUI.TbConfirm}"
+                IsDefault="True"
+                Style="{StaticResource DefButton}" />
+            <Button
+                x:Name="btnCancel"
+                Width="100"
+                Margin="{StaticResource MarginLeftRight8}"
+                Content="{x:Static resx:ResUI.TbCancel}"
+                IsCancel="true"
+                Style="{StaticResource DefButton}" />
+        </StackPanel>
+        <ScrollViewer
+            materialDesign:ScrollViewerAssist.IsAutoHideEnabled="True"
+            HorizontalScrollBarVisibility="Auto"
+            VerticalScrollBarVisibility="Auto">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <Grid Grid.Row="0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="180" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        Margin="{StaticResource Margin4}"
+                        Style="{StaticResource ModuleTitle}"
+                        Text="{x:Static resx:ResUI.menuServers}" />
+
+
+                    <TextBlock
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        Margin="{StaticResource Margin4}"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource ToolbarTextBlock}"
+                        Text="{x:Static resx:ResUI.TbRemarks}" />
+                    <TextBox
+                        x:Name="txtRemarks"
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        Width="400"
+                        Margin="{StaticResource Margin4}"
+                        Style="{StaticResource DefTextBox}" />
+
+                    <TextBlock
+                        Grid.Row="2"
+                        Grid.Column="0"
+                        Margin="{StaticResource Margin4}"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource ToolbarTextBlock}"
+                        Text="{x:Static resx:ResUI.TbCoreType}" />
+                    <ComboBox
+                        x:Name="cmbCoreType"
+                        Grid.Row="2"
+                        Grid.Column="1"
+                        Width="200"
+                        Margin="{StaticResource Margin4}"
+                        materialDesign:HintAssist.Hint="{x:Static resx:ResUI.TbCoreType}"
+                        Style="{StaticResource DefComboBox}" />
+
+                    <Grid
+                        x:Name="gridPolicyGroup"
+                        Grid.Row="3"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="3">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="180" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Row="3"
+                            Grid.Column="0"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            Style="{StaticResource ToolbarTextBlock}"
+                            Text="{x:Static resx:ResUI.TbPolicyGroupType}" />
+                        <ComboBox
+                            x:Name="cmbPolicyGroupType"
+                            Grid.Row="3"
+                            Grid.Column="1"
+                            Width="200"
+                            Margin="{StaticResource Margin4}"
+                            materialDesign:HintAssist.Hint="{x:Static resx:ResUI.TbPolicyGroupType}"
+                            Style="{StaticResource DefComboBox}" />
+                    </Grid>
+                </Grid>
+
+                <DataGrid
+                    x:Name="lstChild"
+                    Grid.Row="1"
+                    AutoGenerateColumns="False"
+                    BorderThickness="1"
+                    CanUserAddRows="False"
+                    CanUserResizeRows="False"
+                    CanUserSortColumns="False"
+                    EnableRowVirtualization="True"
+                    GridLinesVisibility="All"
+                    HeadersVisibility="Column"
+                    IsReadOnly="True"
+                    Style="{StaticResource DefDataGrid}">
+                    <DataGrid.ContextMenu>
+                        <ContextMenu Style="{StaticResource DefContextMenu}">
+                            <MenuItem
+                                x:Name="menuAddChildServer"
+                                Height="{StaticResource MenuItemHeight}"
+                                Click="MenuAddChild_Click"
+                                Header="{x:Static resx:ResUI.menuAddChildServer}" />
+                            <MenuItem
+                                x:Name="menuRemoveChildServer"
+                                Height="{StaticResource MenuItemHeight}"
+                                Header="{x:Static resx:ResUI.menuRemoveChildServer}" />
+                            <MenuItem
+                                x:Name="menuSelectAllChild"
+                                Height="{StaticResource MenuItemHeight}"
+                                Header="{x:Static resx:ResUI.menuSelectAll}" />
+                            <Separator />
+                            <MenuItem
+                                x:Name="menuMoveTop"
+                                Height="{StaticResource MenuItemHeight}"
+                                Header="{x:Static resx:ResUI.menuMoveTop}" />
+                            <MenuItem
+                                x:Name="menuMoveUp"
+                                Height="{StaticResource MenuItemHeight}"
+                                Header="{x:Static resx:ResUI.menuMoveUp}" />
+                            <MenuItem
+                                x:Name="menuMoveDown"
+                                Height="{StaticResource MenuItemHeight}"
+                                Header="{x:Static resx:ResUI.menuMoveDown}" />
+                            <MenuItem
+                                x:Name="menuMoveBottom"
+                                Height="{StaticResource MenuItemHeight}"
+                                Header="{x:Static resx:ResUI.menuMoveBottom}" />
+                        </ContextMenu>
+                    </DataGrid.ContextMenu>
+                    <DataGrid.Columns>
+                        <DataGridTextColumn
+                            Width="150"
+                            Binding="{Binding ConfigType}"
+                            Header="{x:Static resx:ResUI.LvServiceType}" />
+                        <DataGridTextColumn
+                            Width="150"
+                            Binding="{Binding Remarks}"
+                            Header="{x:Static resx:ResUI.LvRemarks}" />
+                        <DataGridTextColumn
+                            Width="120"
+                            Binding="{Binding Address}"
+                            Header="{x:Static resx:ResUI.LvAddress}" />
+                        <DataGridTextColumn
+                            Width="100"
+                            Binding="{Binding Port}"
+                            Header="{x:Static resx:ResUI.LvPort}" />
+                        <DataGridTextColumn
+                            Width="100"
+                            Binding="{Binding Network}"
+                            Header="{x:Static resx:ResUI.LvTransportProtocol}" />
+                        <DataGridTextColumn
+                            Width="100"
+                            Binding="{Binding StreamSecurity}"
+                            Header="{x:Static resx:ResUI.LvTLS}" />
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Grid>
+        </ScrollViewer>
+    </DockPanel>
+</base:WindowBase>

--- a/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml.cs
@@ -15,6 +15,8 @@ public partial class AddGroupServerWindow
         this.Owner = Application.Current.MainWindow;
         this.Loaded += Window_Loaded;
         this.PreviewKeyDown += AddGroupServerWindow_PreviewKeyDown;
+        lstChild.SelectionChanged += LstChild_SelectionChanged;
+        menuSelectAllChild.Click += MenuSelectAllChild_Click;
 
         ViewModel = new AddGroupServerViewModel(profileItem, UpdateViewHandler);
 
@@ -46,6 +48,7 @@ public partial class AddGroupServerWindow
             this.Bind(ViewModel, vm => vm.PolicyGroupType, v => v.cmbPolicyGroupType.Text).DisposeWith(disposables);
 
             this.OneWayBind(ViewModel, vm => vm.ChildItemsObs, v => v.lstChild.ItemsSource).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SelectedChild, v => v.lstChild.SelectedItem).DisposeWith(disposables);
 
             this.BindCommand(ViewModel, vm => vm.RemoveCmd, v => v.menuRemoveChildServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.MoveTopCmd, v => v.menuMoveTop).DisposeWith(disposables);
@@ -119,5 +122,18 @@ public partial class AddGroupServerWindow
             var profiles = await selectWindow.ProfileItems;
             ViewModel?.ChildItemsObs.AddRange(profiles);
         }
+    }
+
+    private void LstChild_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+    {
+        if (ViewModel != null)
+        {
+            ViewModel.SelectedChildren = lstChild.SelectedItems.Cast<ProfileItem>().ToList();
+        }
+    }
+
+    private void MenuSelectAllChild_Click(object sender, RoutedEventArgs e)
+    {
+        lstChild.SelectAll();
     }
 }

--- a/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml.cs
@@ -1,8 +1,8 @@
+using System.Reactive.Disposables;
 using System.Windows;
 using System.Windows.Input;
-using ReactiveUI;
-using System.Reactive.Disposables;
 using DynamicData;
+using ReactiveUI;
 
 namespace v2rayN.Views;
 

--- a/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml.cs
@@ -59,6 +59,7 @@ public partial class AddGroupServerWindow
 
             this.BindCommand(ViewModel, vm => vm.SaveCmd, v => v.btnSave).DisposeWith(disposables);
         });
+        WindowsUtils.SetDarkBorder(this, AppManager.Instance.Config.UiItem.CurrentTheme);
     }
 
     private async Task<bool> UpdateViewHandler(EViewAction action, object? obj)

--- a/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml.cs
@@ -1,0 +1,126 @@
+using System.Windows;
+using System.Windows.Input;
+using ReactiveUI;
+using System.Reactive.Disposables;
+
+namespace v2rayN.Views;
+
+public partial class AddGroupServerWindow
+{
+    public AddGroupServerWindow(ProfileItem profileItem)
+    {
+        InitializeComponent();
+
+        this.Owner = Application.Current.MainWindow;
+        this.Loaded += Window_Loaded;
+        this.PreviewKeyDown += AddGroupServerWindow_PreviewKeyDown;
+
+        ViewModel = new AddGroupServerViewModel(profileItem, UpdateViewHandler);
+
+        cmbCoreType.ItemsSource = Global.CoreTypes;
+        cmbPolicyGroupType.ItemsSource = new List<string>
+        {
+            ResUI.TbLeastPing,
+            ResUI.TbRandom,
+            ResUI.TbRoundRobin,
+            ResUI.TbLeastLoad,
+        };
+
+        switch (profileItem.ConfigType)
+        {
+            case EConfigType.PolicyGroup:
+                this.Title = ResUI.TbConfigTypePolicyGroup;
+                break;
+
+            case EConfigType.ProxyChain:
+                this.Title = ResUI.TbConfigTypeProxyChain;
+                gridPolicyGroup.Visibility = Visibility.Collapsed;
+                break;
+        }
+
+        this.WhenActivated(disposables =>
+        {
+            this.Bind(ViewModel, vm => vm.SelectedSource.Remarks, v => v.txtRemarks.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.CoreType, v => v.cmbCoreType.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.PolicyGroupType, v => v.cmbPolicyGroupType.Text).DisposeWith(disposables);
+
+            this.OneWayBind(ViewModel, vm => vm.ChildItemsObs, v => v.lstChild.ItemsSource).DisposeWith(disposables);
+
+            this.BindCommand(ViewModel, vm => vm.RemoveCmd, v => v.menuRemoveChildServer).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.MoveTopCmd, v => v.menuMoveTop).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.MoveUpCmd, v => v.menuMoveUp).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.MoveDownCmd, v => v.menuMoveDown).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.MoveBottomCmd, v => v.menuMoveBottom).DisposeWith(disposables);
+
+            this.BindCommand(ViewModel, vm => vm.SaveCmd, v => v.btnSave).DisposeWith(disposables);
+        });
+    }
+
+    private async Task<bool> UpdateViewHandler(EViewAction action, object? obj)
+    {
+        switch (action)
+        {
+            case EViewAction.CloseWindow:
+                this.DialogResult = true;
+                break;
+        }
+        return await Task.FromResult(true);
+    }
+
+    private void Window_Loaded(object sender, RoutedEventArgs e)
+    {
+        txtRemarks.Focus();
+    }
+
+    private void AddGroupServerWindow_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (!lstChild.IsKeyboardFocusWithin)
+            return;
+        if (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl))
+        {
+            if (e.Key == Key.A)
+            {
+                lstChild.SelectAll();
+            }
+        }
+        else
+        {
+            if (e.Key == Key.T)
+            {
+                ViewModel?.MoveServer(EMove.Top);
+            }
+            else if (e.Key == Key.U)
+            {
+                ViewModel?.MoveServer(EMove.Up);
+            }
+            else if (e.Key == Key.D)
+            {
+                ViewModel?.MoveServer(EMove.Down);
+            }
+            else if (e.Key == Key.B)
+            {
+                ViewModel?.MoveServer(EMove.Bottom);
+            }
+            else if (e.Key == Key.Delete)
+            {
+                ViewModel?.ChildRemoveAsync();
+            }
+        }
+    }
+
+    private async void MenuAddChild_Click(object sender, RoutedEventArgs e)
+    {
+        var selectWindow = new ProfilesSelectWindow();
+        if (selectWindow.ShowDialog() == true)
+        {
+            var profile = await selectWindow.ProfileItem;
+            if (profile != null)
+            {
+                if (ViewModel != null)
+                {
+                    ViewModel.ChildItemsObs.Add(profile);
+                }
+            }
+        }
+    }
+}

--- a/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml.cs
@@ -116,7 +116,14 @@ public partial class AddGroupServerWindow
     private async void MenuAddChild_Click(object sender, RoutedEventArgs e)
     {
         var selectWindow = new ProfilesSelectWindow();
-        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
+        if (ViewModel?.SelectedSource?.ConfigType == EConfigType.PolicyGroup)
+        {
+            selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom }, exclude: true);
+        }
+        else
+        {
+            selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
+        }
         selectWindow.AllowMultiSelect(true);
         if (selectWindow.ShowDialog() == true)
         {

--- a/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml.cs
@@ -24,6 +24,7 @@ public partial class AddGroupServerWindow
         cmbPolicyGroupType.ItemsSource = new List<string>
         {
             ResUI.TbLeastPing,
+            ResUI.TbFallback,
             ResUI.TbRandom,
             ResUI.TbRoundRobin,
             ResUI.TbLeastLoad,

--- a/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using System.Windows.Input;
 using ReactiveUI;
 using System.Reactive.Disposables;
+using DynamicData;
 
 namespace v2rayN.Views;
 
@@ -111,16 +112,12 @@ public partial class AddGroupServerWindow
     private async void MenuAddChild_Click(object sender, RoutedEventArgs e)
     {
         var selectWindow = new ProfilesSelectWindow();
+        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
+        selectWindow.AllowMultiSelect(true);
         if (selectWindow.ShowDialog() == true)
         {
-            var profile = await selectWindow.ProfileItem;
-            if (profile != null)
-            {
-                if (ViewModel != null)
-                {
-                    ViewModel.ChildItemsObs.Add(profile);
-                }
-            }
+            var profiles = await selectWindow.ProfileItems;
+            ViewModel?.ChildItemsObs.AddRange(profiles);
         }
     }
 }

--- a/v2rayN/v2rayN/Views/MainWindow.xaml
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml
@@ -71,6 +71,14 @@
                                     x:Name="menuAddCustomServer"
                                     Height="{StaticResource MenuItemHeight}"
                                     Header="{x:Static resx:ResUI.menuAddCustomServer}" />
+                                <MenuItem
+                                    x:Name="menuAddPolicyGroupServer"
+                                    Height="{StaticResource MenuItemHeight}"
+                                    Header="{x:Static resx:ResUI.menuAddPolicyGroupServer}" />
+                                <MenuItem
+                                    x:Name="menuAddProxyChainServer"
+                                    Height="{StaticResource MenuItemHeight}"
+                                    Header="{x:Static resx:ResUI.menuAddProxyChainServer}" />
                                 <Separator Margin="-40,5" />
                                 <MenuItem
                                     x:Name="menuAddVmessServer"

--- a/v2rayN/v2rayN/Views/MainWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml.cs
@@ -79,6 +79,8 @@ public partial class MainWindow
             this.BindCommand(ViewModel, vm => vm.AddWireguardServerCmd, v => v.menuAddWireguardServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddAnytlsServerCmd, v => v.menuAddAnytlsServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddCustomServerCmd, v => v.menuAddCustomServer).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.AddPolicyGroupServerCmd, v => v.menuAddPolicyGroupServer).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.AddProxyChainServerCmd, v => v.menuAddProxyChainServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddServerViaClipboardCmd, v => v.menuAddServerViaClipboard).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddServerViaScanCmd, v => v.menuAddServerViaScan).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.AddServerViaImageCmd, v => v.menuAddServerViaImage).DisposeWith(disposables);
@@ -194,6 +196,11 @@ public partial class MainWindow
                 if (obj is null)
                     return false;
                 return (new AddServer2Window((ProfileItem)obj)).ShowDialog() ?? false;
+
+            case EViewAction.AddGroupServerWindow:
+                if (obj is null)
+                    return false;
+                return (new AddGroupServerWindow((ProfileItem)obj)).ShowDialog() ?? false;
 
             case EViewAction.DNSSettingWindow:
                 return (new DNSSettingWindow().ShowDialog() ?? false);

--- a/v2rayN/v2rayN/Views/ProfilesView.xaml
+++ b/v2rayN/v2rayN/Views/ProfilesView.xaml
@@ -147,6 +147,10 @@
                                 x:Name="menuGenGroupMultipleServerSingBoxLeastPing"
                                 Height="{StaticResource MenuItemHeight}"
                                 Header="{x:Static resx:ResUI.menuGenGroupMultipleServerSingBoxLeastPing}" />
+                            <MenuItem
+                                x:Name="menuGenGroupMultipleServerSingBoxFallback"
+                                Height="{StaticResource MenuItemHeight}"
+                                Header="{x:Static resx:ResUI.menuGenGroupMultipleServerSingBoxFallback}" />
                         </MenuItem>
                         <Separator />
                         <MenuItem

--- a/v2rayN/v2rayN/Views/ProfilesView.xaml
+++ b/v2rayN/v2rayN/Views/ProfilesView.xaml
@@ -125,28 +125,28 @@
                             Height="{StaticResource MenuItemHeight}"
                             Header="{x:Static resx:ResUI.menuShareServer}" />
                         <Separator />
-                        <MenuItem Header="{x:Static resx:ResUI.menuSetDefaultMultipleServer}">
+                        <MenuItem Header="{x:Static resx:ResUI.menuGenGroupMultipleServer}">
                             <MenuItem
-                                x:Name="menuSetDefaultMultipleServerXrayRandom"
+                                x:Name="menuGenGroupMultipleServerXrayRandom"
                                 Height="{StaticResource MenuItemHeight}"
-                                Header="{x:Static resx:ResUI.menuSetDefaultMultipleServerXrayRandom}" />
+                                Header="{x:Static resx:ResUI.menuGenGroupMultipleServerXrayRandom}" />
                             <MenuItem
-                                x:Name="menuSetDefaultMultipleServerXrayRoundRobin"
+                                x:Name="menuGenGroupMultipleServerXrayRoundRobin"
                                 Height="{StaticResource MenuItemHeight}"
-                                Header="{x:Static resx:ResUI.menuSetDefaultMultipleServerXrayRoundRobin}" />
+                                Header="{x:Static resx:ResUI.menuGenGroupMultipleServerXrayRoundRobin}" />
                             <MenuItem
-                                x:Name="menuSetDefaultMultipleServerXrayLeastPing"
+                                x:Name="menuGenGroupMultipleServerXrayLeastPing"
                                 Height="{StaticResource MenuItemHeight}"
-                                Header="{x:Static resx:ResUI.menuSetDefaultMultipleServerXrayLeastPing}" />
+                                Header="{x:Static resx:ResUI.menuGenGroupMultipleServerXrayLeastPing}" />
                             <MenuItem
-                                x:Name="menuSetDefaultMultipleServerXrayLeastLoad"
+                                x:Name="menuGenGroupMultipleServerXrayLeastLoad"
                                 Height="{StaticResource MenuItemHeight}"
-                                Header="{x:Static resx:ResUI.menuSetDefaultMultipleServerXrayLeastLoad}" />
+                                Header="{x:Static resx:ResUI.menuGenGroupMultipleServerXrayLeastLoad}" />
                             <Separator />
                             <MenuItem
-                                x:Name="menuSetDefaultMultipleServerSingBoxLeastPing"
+                                x:Name="menuGenGroupMultipleServerSingBoxLeastPing"
                                 Height="{StaticResource MenuItemHeight}"
-                                Header="{x:Static resx:ResUI.menuSetDefaultMultipleServerSingBoxLeastPing}" />
+                                Header="{x:Static resx:ResUI.menuGenGroupMultipleServerSingBoxLeastPing}" />
                         </MenuItem>
                         <Separator />
                         <MenuItem

--- a/v2rayN/v2rayN/Views/ProfilesView.xaml.cs
+++ b/v2rayN/v2rayN/Views/ProfilesView.xaml.cs
@@ -148,6 +148,11 @@ public partial class ProfilesView
                     return false;
                 return (new AddServer2Window((ProfileItem)obj)).ShowDialog() ?? false;
 
+            case EViewAction.AddGroupServerWindow:
+                if (obj is null)
+                    return false;
+                return (new AddGroupServerWindow((ProfileItem)obj)).ShowDialog() ?? false;
+
             case EViewAction.ShareServer:
                 if (obj is null)
                     return false;

--- a/v2rayN/v2rayN/Views/ProfilesView.xaml.cs
+++ b/v2rayN/v2rayN/Views/ProfilesView.xaml.cs
@@ -60,11 +60,11 @@ public partial class ProfilesView
             this.BindCommand(ViewModel, vm => vm.CopyServerCmd, v => v.menuCopyServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.SetDefaultServerCmd, v => v.menuSetDefaultServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.ShareServerCmd, v => v.menuShareServer).DisposeWith(disposables);
-            this.BindCommand(ViewModel, vm => vm.SetDefaultMultipleServerXrayRandomCmd, v => v.menuSetDefaultMultipleServerXrayRandom).DisposeWith(disposables);
-            this.BindCommand(ViewModel, vm => vm.SetDefaultMultipleServerXrayRoundRobinCmd, v => v.menuSetDefaultMultipleServerXrayRoundRobin).DisposeWith(disposables);
-            this.BindCommand(ViewModel, vm => vm.SetDefaultMultipleServerXrayLeastPingCmd, v => v.menuSetDefaultMultipleServerXrayLeastPing).DisposeWith(disposables);
-            this.BindCommand(ViewModel, vm => vm.SetDefaultMultipleServerXrayLeastLoadCmd, v => v.menuSetDefaultMultipleServerXrayLeastLoad).DisposeWith(disposables);
-            this.BindCommand(ViewModel, vm => vm.SetDefaultMultipleServerSingBoxLeastPingCmd, v => v.menuSetDefaultMultipleServerSingBoxLeastPing).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.GenGroupMultipleServerXrayRandomCmd, v => v.menuGenGroupMultipleServerXrayRandom).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.GenGroupMultipleServerXrayRoundRobinCmd, v => v.menuGenGroupMultipleServerXrayRoundRobin).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.GenGroupMultipleServerXrayLeastPingCmd, v => v.menuGenGroupMultipleServerXrayLeastPing).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.GenGroupMultipleServerXrayLeastLoadCmd, v => v.menuGenGroupMultipleServerXrayLeastLoad).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.GenGroupMultipleServerSingBoxLeastPingCmd, v => v.menuGenGroupMultipleServerSingBoxLeastPing).DisposeWith(disposables);
 
             //servers move
             this.OneWayBind(ViewModel, vm => vm.SubItems, v => v.cmbMoveToGroup.ItemsSource).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/ProfilesView.xaml.cs
+++ b/v2rayN/v2rayN/Views/ProfilesView.xaml.cs
@@ -65,6 +65,7 @@ public partial class ProfilesView
             this.BindCommand(ViewModel, vm => vm.GenGroupMultipleServerXrayLeastPingCmd, v => v.menuGenGroupMultipleServerXrayLeastPing).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.GenGroupMultipleServerXrayLeastLoadCmd, v => v.menuGenGroupMultipleServerXrayLeastLoad).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.GenGroupMultipleServerSingBoxLeastPingCmd, v => v.menuGenGroupMultipleServerSingBoxLeastPing).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.GenGroupMultipleServerSingBoxFallbackCmd, v => v.menuGenGroupMultipleServerSingBoxFallback).DisposeWith(disposables);
 
             //servers move
             this.OneWayBind(ViewModel, vm => vm.SubItems, v => v.cmbMoveToGroup.ItemsSource).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/RoutingRuleDetailsWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/RoutingRuleDetailsWindow.xaml.cs
@@ -91,7 +91,7 @@ public partial class RoutingRuleDetailsWindow
     private async void BtnSelectProfile_Click(object sender, RoutedEventArgs e)
     {
         var selectWindow = new ProfilesSelectWindow();
-        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
+        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom }, exclude: true);
         if (selectWindow.ShowDialog() == true)
         {
             var profile = await selectWindow.ProfileItem;

--- a/v2rayN/v2rayN/Views/RoutingRuleDetailsWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/RoutingRuleDetailsWindow.xaml.cs
@@ -91,7 +91,7 @@ public partial class RoutingRuleDetailsWindow
     private async void BtnSelectProfile_Click(object sender, RoutedEventArgs e)
     {
         var selectWindow = new ProfilesSelectWindow();
-        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom }, exclude: true);
+        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
         if (selectWindow.ShowDialog() == true)
         {
             var profile = await selectWindow.ProfileItem;

--- a/v2rayN/v2rayN/Views/SubEditWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/SubEditWindow.xaml.cs
@@ -57,7 +57,7 @@ public partial class SubEditWindow
     private async void BtnSelectPrevProfile_Click(object sender, RoutedEventArgs e)
     {
         var selectWindow = new ProfilesSelectWindow();
-        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom }, exclude: true);
+        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
         if (selectWindow.ShowDialog() == true)
         {
             var profile = await selectWindow.ProfileItem;
@@ -71,7 +71,7 @@ public partial class SubEditWindow
     private async void BtnSelectNextProfile_Click(object sender, RoutedEventArgs e)
     {
         var selectWindow = new ProfilesSelectWindow();
-        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom }, exclude: true);
+        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
         if (selectWindow.ShowDialog() == true)
         {
             var profile = await selectWindow.ProfileItem;


### PR DESCRIPTION
支持界面化配置组和链式代理

右键行为改为生成配置组，而不是生成自定义配置

配置组如果有节点不支持则跳过，链式代理则是直接 break，可能导致最终落地不对

#7887

<img height="300" alt="image" src="https://github.com/user-attachments/assets/a902da6f-95f6-45ba-896a-e4424fc82afa" />
<img height="300" alt="image" src="https://github.com/user-attachments/assets/eeaed897-adc2-4286-98b0-e4b913b3c6b9" />
