### PR TITLE
Add subscription usage/expiry progress + auto refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -399,3 +399,6 @@ FodyWeavers.xsd
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# AI Tools
+AGENTS.md

--- a/v2rayN/ServiceLib/Common/Utils.cs
+++ b/v2rayN/ServiceLib/Common/Utils.cs
@@ -171,22 +171,22 @@ public class Utils
 
     public static string HumanFy(long amount)
     {
-        if (amount <= 0)
-        {
-            return $"{amount:f1} B";
-        }
-
-        string[] units = ["KB", "MB", "GB", "TB", "PB"];
+        // Bytes → KB → MB → GB → TB → PB
+        string[] units = ["B", "KB", "MB", "GB", "TB", "PB"];
         var unitIndex = 0;
-        double size = amount;
+        double size = amount < 0 ? 0 : (double)amount;
 
-        // Loop and divide by 1024 until a suitable unit is found
         while (size >= 1024 && unitIndex < units.Length - 1)
         {
             size /= 1024;
             unitIndex++;
         }
 
+        // For bytes, show integer without decimal; for others keep 1 decimal
+        if (unitIndex == 0)
+        {
+            return $"{(long)size} {units[unitIndex]}";
+        }
         return $"{size:f1} {units[unitIndex]}";
     }
 

--- a/v2rayN/ServiceLib/Events/AppEvents.cs
+++ b/v2rayN/ServiceLib/Events/AppEvents.cs
@@ -1,4 +1,5 @@
 using System.Reactive;
+using ServiceLib.Models;
 
 namespace ServiceLib.Events;
 
@@ -29,4 +30,7 @@ public static class AppEvents
     public static readonly EventChannel<Unit> TestServerRequested = new();
     public static readonly EventChannel<Unit> InboundDisplayRequested = new();
     public static readonly EventChannel<ESysProxyType> SysProxyChangeRequested = new();
+
+    // Fired when subscription usage/expiry info updates
+    public static readonly EventChannel<SubscriptionUsageInfo> SubscriptionInfoUpdated = new();
 }

