### PR TITLE
Migrate to SourceGenerators

### DIFF
--- a/v2rayN/Directory.Packages.props
+++ b/v2rayN/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="MessageBox.Avalonia" Version="3.2.0" />
     <PackageVersion Include="QRCoder" Version="1.7.0" />
     <PackageVersion Include="ReactiveUI" Version="22.2.1" />
-    <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />
+    <PackageVersion Include="ReactiveUI.SourceGenerators" Version="2.5.1" />
     <PackageVersion Include="ReactiveUI.WPF" Version="22.2.1" />
     <PackageVersion Include="Semi.Avalonia" Version="11.3.7" />
     <PackageVersion Include="Semi.Avalonia.AvaloniaEdit" Version="11.2.0.1" />

--- a/v2rayN/ServiceLib/GlobalUsings.cs
+++ b/v2rayN/ServiceLib/GlobalUsings.cs
@@ -18,7 +18,7 @@ global using System.Text.RegularExpressions;
 global using DynamicData;
 global using DynamicData.Binding;
 global using ReactiveUI;
-global using ReactiveUI.Fody.Helpers;
+global using ReactiveUI.SourceGenerators;
 global using ServiceLib.Base;
 global using ServiceLib.Common;
 global using ServiceLib.Enums;

--- a/v2rayN/ServiceLib/Models/CheckUpdateModel.cs
+++ b/v2rayN/ServiceLib/Models/CheckUpdateModel.cs
@@ -1,10 +1,10 @@
 namespace ServiceLib.Models;
 
-public class CheckUpdateModel : ReactiveObject
+public partial class CheckUpdateModel : ReactiveObject
 {
     public bool? IsSelected { get; set; }
     public string? CoreType { get; set; }
-    [Reactive] public string? Remarks { get; set; }
+    [Reactive] private string? _remarks;
     public string? FileName { get; set; }
     public bool? IsFinished { get; set; }
 }

--- a/v2rayN/ServiceLib/Models/ClashProxyModel.cs
+++ b/v2rayN/ServiceLib/Models/ClashProxyModel.cs
@@ -1,7 +1,7 @@
 namespace ServiceLib.Models;
 
 [Serializable]
-public class ClashProxyModel : ReactiveObject
+public partial class ClashProxyModel : ReactiveObject
 {
     public string? Name { get; set; }
 
@@ -9,9 +9,9 @@ public class ClashProxyModel : ReactiveObject
 
     public string? Now { get; set; }
 
-    [Reactive] public int Delay { get; set; }
+    [Reactive] private int _delay;
 
-    [Reactive] public string? DelayName { get; set; }
+    [Reactive] private string? _delayName;
 
     public bool IsActive { get; set; }
 }

--- a/v2rayN/ServiceLib/Models/ProfileItemModel.cs
+++ b/v2rayN/ServiceLib/Models/ProfileItemModel.cs
@@ -1,32 +1,32 @@
 namespace ServiceLib.Models;
 
 [Serializable]
-public class ProfileItemModel : ProfileItem
+public partial class ProfileItemModel : ProfileItem
 {
     public bool IsActive { get; set; }
     public string SubRemarks { get; set; }
 
     [Reactive]
-    public int Delay { get; set; }
+    private int _delay;
 
     public decimal Speed { get; set; }
     public int Sort { get; set; }
 
     [Reactive]
-    public string DelayVal { get; set; }
+    private string _delayVal;
 
     [Reactive]
-    public string SpeedVal { get; set; }
+    private string _speedVal;
 
     [Reactive]
-    public string TodayUp { get; set; }
+    private string _todayUp;
 
     [Reactive]
-    public string TodayDown { get; set; }
+    private string _todayDown;
 
     [Reactive]
-    public string TotalUp { get; set; }
+    private string _totalUp;
 
     [Reactive]
-    public string TotalDown { get; set; }
+    private string _totalDown;
 }

--- a/v2rayN/ServiceLib/ServiceLib.csproj
+++ b/v2rayN/ServiceLib/ServiceLib.csproj
@@ -9,7 +9,7 @@
 		<PackageReference Include="ReactiveUI">
 			<TreatAsUsed>true</TreatAsUsed>
 		</PackageReference>
-		<PackageReference Include="ReactiveUI.Fody" />
+		<PackageReference Include="ReactiveUI.SourceGenerators" />
 		<PackageReference Include="sqlite-net-pcl" />
 		<PackageReference Include="NLog" />
 		<PackageReference Include="WebDav.Client" />

--- a/v2rayN/ServiceLib/ViewModels/AddGroupServerViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/AddGroupServerViewModel.cs
@@ -1,21 +1,21 @@
 namespace ServiceLib.ViewModels;
 
