### PR TITLE
Update CheckUpdateViewModel.cs

### DIFF
--- a/v2rayN/ServiceLib/ViewModels/CheckUpdateViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/CheckUpdateViewModel.cs
@@ -71,8 +71,6 @@ public class CheckUpdateViewModel : MyReactiveObject
             var sp = Utils.StartupPath()?.Replace('\\', '/');
             if (!string.IsNullOrEmpty(sp) && sp.StartsWith("/opt/v2rayN", StringComparison.OrdinalIgnoreCase))
                 return true;
-            if (System.IO.Directory.Exists("/opt/v2rayN"))
-                return true;
         }
         catch
         {

--- a/v2rayN/ServiceLib/ViewModels/CheckUpdateViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/CheckUpdateViewModel.cs
@@ -50,6 +50,7 @@ public class CheckUpdateViewModel : MyReactiveObject
         if (RuntimeInformation.ProcessArchitecture != Architecture.X86)
         {
             CheckUpdateModels.Add(GetCheckUpdateModel(_v2rayN));
+            //Not Windows and under Win10
             if (!(Utils.IsWindows() && Environment.OSVersion.Version.Major < 10))
             {
                 CheckUpdateModels.Add(GetCheckUpdateModel(ECoreType.Xray.ToString()));


### PR DESCRIPTION
本次补丁阻止Linux用户使用deb/rpm/appimage安装的v2rayN通过内置更新器更新v2rayN软件本体。
在安装软件后，内置更新器将会提示不支持。
<img width="1728" height="1080" alt="2025-09-11 23 44 44" src="https://github.com/user-attachments/assets/467fde0d-ba4a-49c8-8303-96d8e77aed60" />
如果用户拨开开关，将会提示不支持，不会更新v2rayN本体，也不会因为更新失败而导致闪退。
<img width="1728" height="1080" alt="2025-09-11 23 46 28" src="https://github.com/user-attachments/assets/47435cc0-236f-4990-85c3-32546c03ea54" />