--- a/v2rayN/ServiceLib/Manager/SubscriptionInfoManager.cs
+++ b/v2rayN/ServiceLib/Manager/SubscriptionInfoManager.cs
@@ -1,0 +1,208 @@
+using System.Text.RegularExpressions;
+using ServiceLib.Common;
+using ServiceLib.Models;
+
+namespace ServiceLib.Manager;
+
+public sealed class SubscriptionInfoManager
+{
+    private static readonly Lazy<SubscriptionInfoManager> _instance = new(() => new());
+    public static SubscriptionInfoManager Instance => _instance.Value;
+
+    private readonly Dictionary<string, SubscriptionUsageInfo> _map = new(StringComparer.OrdinalIgnoreCase);
+    private readonly string _storeFile = Utils.GetConfigPath("SubUsage.json");
+    private readonly object _saveLock = new();
+    private readonly object _mapLock = new();
+
+    private SubscriptionInfoManager()
+    {
+        try
+        {
+            if (File.Exists(_storeFile))
+            {
+                var txt = File.ReadAllText(_storeFile);
+                var data = JsonUtils.Deserialize<Dictionary<string, SubscriptionUsageInfo>>(txt);
+                if (data != null)
+                {
+                    foreach (var kv in data)
+                    {
+                        if (kv.Value != null)
+                        {
+                            _map[kv.Key] = kv.Value;
+                        }
+                    }
+                }
+            }
+        }
+        catch { }
+    }
+
+    public SubscriptionUsageInfo? Get(string subId)
+    {
+        if (subId.IsNullOrEmpty()) return null;
+        lock (_mapLock)
+        {
+            _map.TryGetValue(subId, out var info);
+            return info;
+        }
+    }
+
+    public void Update(string subId, SubscriptionUsageInfo info)
+    {
+        if (subId.IsNullOrEmpty() || info == null) return;
+        info.SubId = subId;
+        lock (_mapLock)
+        {
+            _map[subId] = info;
+        }
+        AppEvents.SubscriptionInfoUpdated.Publish(info);
+        SaveCopy();
+    }
+
+    public void Clear(string subId)
+    {
+        if (subId.IsNullOrEmpty()) return;
+        lock (_mapLock)
+        {
+            _map.Remove(subId);
+        }
+        SaveCopy();
+    }
+
+    // Common subscription header: "Subscription-Userinfo: upload=123; download=456; total=789; expire=1700000000"
+    public void UpdateFromHeader(string subId, IEnumerable<string>? headerValues)
+    {
+        if (headerValues == null) return;
+        var raw = headerValues.FirstOrDefault();
+        if (raw.IsNullOrEmpty()) return;
+
+        var info = ParseUserinfo(raw);
+        if (info != null)
+        {
+            Update(subId, info);
+        }
+    }
+
+    private static SubscriptionUsageInfo? ParseUserinfo(string raw)
+    {
+        try
+        {
+            var info = new SubscriptionUsageInfo();
+
+            var rx = new Regex(@"(?i)(upload|download|total|expire)\s*=\s*([0-9]+)", RegexOptions.Compiled);
+            foreach (Match m in rx.Matches(raw))
+            {
+                var key = m.Groups[1].Value.ToLowerInvariant();
+                if (!long.TryParse(m.Groups[2].Value, out var val)) continue;
+                switch (key)
+                {
+                    case "upload": info.Upload = val; break;
+                    case "download": info.Download = val; break;
+                    case "total": info.Total = val; break;
+                    case "expire": info.ExpireEpoch = val; break;
+                }
+            }
+
+            if (info.Total == 0 && info.Upload == 0 && info.Download == 0 && info.ExpireEpoch == 0)
+            {
+                return null;
+            }
+            return info;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private void SaveCopy()
+    {
+        try
+        {
+            Dictionary<string, SubscriptionUsageInfo> snapshot;
+            lock (_mapLock)
+            {
+                snapshot = new(_map);
+            }
+            var txt = JsonUtils.Serialize(snapshot, true, true);
+            var tmp = _storeFile + ".tmp";
+            lock (_saveLock)
+            {
+                File.WriteAllText(tmp, txt);
+                if (File.Exists(_storeFile))
+                {
+                    File.Replace(tmp, _storeFile, null);
+                }
+                else
+                {
+                    File.Move(tmp, _storeFile);
+                }
+            }
+        }
+        catch { }
+    }
+
+    public async Task FetchHeadersForAll(Config config)
+    {
+        try
+        {
+            var subs = await AppManager.Instance.SubItems();
+            if (subs is not { Count: > 0 }) return;
+            foreach (var s in subs)
+            {
+                await FetchHeaderForSub(config, s);
+            }
+        }
+        catch { }
+    }
+
+    public async Task FetchHeaderForSub(Config config, SubItem s)
+    {
+        try
+        {
+            var originalUrl = Utils.GetPunycode(s.Url.TrimEx());
+            if (originalUrl.IsNullOrEmpty()) return;
+
+            string url = originalUrl;
+            if (s.ConvertTarget.IsNotEmpty())
+            {
+                var subConvertUrl = config.ConstItem.SubConvertUrl.IsNullOrEmpty()
+                    ? Global.SubConvertUrls.FirstOrDefault()
+                    : config.ConstItem.SubConvertUrl;
+                if (subConvertUrl.IsNotEmpty())
+                {
+                    url = string.Format(subConvertUrl!, Utils.UrlEncode(originalUrl));
+                    if (!url.Contains("target=")) url += string.Format("&target={0}", s.ConvertTarget);
+                    if (!url.Contains("config=")) url += string.Format("&config={0}", Global.SubConvertConfig.FirstOrDefault());
+                }
+            }
+
+            var dl = new DownloadService();
+            // via proxy then direct
+            foreach (var blProxy in new[] { true, false })
+            {
+                var (userHeader, _) = await dl.TryGetWithHeaders(url, blProxy, s.UserAgent, timeoutSeconds: 8);
+                if (userHeader.IsNotEmpty())
+                {
+                    UpdateFromHeader(s.Id, new[] { userHeader });
+                    return;
+                }
+            }
+
+            // fallback to original url if converted
+            if (s.ConvertTarget.IsNotEmpty())
+            {
+                foreach (var blProxy in new[] { true, false })
+                {
+                    var (userHeader2, _) = await dl.TryGetWithHeaders(originalUrl, blProxy, s.UserAgent, timeoutSeconds: 6);
+                    if (userHeader2.IsNotEmpty())
+                    {
+                        UpdateFromHeader(s.Id, new[] { userHeader2 });
+                        return;
+                    }
+                }
+            }
+        }
+        catch { }
+    }
+}

--- a/v2rayN/ServiceLib/Manager/TaskManager.cs
+++ b/v2rayN/ServiceLib/Manager/TaskManager.cs
@@ -79,6 +79,8 @@ public class TaskManager
                     Logging.SaveLog($"Update subscription end. {msg}");
                 }
             });