-public class AddGroupServerViewModel : MyReactiveObject
+public partial class AddGroupServerViewModel : MyReactiveObject
 {
     [Reactive]
-    public ProfileItem SelectedSource { get; set; }
+    private ProfileItem _selectedSource;
 
     [Reactive]
-    public ProfileItem SelectedChild { get; set; }
+    private ProfileItem _selectedChild;
 
-    [Reactive]
+    // [Reactive]
     public IList<ProfileItem> SelectedChildren { get; set; }
 
     [Reactive]
-    public string? CoreType { get; set; }
+    private string? _coreType;
 
     [Reactive]
-    public string? PolicyGroupType { get; set; }
+    private string? _policyGroupType;
 
     public IObservableCollection<ProfileItem> ChildItemsObs { get; } = new ObservableCollectionExtended<ProfileItem>();
 

--- a/v2rayN/ServiceLib/ViewModels/AddServer2ViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/AddServer2ViewModel.cs
@@ -1,12 +1,12 @@
 namespace ServiceLib.ViewModels;
 
-public class AddServer2ViewModel : MyReactiveObject
+public partial class AddServer2ViewModel : MyReactiveObject
 {
     [Reactive]
-    public ProfileItem SelectedSource { get; set; }
+    private ProfileItem _selectedSource;
 
     [Reactive]
-    public string? CoreType { get; set; }
+    private string? _coreType;
 
     public ReactiveCommand<Unit, Unit> BrowseServerCmd { get; }
     public ReactiveCommand<Unit, Unit> EditServerCmd { get; }

--- a/v2rayN/ServiceLib/ViewModels/AddServerViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/AddServerViewModel.cs
@@ -1,12 +1,12 @@
 namespace ServiceLib.ViewModels;
 
-public class AddServerViewModel : MyReactiveObject
+public partial class AddServerViewModel : MyReactiveObject
 {
     [Reactive]
-    public ProfileItem SelectedSource { get; set; }
+    private ProfileItem _selectedSource;
 
     [Reactive]
-    public string? CoreType { get; set; }
+    private string? _coreType;
 
     public ReactiveCommand<Unit, Unit> SaveCmd { get; }
 

--- a/v2rayN/ServiceLib/ViewModels/BackupAndRestoreViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/BackupAndRestoreViewModel.cs
@@ -1,6 +1,6 @@
 namespace ServiceLib.ViewModels;
 
-public class BackupAndRestoreViewModel : MyReactiveObject
+public partial class BackupAndRestoreViewModel : MyReactiveObject
 {
     private readonly string _guiConfigs = "guiConfigs";
     private static string BackupFileName => $"backup_{DateTime.Now:yyyyMMddHHmmss}.zip";
@@ -10,10 +10,10 @@ public class BackupAndRestoreViewModel : MyReactiveObject
     public ReactiveCommand<Unit, Unit> WebDavCheckCmd { get; }
 
     [Reactive]
-    public WebDavItem SelectedSource { get; set; }
+    private WebDavItem _selectedSource;
 
     [Reactive]
-    public string OperationMsg { get; set; }
+    private string _operationMsg;
 
     public BackupAndRestoreViewModel(Func<EViewAction, object?, Task<bool>>? updateView)
     {

--- a/v2rayN/ServiceLib/ViewModels/CheckUpdateViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/CheckUpdateViewModel.cs
@@ -1,6 +1,6 @@
 namespace ServiceLib.ViewModels;
 
-public class CheckUpdateViewModel : MyReactiveObject
+public partial class CheckUpdateViewModel : MyReactiveObject
 {
     private const string _geo = "GeoFiles";
     private readonly string _v2rayN = ECoreType.v2rayN.ToString();
@@ -9,7 +9,7 @@ public class CheckUpdateViewModel : MyReactiveObject
 
     public IObservableCollection<CheckUpdateModel> CheckUpdateModels { get; } = new ObservableCollectionExtended<CheckUpdateModel>();
     public ReactiveCommand<Unit, Unit> CheckUpdateCmd { get; }
-    [Reactive] public bool EnableCheckPreReleaseUpdate { get; set; }
+    [Reactive] private bool _enableCheckPreReleaseUpdate;
 
     public CheckUpdateViewModel(Func<EViewAction, object?, Task<bool>>? updateView)
     {

--- a/v2rayN/ServiceLib/ViewModels/ClashConnectionsViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ClashConnectionsViewModel.cs
@@ -1,20 +1,20 @@
 namespace ServiceLib.ViewModels;
 
-public class ClashConnectionsViewModel : MyReactiveObject
+public partial class ClashConnectionsViewModel : MyReactiveObject
 {
     public IObservableCollection<ClashConnectionModel> ConnectionItems { get; } = new ObservableCollectionExtended<ClashConnectionModel>();
 
     [Reactive]
-    public ClashConnectionModel SelectedSource { get; set; }
+    private ClashConnectionModel _selectedSource;
 
     public ReactiveCommand<Unit, Unit> ConnectionCloseCmd { get; }
     public ReactiveCommand<Unit, Unit> ConnectionCloseAllCmd { get; }
 
     [Reactive]
-    public string HostFilter { get; set; }
+    private string _hostFilter;
 
     [Reactive]
-    public bool AutoRefresh { get; set; }
+    private bool _autoRefresh;
 
     public ClashConnectionsViewModel(Func<EViewAction, object?, Task<bool>>? updateView)
     {

--- a/v2rayN/ServiceLib/ViewModels/ClashProxiesViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ClashProxiesViewModel.cs
@@ -4,7 +4,7 @@ using static ServiceLib.Models.ClashProxies;
 
 namespace ServiceLib.ViewModels;
 
-public class ClashProxiesViewModel : MyReactiveObject
+public partial class ClashProxiesViewModel : MyReactiveObject
 {
     private Dictionary<string, ProxiesItem>? _proxies;
     private Dictionary<string, ProvidersItem>? _providers;
@@ -14,10 +14,10 @@ public class ClashProxiesViewModel : MyReactiveObject
     public IObservableCollection<ClashProxyModel> ProxyDetails { get; } = new ObservableCollectionExtended<ClashProxyModel>();
 
     [Reactive]
-    public ClashProxyModel SelectedGroup { get; set; }
+    private ClashProxyModel _selectedGroup;
 
     [Reactive]
-    public ClashProxyModel SelectedDetail { get; set; }
+    private ClashProxyModel _selectedDetail;
 
     public ReactiveCommand<Unit, Unit> ProxiesReloadCmd { get; }
     public ReactiveCommand<Unit, Unit> ProxiesDelayTestCmd { get; }
@@ -25,13 +25,13 @@ public class ClashProxiesViewModel : MyReactiveObject
     public ReactiveCommand<Unit, Unit> ProxiesSelectActivityCmd { get; }
 
     [Reactive]
-    public int RuleModeSelected { get; set; }
+    private int _ruleModeSelected;
 
     [Reactive]
-    public int SortingSelected { get; set; }
+    private int _sortingSelected;
 
     [Reactive]
-    public bool AutoRefresh { get; set; }
+    private bool _autoRefresh;
 
     public ClashProxiesViewModel(Func<EViewAction, object?, Task<bool>>? updateView)
     {

--- a/v2rayN/ServiceLib/ViewModels/DNSSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/DNSSettingViewModel.cs
@@ -1,33 +1,33 @@
 namespace ServiceLib.ViewModels;
 
-public class DNSSettingViewModel : MyReactiveObject
+public partial class DNSSettingViewModel : MyReactiveObject
 {
-    [Reactive] public bool? UseSystemHosts { get; set; }
-    [Reactive] public bool? AddCommonHosts { get; set; }
-    [Reactive] public bool? FakeIP { get; set; }
-    [Reactive] public bool? BlockBindingQuery { get; set; }
-    [Reactive] public string? DirectDNS { get; set; }
-    [Reactive] public string? RemoteDNS { get; set; }
-    [Reactive] public string? BootstrapDNS { get; set; }
-    [Reactive] public string? RayStrategy4Freedom { get; set; }
-    [Reactive] public string? SingboxStrategy4Direct { get; set; }
-    [Reactive] public string? SingboxStrategy4Proxy { get; set; }
-    [Reactive] public string? Hosts { get; set; }
-    [Reactive] public string? DirectExpectedIPs { get; set; }
+    [Reactive] private bool? _useSystemHosts;
+    [Reactive] private bool? _addCommonHosts;
+    [Reactive] private bool? _fakeIP;
+    [Reactive] private bool? _blockBindingQuery;
+    [Reactive] private string? _directDNS;
+    [Reactive] private string? _remoteDNS;
+    [Reactive] private string? _bootstrapDNS;
+    [Reactive] private string? _rayStrategy4Freedom;
+    [Reactive] private string? _singboxStrategy4Direct;
+    [Reactive] private string? _singboxStrategy4Proxy;
+    [Reactive] private string? _hosts;
+    [Reactive] private string? _directExpectedIPs;
 
-    [Reactive] public bool UseSystemHostsCompatible { get; set; }
-    [Reactive] public string DomainStrategy4FreedomCompatible { get; set; }
-    [Reactive] public string DomainDNSAddressCompatible { get; set; }
-    [Reactive] public string NormalDNSCompatible { get; set; }
+    [Reactive] private bool _useSystemHostsCompatible;
+    [Reactive] private string _domainStrategy4FreedomCompatible;
+    [Reactive] private string _domainDNSAddressCompatible;
+    [Reactive] private string _normalDNSCompatible;
 
-    [Reactive] public string DomainStrategy4Freedom2Compatible { get; set; }
-    [Reactive] public string DomainDNSAddress2Compatible { get; set; }
-    [Reactive] public string NormalDNS2Compatible { get; set; }
-    [Reactive] public string TunDNS2Compatible { get; set; }
-    [Reactive] public bool RayCustomDNSEnableCompatible { get; set; }
-    [Reactive] public bool SBCustomDNSEnableCompatible { get; set; }
+    [Reactive] private string _domainStrategy4Freedom2Compatible;
+    [Reactive] private string _domainDNSAddress2Compatible;
+    [Reactive] private string _normalDNS2Compatible;
+    [Reactive] private string _tunDNS2Compatible;
+    [Reactive] private bool _rayCustomDNSEnableCompatible;
+    [Reactive] private bool _sBCustomDNSEnableCompatible;
 
-    [ObservableAsProperty] public bool IsSimpleDNSEnabled { get; }
+    [ObservableAsProperty] private bool _isSimpleDNSEnabled;
 
     public ReactiveCommand<Unit, Unit> SaveCmd { get; }
     public ReactiveCommand<Unit, Unit> ImportDefConfig4V2rayCompatibleCmd { get; }
@@ -54,7 +54,7 @@ public class DNSSettingViewModel : MyReactiveObject
 
         this.WhenAnyValue(x => x.RayCustomDNSEnableCompatible, x => x.SBCustomDNSEnableCompatible)
             .Select(x => !(x.Item1 && x.Item2))
-            .ToPropertyEx(this, x => x.IsSimpleDNSEnabled);
+            .ToProperty(this, x => x.IsSimpleDNSEnabled);
 
         _ = Init();
     }

--- a/v2rayN/ServiceLib/ViewModels/FullConfigTemplateViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/FullConfigTemplateViewModel.cs
@@ -1,35 +1,35 @@
 namespace ServiceLib.ViewModels;
 
-public class FullConfigTemplateViewModel : MyReactiveObject
+public partial class FullConfigTemplateViewModel : MyReactiveObject
 {
     #region Reactive
 
     [Reactive]
-    public bool EnableFullConfigTemplate4Ray { get; set; }
+    private bool _enableFullConfigTemplate4Ray;
 
     [Reactive]
-    public bool EnableFullConfigTemplate4Singbox { get; set; }
+    private bool _enableFullConfigTemplate4Singbox;
 
     [Reactive]
-    public string FullConfigTemplate4Ray { get; set; }
+    private string _fullConfigTemplate4Ray;
 
     [Reactive]
-    public string FullConfigTemplate4Singbox { get; set; }
+    private string _fullConfigTemplate4Singbox;
 
     [Reactive]
-    public string FullTunConfigTemplate4Singbox { get; set; }
+    private string _fullTunConfigTemplate4Singbox;
 
     [Reactive]
-    public bool AddProxyOnly4Ray { get; set; }
+    private bool _addProxyOnly4Ray;
 
     [Reactive]
-    public bool AddProxyOnly4Singbox { get; set; }
+    private bool _addProxyOnly4Singbox;
 
     [Reactive]
-    public string ProxyDetour4Ray { get; set; }
+    private string _proxyDetour4Ray;
 
     [Reactive]
-    public string ProxyDetour4Singbox { get; set; }
+    private string _proxyDetour4Singbox;
 
     public ReactiveCommand<Unit, Unit> SaveCmd { get; }
 

--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -2,7 +2,7 @@ using System.Reactive.Concurrency;
 
 namespace ServiceLib.ViewModels;
 
-public class MainWindowViewModel : MyReactiveObject
+public partial class MainWindowViewModel : MyReactiveObject
 {
     #region Menu
 
@@ -54,13 +54,13 @@ public class MainWindowViewModel : MyReactiveObject
     public ReactiveCommand<Unit, Unit> ReloadCmd { get; }
 
     [Reactive]
-    public bool BlReloadEnabled { get; set; }
+    private bool _blReloadEnabled;
 
     [Reactive]
-    public bool ShowClashUI { get; set; }
+    private bool _showClashUI;
 
     [Reactive]
-    public int TabMainSelectedIndex { get; set; }
+    private int _tabMainSelectedIndex;
 
     #endregion Menu
 

--- a/v2rayN/ServiceLib/ViewModels/MsgViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MsgViewModel.cs
@@ -1,6 +1,6 @@
 namespace ServiceLib.ViewModels;
 
-public class MsgViewModel : MyReactiveObject
+public partial class MsgViewModel : MyReactiveObject
 {
     private readonly ConcurrentQueue<string> _queueMsg = new();
     private volatile bool _lastMsgFilterNotAvailable;
@@ -8,10 +8,10 @@ public class MsgViewModel : MyReactiveObject
     public int NumMaxMsg { get; } = 500;
 
     [Reactive]
-    public string MsgFilter { get; set; }
+    private string _msgFilter;
 
     [Reactive]
-    public bool AutoRefresh { get; set; }
+    private bool _autoRefresh;
 
     public MsgViewModel(Func<EViewAction, object?, Task<bool>>? updateView)
     {

--- a/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
@@ -1,102 +1,102 @@
 namespace ServiceLib.ViewModels;
 
-public class OptionSettingViewModel : MyReactiveObject
+public partial class OptionSettingViewModel : MyReactiveObject
 {
     #region Core
 
-    [Reactive] public int localPort { get; set; }
-    [Reactive] public bool SecondLocalPortEnabled { get; set; }
-    [Reactive] public bool udpEnabled { get; set; }
-    [Reactive] public bool sniffingEnabled { get; set; }
-    public IList<string> destOverride { get; set; }
-    [Reactive] public bool routeOnly { get; set; }
-    [Reactive] public bool allowLANConn { get; set; }
-    [Reactive] public bool newPort4LAN { get; set; }
-    [Reactive] public string user { get; set; }
-    [Reactive] public string pass { get; set; }
-    [Reactive] public bool muxEnabled { get; set; }
-    [Reactive] public bool logEnabled { get; set; }
-    [Reactive] public string loglevel { get; set; }
-    [Reactive] public bool defAllowInsecure { get; set; }
-    [Reactive] public string defFingerprint { get; set; }
-    [Reactive] public string defUserAgent { get; set; }
-    [Reactive] public string mux4SboxProtocol { get; set; }
-    [Reactive] public bool enableCacheFile4Sbox { get; set; }
-    [Reactive] public int hyUpMbps { get; set; }
-    [Reactive] public int hyDownMbps { get; set; }
-    [Reactive] public bool enableFragment { get; set; }
+    [Reactive] private int _localPort;
+    [Reactive] private bool _secondLocalPortEnabled;
+    [Reactive] private bool _udpEnabled;
+    [Reactive] private bool _sniffingEnabled;
+    public IList<string> DestOverride { get; set; }
+    [Reactive] private bool _routeOnly;
+    [Reactive] private bool _allowLANConn;
+    [Reactive] private bool _newPort4LAN;
+    [Reactive] private string _user;
+    [Reactive] private string _pass;
+    [Reactive] private bool _muxEnabled;
+    [Reactive] private bool _logEnabled;
+    [Reactive] private string _logLevel;
+    [Reactive] private bool _defAllowInsecure;
+    [Reactive] private string _defFingerprint;
+    [Reactive] private string _defUserAgent;
+    [Reactive] private string _mux4SboxProtocol;
+    [Reactive] private bool _enableCacheFile4Sbox;
+    [Reactive] private int _hyUpMbps;
+    [Reactive] private int _hyDownMbps;
+    [Reactive] private bool _enableFragment;
 
     #endregion Core
 
     #region Core KCP
 
-    //[Reactive] public int Kcpmtu { get; set; }
-    //[Reactive] public int Kcptti { get; set; }
-    //[Reactive] public int KcpuplinkCapacity { get; set; }
-    //[Reactive] public int KcpdownlinkCapacity { get; set; }
-    //[Reactive] public int KcpreadBufferSize { get; set; }
-    //[Reactive] public int KcpwriteBufferSize { get; set; }
-    //[Reactive] public bool Kcpcongestion { get; set; }
+    //[Reactive] private int _kcpmtu;
+    //[Reactive] private int _kcptti;
+    //[Reactive] private int _kcpuplinkCapacity;
+    //[Reactive] private int _kcpdownlinkCapacity;
+    //[Reactive] private int _kcpreadBufferSize;
+    //[Reactive] private int _kcpwriteBufferSize;
+    //[Reactive] private bool _kcpcongestion;
 
     #endregion Core KCP
 
     #region UI
 
-    [Reactive] public bool AutoRun { get; set; }
-    [Reactive] public bool EnableStatistics { get; set; }
-    [Reactive] public bool KeepOlderDedupl { get; set; }
-    [Reactive] public bool DisplayRealTimeSpeed { get; set; }
-    [Reactive] public bool EnableAutoAdjustMainLvColWidth { get; set; }
-    [Reactive] public bool EnableUpdateSubOnlyRemarksExist { get; set; }
-    [Reactive] public bool AutoHideStartup { get; set; }
-    [Reactive] public bool Hide2TrayWhenClose { get; set; }
-    [Reactive] public bool EnableDragDropSort { get; set; }
-    [Reactive] public bool DoubleClick2Activate { get; set; }
-    [Reactive] public int AutoUpdateInterval { get; set; }
-    [Reactive] public int TrayMenuServersLimit { get; set; }
-    [Reactive] public string CurrentFontFamily { get; set; }
-    [Reactive] public int SpeedTestTimeout { get; set; }
-    [Reactive] public string SpeedTestUrl { get; set; }
-    [Reactive] public string SpeedPingTestUrl { get; set; }
-    [Reactive] public int MixedConcurrencyCount { get; set; }
-    [Reactive] public bool EnableHWA { get; set; }
-    [Reactive] public string SubConvertUrl { get; set; }
-    [Reactive] public int MainGirdOrientation { get; set; }
-    [Reactive] public string GeoFileSourceUrl { get; set; }
-    [Reactive] public string SrsFileSourceUrl { get; set; }
-    [Reactive] public string RoutingRulesSourceUrl { get; set; }
-    [Reactive] public string IPAPIUrl { get; set; }
+    [Reactive] private bool _autoRun;
+    [Reactive] private bool _enableStatistics;
+    [Reactive] private bool _keepOlderDedupl;
+    [Reactive] private bool _displayRealTimeSpeed;
+    [Reactive] private bool _enableAutoAdjustMainLvColWidth;
+    [Reactive] private bool _enableUpdateSubOnlyRemarksExist;
+    [Reactive] private bool _autoHideStartup;
+    [Reactive] private bool _hide2TrayWhenClose;
+    [Reactive] private bool _enableDragDropSort;
+    [Reactive] private bool _doubleClick2Activate;
+    [Reactive] private int _autoUpdateInterval;
+    [Reactive] private int _trayMenuServersLimit;
+    [Reactive] private string _currentFontFamily;
+    [Reactive] private int _speedTestTimeout;
+    [Reactive] private string _speedTestUrl;
+    [Reactive] private string _speedPingTestUrl;
+    [Reactive] private int _mixedConcurrencyCount;
+    [Reactive] private bool _enableHWA;
+    [Reactive] private string _subConvertUrl;
+    [Reactive] private int _mainGirdOrientation;
+    [Reactive] private string _geoFileSourceUrl;
+    [Reactive] private string _srsFileSourceUrl;
+    [Reactive] private string _routingRulesSourceUrl;
+    [Reactive] private string _ipAPIUrl;
 
     #endregion UI
 
     #region System proxy
 
-    [Reactive] public bool notProxyLocalAddress { get; set; }
-    [Reactive] public string systemProxyAdvancedProtocol { get; set; }
-    [Reactive] public string systemProxyExceptions { get; set; }
+    [Reactive] private bool _notProxyLocalAddress;
+    [Reactive] private string _systemProxyAdvancedProtocol;
+    [Reactive] private string _systemProxyExceptions;
 
     #endregion System proxy
 
     #region Tun mode
 
-    [Reactive] public bool TunAutoRoute { get; set; }
-    [Reactive] public bool TunStrictRoute { get; set; }
-    [Reactive] public string TunStack { get; set; }
-    [Reactive] public int TunMtu { get; set; }
-    [Reactive] public bool TunEnableExInbound { get; set; }
-    [Reactive] public bool TunEnableIPv6Address { get; set; }
+    [Reactive] private bool _tunAutoRoute;
+    [Reactive] private bool _tunStrictRoute;
+    [Reactive] private string _tunStack;
+    [Reactive] private int _tunMtu;
+    [Reactive] private bool _tunEnableExInbound;
+    [Reactive] private bool _tunEnableIPv6Address;
 
     #endregion Tun mode
 
     #region CoreType
 
-    [Reactive] public string CoreType1 { get; set; }
-    [Reactive] public string CoreType2 { get; set; }
-    [Reactive] public string CoreType3 { get; set; }
-    [Reactive] public string CoreType4 { get; set; }
-    [Reactive] public string CoreType5 { get; set; }
-    [Reactive] public string CoreType6 { get; set; }
-    [Reactive] public string CoreType9 { get; set; }
+    [Reactive] private string _coreType1;
+    [Reactive] private string _coreType2;
+    [Reactive] private string _coreType3;
+    [Reactive] private string _coreType4;
+    [Reactive] private string _coreType5;
+    [Reactive] private string _coreType6;
+    [Reactive] private string _coreType9;
 
     #endregion CoreType
 
@@ -122,26 +122,26 @@ public class OptionSettingViewModel : MyReactiveObject
         #region Core
 
         var inbound = _config.Inbound.First();
-        localPort = inbound.LocalPort;
+        LocalPort = inbound.LocalPort;
         SecondLocalPortEnabled = inbound.SecondLocalPortEnabled;
-        udpEnabled = inbound.UdpEnabled;
-        sniffingEnabled = inbound.SniffingEnabled;
-        routeOnly = inbound.RouteOnly;
-        allowLANConn = inbound.AllowLANConn;
-        newPort4LAN = inbound.NewPort4LAN;
-        user = inbound.User;
-        pass = inbound.Pass;
-        muxEnabled = _config.CoreBasicItem.MuxEnabled;
-        logEnabled = _config.CoreBasicItem.LogEnabled;
-        loglevel = _config.CoreBasicItem.Loglevel;
-        defAllowInsecure = _config.CoreBasicItem.DefAllowInsecure;
-        defFingerprint = _config.CoreBasicItem.DefFingerprint;
-        defUserAgent = _config.CoreBasicItem.DefUserAgent;
-        mux4SboxProtocol = _config.Mux4SboxItem.Protocol;
-        enableCacheFile4Sbox = _config.CoreBasicItem.EnableCacheFile4Sbox;
-        hyUpMbps = _config.HysteriaItem.UpMbps;
-        hyDownMbps = _config.HysteriaItem.DownMbps;
-        enableFragment = _config.CoreBasicItem.EnableFragment;
+        UdpEnabled = inbound.UdpEnabled;
+        SniffingEnabled = inbound.SniffingEnabled;
+        RouteOnly = inbound.RouteOnly;
+        AllowLANConn = inbound.AllowLANConn;
+        NewPort4LAN = inbound.NewPort4LAN;
+        User = inbound.User;
+        Pass = inbound.Pass;
+        MuxEnabled = _config.CoreBasicItem.MuxEnabled;
+        LogEnabled = _config.CoreBasicItem.LogEnabled;
+        LogLevel = _config.CoreBasicItem.Loglevel;
+        DefAllowInsecure = _config.CoreBasicItem.DefAllowInsecure;
+        DefFingerprint = _config.CoreBasicItem.DefFingerprint;
+        DefUserAgent = _config.CoreBasicItem.DefUserAgent;
+        Mux4SboxProtocol = _config.Mux4SboxItem.Protocol;
+        EnableCacheFile4Sbox = _config.CoreBasicItem.EnableCacheFile4Sbox;
+        HyUpMbps = _config.HysteriaItem.UpMbps;
+        HyDownMbps = _config.HysteriaItem.DownMbps;
+        EnableFragment = _config.CoreBasicItem.EnableFragment;
 
         #endregion Core
 
@@ -182,15 +182,15 @@ public class OptionSettingViewModel : MyReactiveObject
         GeoFileSourceUrl = _config.ConstItem.GeoSourceUrl;
         SrsFileSourceUrl = _config.ConstItem.SrsSourceUrl;
         RoutingRulesSourceUrl = _config.ConstItem.RouteRulesTemplateSourceUrl;
-        IPAPIUrl = _config.SpeedTestItem.IPAPIUrl;
+        IpAPIUrl = _config.SpeedTestItem.IPAPIUrl;
 
         #endregion UI
 
         #region System proxy
 
-        notProxyLocalAddress = _config.SystemProxyItem.NotProxyLocalAddress;
-        systemProxyAdvancedProtocol = _config.SystemProxyItem.SystemProxyAdvancedProtocol;
-        systemProxyExceptions = _config.SystemProxyItem.SystemProxyExceptions;
+        NotProxyLocalAddress = _config.SystemProxyItem.NotProxyLocalAddress;
+        SystemProxyAdvancedProtocol = _config.SystemProxyItem.SystemProxyAdvancedProtocol;
+        SystemProxyExceptions = _config.SystemProxyItem.SystemProxyExceptions;
 
         #endregion System proxy
 
@@ -267,8 +267,8 @@ public class OptionSettingViewModel : MyReactiveObject
 
     private async Task SaveSettingAsync()
     {
-        if (localPort.ToString().IsNullOrEmpty() || !Utils.IsNumeric(localPort.ToString())
-           || localPort <= 0 || localPort >= Global.MaxPort)
+        if (LocalPort.ToString().IsNullOrEmpty() || !Utils.IsNumeric(LocalPort.ToString())
+           || LocalPort <= 0 || LocalPort >= Global.MaxPort)
         {
             NoticeManager.Instance.Enqueue(ResUI.FillLocalListeningPort);
             return;
@@ -292,31 +292,31 @@ public class OptionSettingViewModel : MyReactiveObject
         //}
 
         //Core
-        _config.Inbound.First().LocalPort = localPort;
+        _config.Inbound.First().LocalPort = LocalPort;
         _config.Inbound.First().SecondLocalPortEnabled = SecondLocalPortEnabled;
-        _config.Inbound.First().UdpEnabled = udpEnabled;
-        _config.Inbound.First().SniffingEnabled = sniffingEnabled;
-        _config.Inbound.First().DestOverride = destOverride?.ToList();
-        _config.Inbound.First().RouteOnly = routeOnly;
-        _config.Inbound.First().AllowLANConn = allowLANConn;
-        _config.Inbound.First().NewPort4LAN = newPort4LAN;
-        _config.Inbound.First().User = user;
-        _config.Inbound.First().Pass = pass;
+        _config.Inbound.First().UdpEnabled = UdpEnabled;
+        _config.Inbound.First().SniffingEnabled = SniffingEnabled;
+        _config.Inbound.First().DestOverride = DestOverride?.ToList();
+        _config.Inbound.First().RouteOnly = RouteOnly;
+        _config.Inbound.First().AllowLANConn = AllowLANConn;
+        _config.Inbound.First().NewPort4LAN = NewPort4LAN;
+        _config.Inbound.First().User = User;
+        _config.Inbound.First().Pass = Pass;
         if (_config.Inbound.Count > 1)
         {
             _config.Inbound.RemoveAt(1);
         }
-        _config.CoreBasicItem.LogEnabled = logEnabled;
-        _config.CoreBasicItem.Loglevel = loglevel;
-        _config.CoreBasicItem.MuxEnabled = muxEnabled;
-        _config.CoreBasicItem.DefAllowInsecure = defAllowInsecure;
-        _config.CoreBasicItem.DefFingerprint = defFingerprint;
-        _config.CoreBasicItem.DefUserAgent = defUserAgent;
-        _config.Mux4SboxItem.Protocol = mux4SboxProtocol;
-        _config.CoreBasicItem.EnableCacheFile4Sbox = enableCacheFile4Sbox;
-        _config.HysteriaItem.UpMbps = hyUpMbps;
-        _config.HysteriaItem.DownMbps = hyDownMbps;
-        _config.CoreBasicItem.EnableFragment = enableFragment;
+        _config.CoreBasicItem.LogEnabled = LogEnabled;
+        _config.CoreBasicItem.Loglevel = LogLevel;
+        _config.CoreBasicItem.MuxEnabled = MuxEnabled;
+        _config.CoreBasicItem.DefAllowInsecure = DefAllowInsecure;
+        _config.CoreBasicItem.DefFingerprint = DefFingerprint;
+        _config.CoreBasicItem.DefUserAgent = DefUserAgent;
+        _config.Mux4SboxItem.Protocol = Mux4SboxProtocol;
+        _config.CoreBasicItem.EnableCacheFile4Sbox = EnableCacheFile4Sbox;
+        _config.HysteriaItem.UpMbps = HyUpMbps;
+        _config.HysteriaItem.DownMbps = HyDownMbps;
+        _config.CoreBasicItem.EnableFragment = EnableFragment;
 
         _config.GuiItem.AutoRun = AutoRun;
         _config.GuiItem.EnableStatistics = EnableStatistics;
@@ -341,12 +341,12 @@ public class OptionSettingViewModel : MyReactiveObject
         _config.ConstItem.GeoSourceUrl = GeoFileSourceUrl;
         _config.ConstItem.SrsSourceUrl = SrsFileSourceUrl;
         _config.ConstItem.RouteRulesTemplateSourceUrl = RoutingRulesSourceUrl;
-        _config.SpeedTestItem.IPAPIUrl = IPAPIUrl;
+        _config.SpeedTestItem.IPAPIUrl = IpAPIUrl;
 
         //systemProxy
-        _config.SystemProxyItem.SystemProxyExceptions = systemProxyExceptions;
-        _config.SystemProxyItem.NotProxyLocalAddress = notProxyLocalAddress;
-        _config.SystemProxyItem.SystemProxyAdvancedProtocol = systemProxyAdvancedProtocol;
+        _config.SystemProxyItem.SystemProxyExceptions = SystemProxyExceptions;
+        _config.SystemProxyItem.NotProxyLocalAddress = NotProxyLocalAddress;
+        _config.SystemProxyItem.SystemProxyAdvancedProtocol = SystemProxyAdvancedProtocol;
 
         //tun mode
         _config.TunModeItem.AutoRoute = TunAutoRoute;

--- a/v2rayN/ServiceLib/ViewModels/ProfilesSelectViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ProfilesSelectViewModel.cs
@@ -1,10 +1,10 @@
 namespace ServiceLib.ViewModels;
 
-public class ProfilesSelectViewModel : MyReactiveObject
+public partial class ProfilesSelectViewModel : MyReactiveObject
 {
     #region private prop
 
-    private string _serverFilter = string.Empty;
+    [Reactive] private string _serverFilter = string.Empty;
     private Dictionary<string, bool> _dicHeaderSort = new();
     private string _subIndexId = string.Empty;
 
@@ -22,15 +22,12 @@ public class ProfilesSelectViewModel : MyReactiveObject
     public IObservableCollection<SubItem> SubItems { get; } = new ObservableCollectionExtended<SubItem>();
 
     [Reactive]
-    public ProfileItemModel SelectedProfile { get; set; }
+    private ProfileItemModel _selectedProfile;
 
     public IList<ProfileItemModel> SelectedProfiles { get; set; }
 
     [Reactive]
-    public SubItem SelectedSub { get; set; }
-
-    [Reactive]
-    public string ServerFilter { get; set; }
+    private SubItem _selectedSub;
 
     // Include/Exclude filter for ConfigType
     public List<EConfigType> FilterConfigTypes
@@ -39,7 +36,6 @@ public class ProfilesSelectViewModel : MyReactiveObject
         set => this.RaiseAndSetIfChanged(ref _filterConfigTypes, value);
     }
 
-    [Reactive]
     public bool FilterExclude
     {
         get => _filterExclude;

--- a/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
@@ -1,11 +1,11 @@
 namespace ServiceLib.ViewModels;
 
-public class ProfilesViewModel : MyReactiveObject
+public partial class ProfilesViewModel : MyReactiveObject
 {
     #region private prop
 
     private List<ProfileItem> _lstProfile;
-    private string _serverFilter = string.Empty;
+    [Reactive] private string _serverFilter = string.Empty;
     private Dictionary<string, bool> _dicHeaderSort = new();
     private SpeedtestService? _speedtestService;
 
@@ -18,18 +18,15 @@ public class ProfilesViewModel : MyReactiveObject
     public IObservableCollection<SubItem> SubItems { get; } = new ObservableCollectionExtended<SubItem>();
 
     [Reactive]
-    public ProfileItemModel SelectedProfile { get; set; }
+    private ProfileItemModel _selectedProfile;
 
     public IList<ProfileItemModel> SelectedProfiles { get; set; }
 
     [Reactive]
-    public SubItem SelectedSub { get; set; }
+    private SubItem _selectedSub;
 
     [Reactive]
-    public SubItem SelectedMoveToGroup { get; set; }
-
-    [Reactive]
-    public string ServerFilter { get; set; }
+    private SubItem _selectedMoveToGroup;
 
     #endregion ObservableCollection
 

--- a/v2rayN/ServiceLib/ViewModels/RoutingRuleDetailsViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/RoutingRuleDetailsViewModel.cs
@@ -1,27 +1,27 @@
 namespace ServiceLib.ViewModels;
 
-public class RoutingRuleDetailsViewModel : MyReactiveObject
+public partial class RoutingRuleDetailsViewModel : MyReactiveObject
 {
     public IList<string> ProtocolItems { get; set; }
     public IList<string> InboundTagItems { get; set; }
 
     [Reactive]
-    public RulesItem SelectedSource { get; set; }
+    private RulesItem _selectedSource;
 
     [Reactive]
-    public string Domain { get; set; }
+    private string _domain;
 
     [Reactive]
-    public string IP { get; set; }
+    private string _ip;
 
     [Reactive]
-    public string Process { get; set; }
+    private string _process;
 
     [Reactive]
-    public string? RuleType { get; set; }
+    private string? _ruleType;
 
     [Reactive]
-    public bool AutoSort { get; set; }
+    private bool _autoSort;
 
     public ReactiveCommand<Unit, Unit> SaveCmd { get; }
 
@@ -48,7 +48,7 @@ public class RoutingRuleDetailsViewModel : MyReactiveObject
         }
 
         Domain = Utils.List2String(SelectedSource.Domain, true);
-        IP = Utils.List2String(SelectedSource.Ip, true);
+        Ip = Utils.List2String(SelectedSource.Ip, true);
         Process = Utils.List2String(SelectedSource.Process, true);
         RuleType = SelectedSource.RuleType?.ToString();
     }
@@ -56,19 +56,19 @@ public class RoutingRuleDetailsViewModel : MyReactiveObject
     private async Task SaveRulesAsync()
     {
         Domain = Utils.Convert2Comma(Domain);
-        IP = Utils.Convert2Comma(IP);
+        Ip = Utils.Convert2Comma(Ip);
         Process = Utils.Convert2Comma(Process);
 
         if (AutoSort)
         {
             SelectedSource.Domain = Utils.String2ListSorted(Domain);
-            SelectedSource.Ip = Utils.String2ListSorted(IP);
+            SelectedSource.Ip = Utils.String2ListSorted(Ip);
             SelectedSource.Process = Utils.String2ListSorted(Process);
         }
         else
         {
             SelectedSource.Domain = Utils.String2List(Domain);
-            SelectedSource.Ip = Utils.String2List(IP);
+            SelectedSource.Ip = Utils.String2List(Ip);
             SelectedSource.Process = Utils.String2List(Process);
         }
         SelectedSource.Protocol = ProtocolItems?.ToList();

--- a/v2rayN/ServiceLib/ViewModels/RoutingRuleSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/RoutingRuleSettingViewModel.cs
@@ -1,16 +1,16 @@
 namespace ServiceLib.ViewModels;
 
-public class RoutingRuleSettingViewModel : MyReactiveObject
+public partial class RoutingRuleSettingViewModel : MyReactiveObject
 {
     private List<RulesItem> _rules;
 
     [Reactive]
-    public RoutingItem SelectedRouting { get; set; }
+    private RoutingItem _selectedRouting;
 
     public IObservableCollection<RulesItemModel> RulesItems { get; } = new ObservableCollectionExtended<RulesItemModel>();
 
     [Reactive]
-    public RulesItemModel SelectedSource { get; set; }
+    private RulesItemModel _selectedSource;
 
     public IList<RulesItemModel> SelectedSources { get; set; }
 

--- a/v2rayN/ServiceLib/ViewModels/RoutingSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/RoutingSettingViewModel.cs
@@ -1,21 +1,21 @@
 namespace ServiceLib.ViewModels;
 
-public class RoutingSettingViewModel : MyReactiveObject
+public partial class RoutingSettingViewModel : MyReactiveObject
 {
     #region Reactive
 
     public IObservableCollection<RoutingItemModel> RoutingItems { get; } = new ObservableCollectionExtended<RoutingItemModel>();
 
     [Reactive]
-    public RoutingItemModel SelectedSource { get; set; }
+    private RoutingItemModel _selectedSource;
 
     public IList<RoutingItemModel> SelectedSources { get; set; }
 
     [Reactive]
-    public string DomainStrategy { get; set; }
+    private string _domainStrategy;
 
     [Reactive]
-    public string DomainStrategy4Singbox { get; set; }
+    private string _domainStrategy4Singbox;
 
     public ReactiveCommand<Unit, Unit> RoutingAdvancedAddCmd { get; }
     public ReactiveCommand<Unit, Unit> RoutingAdvancedRemoveCmd { get; }

--- a/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
@@ -1,6 +1,6 @@
 namespace ServiceLib.ViewModels;
 
-public class StatusBarViewModel : MyReactiveObject
+public partial class StatusBarViewModel : MyReactiveObject
 {
     private static readonly Lazy<StatusBarViewModel> _instance = new(() => new(null));
     public static StatusBarViewModel Instance => _instance.Value;
@@ -12,13 +12,13 @@ public class StatusBarViewModel : MyReactiveObject
     public IObservableCollection<ComboItem> Servers { get; } = new ObservableCollectionExtended<ComboItem>();
 
     [Reactive]
-    public RoutingItem SelectedRouting { get; set; }
+    private RoutingItem _selectedRouting;
 
     [Reactive]
-    public ComboItem SelectedServer { get; set; }
+    private ComboItem _selectedServer;
 
     [Reactive]
-    public bool BlServers { get; set; }
+    private bool _blServers;
 
     #endregion ObservableCollection
 
@@ -34,16 +34,16 @@ public class StatusBarViewModel : MyReactiveObject
     #region System Proxy
 
     [Reactive]
-    public bool BlSystemProxyClear { get; set; }
+    private bool _blSystemProxyClear;
 
     [Reactive]
-    public bool BlSystemProxySet { get; set; }
+    private bool _blSystemProxySet;
 
     [Reactive]
-    public bool BlSystemProxyNothing { get; set; }
+    private bool _blSystemProxyNothing;
 
     [Reactive]
-    public bool BlSystemProxyPac { get; set; }
+    private bool _blSystemProxyPac;
 
     public ReactiveCommand<Unit, Unit> SystemProxyClearCmd { get; }
     public ReactiveCommand<Unit, Unit> SystemProxySetCmd { get; }
@@ -51,44 +51,44 @@ public class StatusBarViewModel : MyReactiveObject
     public ReactiveCommand<Unit, Unit> SystemProxyPacCmd { get; }
 
     [Reactive]
-    public bool BlRouting { get; set; }
+    private bool _blRouting;
 
     [Reactive]
-    public int SystemProxySelected { get; set; }
+    private int _systemProxySelected;
 
     [Reactive]
-    public bool BlSystemProxyPacVisible { get; set; }
+    private bool _blSystemProxyPacVisible;
 
     #endregion System Proxy
 
     #region UI
 
     [Reactive]
-    public string InboundDisplay { get; set; }
+    private string _inboundDisplay;
 
     [Reactive]
-    public string InboundLanDisplay { get; set; }
+    private string _inboundLanDisplay;
 
     [Reactive]
-    public string RunningServerDisplay { get; set; }
+    private string _runningServerDisplay;
 
     [Reactive]
-    public string RunningServerToolTipText { get; set; }
+    private string _runningServerToolTipText;
 
     [Reactive]
-    public string RunningInfoDisplay { get; set; }
+    private string _runningInfoDisplay;
 
     [Reactive]
-    public string SpeedProxyDisplay { get; set; }
+    private string _speedProxyDisplay;
 
     [Reactive]
-    public string SpeedDirectDisplay { get; set; }
+    private string _speedDirectDisplay;
 
     [Reactive]
-    public bool EnableTun { get; set; }
+    private bool _enableTun;
 
     [Reactive]
-    public bool BlIsNonWindows { get; set; }
+    private bool _blIsNonWindows;
 
     #endregion UI
 

--- a/v2rayN/ServiceLib/ViewModels/SubEditViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/SubEditViewModel.cs
@@ -1,9 +1,9 @@
 namespace ServiceLib.ViewModels;
 
-public class SubEditViewModel : MyReactiveObject
+public partial class SubEditViewModel : MyReactiveObject
 {
     [Reactive]
-    public SubItem SelectedSource { get; set; }
+    private SubItem _selectedSource;
 
     public ReactiveCommand<Unit, Unit> SaveCmd { get; }
 

--- a/v2rayN/ServiceLib/ViewModels/SubSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/SubSettingViewModel.cs
@@ -1,11 +1,11 @@
 namespace ServiceLib.ViewModels;
 
-public class SubSettingViewModel : MyReactiveObject
+public partial class SubSettingViewModel : MyReactiveObject
 {
     public IObservableCollection<SubItem> SubItems { get; } = new ObservableCollectionExtended<SubItem>();
 
     [Reactive]
-    public SubItem SelectedSource { get; set; }
+    private SubItem _selectedSource;
 
     public IList<SubItem> SelectedSources { get; set; }
 

--- a/v2rayN/v2rayN.Desktop/GlobalUsings.cs
+++ b/v2rayN/v2rayN.Desktop/GlobalUsings.cs
@@ -21,7 +21,7 @@ global using ReactiveUI.Avalonia;
 global using Avalonia.Styling;
 global using Avalonia.Threading;
 global using ReactiveUI;
-global using ReactiveUI.Fody.Helpers;
+global using ReactiveUI.SourceGenerators;
 global using DynamicData;
 global using MsBox.Avalonia.Enums;
 global using ServiceLib;

--- a/v2rayN/v2rayN.Desktop/ViewModels/ThemeSettingViewModel.cs
+++ b/v2rayN/v2rayN.Desktop/ViewModels/ThemeSettingViewModel.cs
@@ -5,13 +5,13 @@ using Semi.Avalonia;
 
 namespace v2rayN.Desktop.ViewModels;
 
-public class ThemeSettingViewModel : MyReactiveObject
+public partial class ThemeSettingViewModel : MyReactiveObject
 {
-    [Reactive] public string CurrentTheme { get; set; }
+    [Reactive] private string _currentTheme;
 
-    [Reactive] public int CurrentFontSize { get; set; }
+    [Reactive] private int _currentFontSize;
 
-    [Reactive] public string CurrentLanguage { get; set; }
+    [Reactive] private string _currentLanguage;
 
     public ThemeSettingViewModel()
     {

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
@@ -53,28 +53,28 @@ public partial class OptionSettingWindow : WindowBase<OptionSettingViewModel>
 
         this.WhenActivated(disposables =>
         {
-            this.Bind(ViewModel, vm => vm.localPort, v => v.txtlocalPort.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.LocalPort, v => v.txtlocalPort.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SecondLocalPortEnabled, v => v.togSecondLocalPortEnabled.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.udpEnabled, v => v.togudpEnabled.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.sniffingEnabled, v => v.togsniffingEnabled.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.routeOnly, v => v.togrouteOnly.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.allowLANConn, v => v.togAllowLANConn.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.newPort4LAN, v => v.togNewPort4LAN.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.newPort4LAN, v => v.txtuser.IsEnabled).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.newPort4LAN, v => v.txtpass.IsEnabled).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.user, v => v.txtuser.Text).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.pass, v => v.txtpass.Text).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.muxEnabled, v => v.togmuxEnabled.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.logEnabled, v => v.toglogEnabled.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.loglevel, v => v.cmbloglevel.SelectedValue).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.defAllowInsecure, v => v.togdefAllowInsecure.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.defFingerprint, v => v.cmbdefFingerprint.SelectedValue).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.defUserAgent, v => v.cmbdefUserAgent.SelectedValue).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.mux4SboxProtocol, v => v.cmbmux4SboxProtocol.SelectedValue).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.enableCacheFile4Sbox, v => v.togenableCacheFile4Sbox.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.hyUpMbps, v => v.txtUpMbps.Text).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.hyDownMbps, v => v.txtDownMbps.Text).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.enableFragment, v => v.togenableFragment.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.UdpEnabled, v => v.togudpEnabled.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SniffingEnabled, v => v.togsniffingEnabled.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.RouteOnly, v => v.togrouteOnly.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.AllowLANConn, v => v.togAllowLANConn.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.NewPort4LAN, v => v.togNewPort4LAN.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.NewPort4LAN, v => v.txtuser.IsEnabled).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.NewPort4LAN, v => v.txtpass.IsEnabled).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.User, v => v.txtuser.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.Pass, v => v.txtpass.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.MuxEnabled, v => v.togmuxEnabled.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.LogEnabled, v => v.toglogEnabled.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.LogLevel, v => v.cmbloglevel.SelectedValue).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.DefAllowInsecure, v => v.togdefAllowInsecure.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.DefFingerprint, v => v.cmbdefFingerprint.SelectedValue).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.DefUserAgent, v => v.cmbdefUserAgent.SelectedValue).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.Mux4SboxProtocol, v => v.cmbmux4SboxProtocol.SelectedValue).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.EnableCacheFile4Sbox, v => v.togenableCacheFile4Sbox.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.HyUpMbps, v => v.txtUpMbps.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.HyDownMbps, v => v.txtDownMbps.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.EnableFragment, v => v.togenableFragment.IsChecked).DisposeWith(disposables);
 
             this.Bind(ViewModel, vm => vm.AutoRun, v => v.togAutoRun.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.EnableStatistics, v => v.togEnableStatistics.IsChecked).DisposeWith(disposables);
@@ -96,11 +96,11 @@ public partial class OptionSettingWindow : WindowBase<OptionSettingViewModel>
             this.Bind(ViewModel, vm => vm.GeoFileSourceUrl, v => v.cmbGetFilesSourceUrl.SelectedValue).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SrsFileSourceUrl, v => v.cmbSrsFilesSourceUrl.SelectedValue).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.RoutingRulesSourceUrl, v => v.cmbRoutingRulesSourceUrl.SelectedValue).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.IPAPIUrl, v => v.cmbIPAPIUrl.SelectedValue).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.IpAPIUrl, v => v.cmbIPAPIUrl.SelectedValue).DisposeWith(disposables);
 
-            this.Bind(ViewModel, vm => vm.notProxyLocalAddress, v => v.tognotProxyLocalAddress.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.systemProxyAdvancedProtocol, v => v.cmbsystemProxyAdvancedProtocol.SelectedValue).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.systemProxyExceptions, v => v.txtsystemProxyExceptions.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.NotProxyLocalAddress, v => v.tognotProxyLocalAddress.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SystemProxyAdvancedProtocol, v => v.cmbsystemProxyAdvancedProtocol.SelectedValue).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SystemProxyExceptions, v => v.txtsystemProxyExceptions.Text).DisposeWith(disposables);
 
             this.Bind(ViewModel, vm => vm.TunAutoRoute, v => v.togAutoRoute.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.TunStrictRoute, v => v.togStrictRoute.IsChecked).DisposeWith(disposables);
@@ -208,7 +208,7 @@ public partial class OptionSettingWindow : WindowBase<OptionSettingViewModel>
     {
         if (ViewModel != null)
         {
-            ViewModel.destOverride = clbdestOverride.SelectedItems.Cast<string>().ToList();
+            ViewModel.DestOverride = clbdestOverride.SelectedItems.Cast<string>().ToList();
         }
     }
 

--- a/v2rayN/v2rayN.Desktop/Views/RoutingRuleDetailsWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/RoutingRuleDetailsWindow.axaml.cs
@@ -47,7 +47,7 @@ public partial class RoutingRuleDetailsWindow : WindowBase<RoutingRuleDetailsVie
             this.Bind(ViewModel, vm => vm.SelectedSource.Network, v => v.cmbNetwork.SelectedValue).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Enabled, v => v.togEnabled.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.Domain, v => v.txtDomain.Text).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.IP, v => v.txtIP.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.Ip, v => v.txtIP.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.Process, v => v.txtProcess.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.AutoSort, v => v.chkAutoSort.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.RuleType, v => v.cmbRuleType.SelectedValue).DisposeWith(disposables);

--- a/v2rayN/v2rayN.Desktop/v2rayN.Desktop.csproj
+++ b/v2rayN/v2rayN.Desktop/v2rayN.Desktop.csproj
@@ -25,7 +25,7 @@
 		<PackageReference Include="ReactiveUI">
 			<TreatAsUsed>true</TreatAsUsed>
 		</PackageReference>
-		<PackageReference Include="ReactiveUI.Fody">
+		<PackageReference Include="ReactiveUI.SourceGenerators">
 			<TreatAsUsed>true</TreatAsUsed>
 		</PackageReference>
 	</ItemGroup>

--- a/v2rayN/v2rayN/GlobalUsings.cs
+++ b/v2rayN/v2rayN/GlobalUsings.cs
@@ -20,7 +20,7 @@ global using System.Windows.Threading;
 global using DynamicData;
 global using DynamicData.Binding;
 global using ReactiveUI;
-global using ReactiveUI.Fody.Helpers;
+global using ReactiveUI.SourceGenerators;
 global using ServiceLib;
 global using ServiceLib.Base;
 global using ServiceLib.Common;

--- a/v2rayN/v2rayN/ViewModels/ThemeSettingViewModel.cs
+++ b/v2rayN/v2rayN/ViewModels/ThemeSettingViewModel.cs
@@ -4,21 +4,20 @@ using MaterialDesignThemes.Wpf;
 
 namespace v2rayN.ViewModels;
 
-public class ThemeSettingViewModel : MyReactiveObject
+public partial class ThemeSettingViewModel : MyReactiveObject
 {
     private readonly PaletteHelper _paletteHelper = new();
 
-    private IObservableCollection<Swatch> _swatches = new ObservableCollectionExtended<Swatch>();
-    public IObservableCollection<Swatch> Swatches => _swatches;
+    public IObservableCollection<Swatch> Swatches { get; } = new ObservableCollectionExtended<Swatch>();
 
     [Reactive]
-    public Swatch SelectedSwatch { get; set; }
+    private Swatch _selectedSwatch;
 
-    [Reactive] public string CurrentTheme { get; set; }
+    [Reactive] private string _currentTheme;
 
-    [Reactive] public int CurrentFontSize { get; set; }
+    [Reactive] private int _currentFontSize;
 
-    [Reactive] public string CurrentLanguage { get; set; }
+    [Reactive] private string _currentLanguage;
 
     public ThemeSettingViewModel()
     {
@@ -48,10 +47,10 @@ public class ThemeSettingViewModel : MyReactiveObject
 
     private void BindingUI()
     {
-        _swatches.AddRange(new SwatchesProvider().Swatches);
+        Swatches.AddRange(new SwatchesProvider().Swatches);
         if (!_config.UiItem.ColorPrimaryName.IsNullOrEmpty())
         {
-            SelectedSwatch = _swatches.FirstOrDefault(t => t.Name == _config.UiItem.ColorPrimaryName);
+            SelectedSwatch = Swatches.FirstOrDefault(t => t.Name == _config.UiItem.ColorPrimaryName);
         }
         CurrentTheme = _config.UiItem.CurrentTheme;
         CurrentFontSize = _config.UiItem.CurrentFontSize;

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
@@ -52,28 +52,28 @@ public partial class OptionSettingWindow
 
         this.WhenActivated(disposables =>
         {
-            this.Bind(ViewModel, vm => vm.localPort, v => v.txtlocalPort.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.LocalPort, v => v.txtlocalPort.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SecondLocalPortEnabled, v => v.togSecondLocalPortEnabled.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.udpEnabled, v => v.togudpEnabled.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.sniffingEnabled, v => v.togsniffingEnabled.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.routeOnly, v => v.togrouteOnly.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.allowLANConn, v => v.togAllowLANConn.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.newPort4LAN, v => v.togNewPort4LAN.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.newPort4LAN, v => v.txtuser.IsEnabled).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.newPort4LAN, v => v.txtpass.IsEnabled).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.user, v => v.txtuser.Text).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.pass, v => v.txtpass.Text).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.muxEnabled, v => v.togmuxEnabled.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.logEnabled, v => v.toglogEnabled.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.loglevel, v => v.cmbloglevel.Text).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.defAllowInsecure, v => v.togdefAllowInsecure.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.defFingerprint, v => v.cmbdefFingerprint.Text).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.defUserAgent, v => v.cmbdefUserAgent.Text).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.mux4SboxProtocol, v => v.cmbmux4SboxProtocol.Text).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.enableCacheFile4Sbox, v => v.togenableCacheFile4Sbox.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.hyUpMbps, v => v.txtUpMbps.Text).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.hyDownMbps, v => v.txtDownMbps.Text).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.enableFragment, v => v.togenableFragment.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.UdpEnabled, v => v.togudpEnabled.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SniffingEnabled, v => v.togsniffingEnabled.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.RouteOnly, v => v.togrouteOnly.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.AllowLANConn, v => v.togAllowLANConn.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.NewPort4LAN, v => v.togNewPort4LAN.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.NewPort4LAN, v => v.txtuser.IsEnabled).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.NewPort4LAN, v => v.txtpass.IsEnabled).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.User, v => v.txtuser.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.Pass, v => v.txtpass.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.MuxEnabled, v => v.togmuxEnabled.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.LogEnabled, v => v.toglogEnabled.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.LogLevel, v => v.cmbloglevel.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.DefAllowInsecure, v => v.togdefAllowInsecure.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.DefFingerprint, v => v.cmbdefFingerprint.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.DefUserAgent, v => v.cmbdefUserAgent.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.Mux4SboxProtocol, v => v.cmbmux4SboxProtocol.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.EnableCacheFile4Sbox, v => v.togenableCacheFile4Sbox.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.HyUpMbps, v => v.txtUpMbps.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.HyDownMbps, v => v.txtDownMbps.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.EnableFragment, v => v.togenableFragment.IsChecked).DisposeWith(disposables);
 
             //this.Bind(ViewModel, vm => vm.Kcpmtu, v => v.txtKcpmtu.Text).DisposeWith(disposables);
             //this.Bind(ViewModel, vm => vm.Kcptti, v => v.txtKcptti.Text).DisposeWith(disposables);
