### PR TITLE
Fix TUN mode cleanup on Linux/macOS

### DIFF
--- a/v2rayN/ServiceLib/Manager/CoreAdminManager.cs
+++ b/v2rayN/ServiceLib/Manager/CoreAdminManager.cs
@@ -34,7 +34,7 @@ public class CoreAdminManager
         StringBuilder sb = new();
         sb.AppendLine("#!/bin/bash");
         var cmdLine = $"{fileName.AppendQuotes()} {string.Format(coreInfo.Arguments, Utils.GetBinConfigPath(configPath).AppendQuotes())}";
-        sb.AppendLine($"sudo -S {cmdLine}");
+        sb.AppendLine($"exec sudo -S -- {cmdLine}");
         var shFilePath = await FileManager.CreateLinuxShellFile("run_as_sudo.sh", sb.ToString(), true);
 
         var procService = new ProcessService(

--- a/v2rayN/ServiceLib/Sample/kill_as_sudo_linux_sh
+++ b/v2rayN/ServiceLib/Sample/kill_as_sudo_linux_sh
@@ -28,15 +28,15 @@ fi
 kill_children() {
     local parent=$1
     local children=$(ps -o pid --no-headers --ppid "$parent")
-    
+
     # Output information about processes being terminated
     echo "Processing children of PID: $parent..."
-    
+
     # Process each child
     for child in $children; do
         # Recursively find and kill child's children first
         kill_children "$child"
-        
+
         # Force kill the child process
         echo "Terminating child process: $child"
         kill -9 "$child" 2>/dev/null || true
@@ -46,6 +46,18 @@ kill_children() {
 echo "============================================"
 echo "Starting termination of process $PID and all its children"
 echo "============================================"
+
+# Try graceful termination first
+echo "Attempting graceful termination (SIGTERM) of PID: $PID"
+kill -15 "$PID" 2>/dev/null || true
+sleep 2
+# If still running, fall back to kill_children
+if ps -p $PID > /dev/null; then
+    echo "Process $PID did not exit after SIGTERM; proceeding with forced termination of its children and itself"
+else
+    echo "Process $PID exited cleanly after SIGTERM"
+    exit 0
+fi
 
 # Find and kill all child processes
 kill_children "$PID"

--- a/v2rayN/ServiceLib/Sample/kill_as_sudo_osx_sh
+++ b/v2rayN/ServiceLib/Sample/kill_as_sudo_osx_sh
@@ -42,6 +42,20 @@ echo "============================================"
 echo "Starting termination of process $PID and all its descendants"
 echo "============================================"
 
+# Try graceful termination first
+echo "Attempting graceful termination (SIGTERM) of PID: $PID"
+kill -15 "$PID" 2>/dev/null || true
+sleep 2
+
+# If still running, fall back to kill_descendants
+# Use the macOS-native 'kill -0' check
+if kill -0 $PID 2>/dev/null; then
+    echo "Process $PID did not exit after SIGTERM; proceeding with forced termination of its descendants and itself"
+else
+    echo "Process $PID exited cleanly after SIGTERM"
+    exit 0
+fi
+
 # Find and kill all descendant processes
 kill_descendants "$PID"
 


### PR DESCRIPTION
Hi, I found a bug that causes network rules (like ip rule) to remain on Linux/macOS after TUN mode is disabled. This is caused by a double bug in the process management logic.

This PR fixes it with two key changes:

    CoreAdminManager.cs:

        The RunProcessAsLinuxSudo function now uses exec sudo -S -- {cmdLine}.

        Why: The original code (sudo -S) caused the GUI to save the PID of the bash script, not the sudo or sing-box process. Using exec replaces the shell process, so the saved PID is now the sudo process's PID. The -- is added for safety to separate sudo arguments from the command.

    kill_as_sudo_linux_sh& kill_as_sudo_osx_sh Templates:

        The scripts are modified to first attempt a graceful shutdown using kill -15 (SIGTERM).

        Why: The original scripts used kill -9 (SIGKILL) immediately. This prevented the sing-box core (which correctly handles SIGTERM/SIGINT) from running its cleanup routines.

        Now, the script sends SIGTERM, which sudo (thanks to Fix #1) correctly forwards to the sing-box core. sing-box then cleans up its own network rules. The script waits 2 seconds and only uses kill -9 as a fallback if the process is still running.

These two fixes work together to ensure a clean exit and proper network rule cleanup on Linux and macOS.