### PR TITLE
Proxy all Google domains

### DIFF
--- a/package-rhel.sh
+++ b/package-rhel.sh
@@ -458,7 +458,7 @@ download_geo_assets() {
       "https://raw.githubusercontent.com/2dust/sing-box-rules/rule-set-geoip/$f" || true
   done
   for f in \
-    geosite-cn.srs geosite-gfw.srs geosite-greatfire.srs \
+    geosite-cn.srs geosite-gfw.srs geosite-google.srs geosite-greatfire.srs \
     geosite-geolocation-cn.srs geosite-category-ads-all.srs geosite-private.srs; do
     curl -fsSL -o "$srss_dir/$f" \
       "https://raw.githubusercontent.com/2dust/sing-box-rules/rule-set-geosite/$f" || true

--- a/v2rayN/ServiceLib/Sample/custom_routing_black
+++ b/v2rayN/ServiceLib/Sample/custom_routing_black
@@ -14,18 +14,17 @@
     ]
   },
   {
-    "remarks": "Google cn",
-    "outboundTag": "proxy",
-    "domain": [
-      "domain:googleapis.cn",
-      "domain:gstatic.com"
-    ]
-  },
-  {
     "remarks": "阻断udp443",
     "outboundTag": "block",
     "port": "443",
     "network": "udp"
+  },
+  {
+    "remarks": "代理Google",
+    "outboundTag": "proxy",
+    "domain": [
+      "geosite:google"
+    ]
   },
   {
     "remarks": "绕过局域网IP",

--- a/v2rayN/ServiceLib/Sample/custom_routing_white
+++ b/v2rayN/ServiceLib/Sample/custom_routing_white
@@ -1,17 +1,16 @@
 [
   {
-    "remarks": "Google cn",
-    "outboundTag": "proxy",
-    "domain": [
-      "domain:googleapis.cn",
-      "domain:gstatic.com"
-    ]
-  },
-  {
     "remarks": "阻断udp443",
     "outboundTag": "block",
     "port": "443",
     "network": "udp"
+  },
+  {
+    "remarks": "代理Google",
+    "outboundTag": "proxy",
+    "domain": [
+      "geosite:google"
+    ]
   },
   {
     "remarks": "绕过局域网IP",

--- a/v2rayN/ServiceLib/Sample/dns_singbox_normal
+++ b/v2rayN/ServiceLib/Sample/dns_singbox_normal
@@ -14,9 +14,8 @@
   ],
   "rules": [
     {
-      "domain_suffix": [
-        "googleapis.cn",
-        "gstatic.com"
+      "rule_set": [
+        "geosite-google"
       ],
       "server": "remote",
       "strategy": "prefer_ipv4"

--- a/v2rayN/ServiceLib/Sample/dns_v2ray_normal
+++ b/v2rayN/ServiceLib/Sample/dns_v2ray_normal
@@ -8,8 +8,7 @@
       "address": "1.1.1.1",
       "skipFallback": true,
       "domains": [
-        "domain:googleapis.cn",
-        "domain:gstatic.com"
+        "geosite:google"
       ]
     },
     {

--- a/v2rayN/ServiceLib/Sample/tun_singbox_dns
+++ b/v2rayN/ServiceLib/Sample/tun_singbox_dns
@@ -14,9 +14,8 @@
   ],
   "rules": [
     {
-      "domain_suffix": [
-        "googleapis.cn",
-        "gstatic.com"
+      "rule_set": [
+        "geosite:google"
       ],
       "server": "remote",
       "strategy": "prefer_ipv4"

--- a/v2rayN/ServiceLib/Sample/tun_singbox_dns
+++ b/v2rayN/ServiceLib/Sample/tun_singbox_dns
@@ -15,7 +15,7 @@
   "rules": [
     {
       "rule_set": [
-        "geosite:google"
+        "geosite-google"
       ],
       "server": "remote",
       "strategy": "prefer_ipv4"

--- a/v2rayN/ServiceLib/Services/UpdateService.cs
+++ b/v2rayN/ServiceLib/Services/UpdateService.cs
@@ -396,6 +396,7 @@ public class UpdateService(Config config, Func<bool, string, Task> updateFunc)
         }
 
         //append dns items TODO
+        geoSiteFiles.Add("google");
         geoSiteFiles.Add("cn");
         geoSiteFiles.Add("geolocation-cn");
         geoSiteFiles.Add("category-ads-all");


### PR DESCRIPTION
v2rayN 默认使用来自 [Loyalsoldier](https://github.com/Loyalsoldier/v2ray-rules-dat) 的 `geosite.dat` 与来自 [SagerNet](https://github.com/SagerNet/sing-geosite) 的 `geosite-cn.srs`。与上游 [V2Fly](https://github.com/v2fly/domain-list-community) 不同，二者的 geosite-cn 都包含了 `google@cn`，这导致默认配置下的 v2rayN 将 `google@cn` 配置为了直连

此提交将所有 Google 域名配置为代理，以解决部分用户的困扰（也可能导致部分用户的不满）

关联 https://github.com/2dust/v2rayN/discussions/8261 https://github.com/v2fly/domain-list-community/issues/2923