@@ -105,11 +105,11 @@ public partial class OptionSettingWindow
             this.Bind(ViewModel, vm => vm.GeoFileSourceUrl, v => v.cmbGetFilesSourceUrl.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SrsFileSourceUrl, v => v.cmbSrsFilesSourceUrl.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.RoutingRulesSourceUrl, v => v.cmbRoutingRulesSourceUrl.Text).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.IPAPIUrl, v => v.cmbIPAPIUrl.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.IpAPIUrl, v => v.cmbIPAPIUrl.Text).DisposeWith(disposables);
 
-            this.Bind(ViewModel, vm => vm.notProxyLocalAddress, v => v.tognotProxyLocalAddress.IsChecked).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.systemProxyAdvancedProtocol, v => v.cmbsystemProxyAdvancedProtocol.Text).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.systemProxyExceptions, v => v.txtsystemProxyExceptions.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.NotProxyLocalAddress, v => v.tognotProxyLocalAddress.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SystemProxyAdvancedProtocol, v => v.cmbsystemProxyAdvancedProtocol.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SystemProxyExceptions, v => v.txtsystemProxyExceptions.Text).DisposeWith(disposables);
 
             this.Bind(ViewModel, vm => vm.TunAutoRoute, v => v.togAutoRoute.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.TunStrictRoute, v => v.togStrictRoute.IsChecked).DisposeWith(disposables);
