### PR TITLE
Update package-osx.sh

### DIFF
--- a/package-osx.sh
+++ b/package-osx.sh
@@ -43,6 +43,8 @@ cat >"$PackagePath/v2rayN.app/Contents/Info.plist" <<-EOF
   <true/>
   <key>NSHighResolutionCapable</key>
   <true/>
+  <key>LSMinimumSystemVersion</key>
+  <string>12.7</string>
 </dict>
 </plist>
 EOF


### PR DESCRIPTION
有许多人总是认为v2rayN与自己macOS老旧版本兼容就考验维护者的心智
直接提高macOS要求到受支持的版本，不支持的版本会被阻止。
https://github.com/2dust/v2rayN/issues/8189
https://github.com/2dust/v2rayN/issues/8300
https://github.com/2dust/v2rayN/issues/8305

<img width="693" height="418" alt="截屏2025-11-11 14 00 38" src="https://github.com/user-attachments/assets/efd778f4-bd94-48c5-9aee-ee7fdd7821da" />