+            // 同步刷新该订阅的用量/到期信息
+            try { await SubscriptionInfoManager.Instance.FetchHeaderForSub(_config, item); } catch { }
             item.UpdateTime = updateTime;
             await ConfigHandler.AddSubItem(_config, item);
             await Task.Delay(1000);

--- a/v2rayN/ServiceLib/Models/SubscriptionUsageInfo.cs
+++ b/v2rayN/ServiceLib/Models/SubscriptionUsageInfo.cs
@@ -1,0 +1,48 @@
+namespace ServiceLib.Models;
+
+public class SubscriptionUsageInfo
+{
+    public string SubId { get; set; } = string.Empty;
+
+    // Bytes
+    public long Upload { get; set; }
+    public long Download { get; set; }
+    public long Total { get; set; }
+
+    // Unix epoch seconds; 0 if unknown
+    public long ExpireEpoch { get; set; }
+
+    public long UsedBytes => Math.Max(0, Upload + Download);
+
+    public int UsagePercent
+    {
+        get
+        {
+            if (Total <= 0) return -1;
+            var p = (int)Math.Round(UsedBytes * 100.0 / Total);
+            return Math.Clamp(p, 0, 100);
+        }
+    }
+
+    public DateTimeOffset? ExpireAt
+    {
+        get
+        {
+            if (ExpireEpoch <= 0) return null;
+            try { return DateTimeOffset.FromUnixTimeSeconds(ExpireEpoch).ToLocalTime(); }
+            catch { return null; }
+        }
+    }
+
+    public int DaysLeft
+    {
+        get
+        {
+            var exp = ExpireAt;
+            if (exp == null) return -1;
+            var days = (int)Math.Ceiling((exp.Value - DateTimeOffset.Now).TotalDays);
+            return Math.Max(days, 0);
+        }
+    }
+}
+

--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -3,6 +3,7 @@ using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
+using ServiceLib.Manager;
 
 namespace ServiceLib.ViewModels;
 
@@ -274,7 +275,15 @@ public class MainWindowViewModel : MyReactiveObject
 
         BlReloadEnabled = true;
         await Reload();
+
+        // 开机自动爬取所有订阅的用量/到期头信息（后台执行）
+        _ = Task.Run(async () =>
+        {
+            try { await SubscriptionInfoManager.Instance.FetchHeadersForAll(_config); } catch { }
+        });
+
     }
+
 
     #endregion Init
 

--- a/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml
@@ -74,6 +74,20 @@
                     Margin="{StaticResource MarginLr4}"
                     VerticalContentAlignment="Center"
                     Watermark="{x:Static resx:ResUI.MsgServerTitle}" />
+
+                <!-- Subscription usage and expiry -->
+                <StackPanel Margin="{StaticResource MarginLr8}" IsVisible="{Binding BlSubInfoVisible}">
+                    <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Left" Margin="0,0,0,2">
+                        <TextBlock Width="56" VerticalAlignment="Center" Text="流量" />
+                        <ProgressBar Height="16" Minimum="0" Maximum="100" Value="{Binding SubUsagePercent}" Width="240" />
+                        <TextBlock VerticalAlignment="Center" Text="{Binding SubUsageText}" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="6" HorizontalAlignment="Left">
+                        <TextBlock Width="56" VerticalAlignment="Center" Text="到期" />
+                        <ProgressBar Height="16" Minimum="0" Maximum="100" Value="{Binding SubExpirePercent}" Width="240" />
+                        <TextBlock VerticalAlignment="Center" Text="{Binding SubExpireText}" />
+                    </StackPanel>
+                </StackPanel>
             </WrapPanel>
             <DataGrid
                 x:Name="lstProfiles"