@@ -207,7 +207,7 @@ public partial class OptionSettingWindow
     {
         if (ViewModel != null)
         {
-            ViewModel.destOverride = clbdestOverride.SelectedItems.Cast<string>().ToList();
+            ViewModel.DestOverride = clbdestOverride.SelectedItems.Cast<string>().ToList();
         }
     }
 }

--- a/v2rayN/v2rayN/Views/RoutingRuleDetailsWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/RoutingRuleDetailsWindow.xaml.cs
@@ -39,7 +39,7 @@ public partial class RoutingRuleDetailsWindow
             this.Bind(ViewModel, vm => vm.SelectedSource.Network, v => v.cmbNetwork.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Enabled, v => v.togEnabled.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.Domain, v => v.txtDomain.Text).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.IP, v => v.txtIP.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.Ip, v => v.txtIP.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.Process, v => v.txtProcess.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.AutoSort, v => v.chkAutoSort.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.RuleType, v => v.cmbRuleType.Text).DisposeWith(disposables);

--- a/v2rayN/v2rayN/v2rayN.csproj
+++ b/v2rayN/v2rayN/v2rayN.csproj
@@ -13,7 +13,7 @@
 	<ItemGroup>
 		<PackageReference Include="MaterialDesignThemes" />
 		<PackageReference Include="H.NotifyIcon.Wpf" />
-		<PackageReference Include="ReactiveUI.Fody">
+		<PackageReference Include="ReactiveUI.SourceGenerators">
 			<TreatAsUsed>true</TreatAsUsed>
 		</PackageReference>
 		<PackageReference Include="ReactiveUI.WPF" />


### PR DESCRIPTION
测了下没什么问题

等几个月 C# 14 发布了能直接从原来的 `[Reactive] public string? Remarks { get; set; }` 迁移为 `[Reactive] public partial string? Remarks { get; set; }`，更方便一点，但是是可选的语法糖，不用也行