### PR TITLE
Simplify sing-box rules for domain_suffix

### DIFF
--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
@@ -316,10 +316,8 @@ public partial class CoreConfigSingboxService
         }
         else if (domain.StartsWith("domain:"))
         {
-            rule.domain ??= [];
             rule.domain_suffix ??= [];
-            rule.domain?.Add(domain.Substring(7));
-            rule.domain_suffix?.Add("." + domain.Substring(7));
+            rule.domain_suffix?.Add(domain.Substring(7));
         }
         else if (domain.StartsWith("full:"))
         {


### PR DESCRIPTION
adapt to new domain_suffix behavior since sing-box 1.9.0

before:

```json
{
	"domain": [
		"example.com"
	],
	"domain_suffix": [
		".example.com"
	]
}
```

after:

```json
{
	"domain_suffix": [
		"example.com"
	]
}
```