--- a/v2rayN/v2rayN/Views/ProfilesView.xaml
+++ b/v2rayN/v2rayN/Views/ProfilesView.xaml
@@ -76,6 +76,50 @@
                     materialDesign:TextFieldAssist.HasClearButton="True"
                     AutomationProperties.Name="{x:Static resx:ResUI.MsgServerTitle}"
                     Style="{StaticResource DefTextBox}" />
+
+                <!-- Subscription usage and expiry -->
+                <StackPanel
+                    Margin="{StaticResource MarginLeftRight8}"
+                    VerticalAlignment="Center"
+                    Orientation="Vertical"
+                    Visibility="{Binding BlSubInfoVisible, Converter={StaticResource BoolToVisConverter}}">
+                    <Grid Margin="0,0,0,2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Width="120" VerticalAlignment="Center" Text="流量" />
+                        <ProgressBar
+                            Grid.Column="1"
+                            Height="16"
+                            Minimum="0"
+                            Maximum="100"
+                            Value="{Binding SubUsagePercent}"
+                            Style="{StaticResource MaterialDesignProgressBar}"
+                            Margin="4,0,4,0"
+                            Width="240" />
+                        <TextBlock Grid.Column="2" VerticalAlignment="Center" Text="{Binding SubUsageText}" Margin="0,0,0,0" />
+                    </Grid>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Width="120" VerticalAlignment="Center" Text="到期" />
+                        <ProgressBar
+                            Grid.Column="1"
+                            Height="16"
+                            Minimum="0"
+                            Maximum="100"
+                            Value="{Binding SubExpirePercent}"
+                            Style="{StaticResource MaterialDesignProgressBar}"
+                            Margin="4,0,4,0"
+                            Width="240" />
+                        <TextBlock Grid.Column="2" VerticalAlignment="Center" Text="{Binding SubExpireText}" Margin="0,0,0,0" />
+                    </Grid>
+                </StackPanel>
             </WrapPanel>
             <DataGrid
                 x:Name="lstProfiles"


### PR DESCRIPTION
背景
- 解决 #8136：在主界面展示订阅的“已用/总量”与“到期剩余”进度条，避免用户手动计算或遗忘。

主要改动
- UI（WPF/Avalonia）：在 Profiles 顶部增加两行进度展示（流量/到期），优化间距。
- 头信息解析：统一在 SubscriptionInfoManager 解析 `Subscription-Userinfo: upload=...; download=...; total=...; expire=...`。
- 生命周期：
  - 更新订阅时抓取并更新用量/到期；
  - 启动后后台抓取一次所有订阅；
  - 按订阅的“自动更新间隔(分钟)”定时刷新（复用 TaskManager 逻辑，不额外起定时器）。
- 持久化：将最近一次用量/到期写入 `guiConfigs/SubUsage.json`，使用临时文件 + 原子替换，线程安全。
- 线程安全：对内存映射加锁并在保存时快照序列化，避免并发写入导致异常或文件损坏。
- 其他：
  - 修正单位换算（B/KB/MB/GB/TB），避免 GB 被显示为 TB；
  - DownloadService.TryGetWithHeaders 释放响应，返回 (header, content)；
  - 去重：移除 ViewModel 内部抓头重复实现，统一走 Manager。

兼容性
- 无数据库/配置结构变更；
- 未启用时进度块隐藏；
- 无 Subscription-Userinfo 头时显示占位，功能不受影响。

后续可选
- 将“流量/到期”文案抽到 Resx 多语言；
- Save 去抖合并写；
- 进度语义（剩余/已过）可配置。

谢谢 Review！
