### PR TITLE
Optimize speedtest

### DIFF
--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -2356,6 +2356,15 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Press ESC to terminate the test 的本地化字符串。
+        /// </summary>
+        public static string SpeedtestingPressEscToExit {
+            get {
+                return ResourceManager.GetString("SpeedtestingPressEscToExit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Skip test 的本地化字符串。
         /// </summary>
         public static string SpeedtestingSkip {
@@ -2383,7 +2392,7 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
-        ///   查找类似 Waiting for testing (press ESC to terminate)... 的本地化字符串。
+        ///   查找类似 Waiting... 的本地化字符串。
         /// </summary>
         public static string SpeedtestingWait {
             get {

--- a/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
@@ -976,7 +976,10 @@
     <value>فعال‌ سازی شتاب‌ دهنده سخت‌ افزاری (نیاز به راه‌اندازی مجدد)</value>
   </data>
   <data name="SpeedtestingWait" xml:space="preserve">
-    <value>در انتظار آزمایش (برای پایان دادن به ESC فشار دهید)...</value>
+    <value>در انتظار آزمایش...</value>
+  </data>
+  <data name="SpeedtestingPressEscToExit" xml:space="preserve">
+    <value>برای پایان دادن به ESC فشار دهید</value>
   </data>
   <data name="TipDisplayLog" xml:space="preserve">
     <value>لطفاً در صورت قطع غیرعادی آن را خاموش کنید</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.fr.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fr.resx
@@ -976,7 +976,10 @@
     <value>Activer l’accélération matérielle (redémarrage requis)</value>
   </data>
   <data name="SpeedtestingWait" xml:space="preserve">
-    <value>En attente du test (appuyer sur Échap pour arrêter)...</value>
+    <value>En attente du test...</value>
+  </data>
+  <data name="SpeedtestingPressEscToExit" xml:space="preserve">
+    <value>Appuyer sur Échap pour arrêter</value>
   </data>
   <data name="TipDisplayLog" xml:space="preserve">
     <value>Désactiver cette option si coupure anormale</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.hu.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.hu.resx
@@ -976,7 +976,10 @@
     <value>Hardveres gyorsítás engedélyezése (újraindítást igényel)</value>
   </data>
   <data name="SpeedtestingWait" xml:space="preserve">
-    <value>Tesztelésre vár (ESC megnyomásával megszakítható)...</value>
+    <value>Tesztelésre vár...</value>
+  </data>
+  <data name="SpeedtestingPressEscToExit" xml:space="preserve">
+    <value>ESC megnyomásával megszakítható</value>
   </data>
   <data name="TipDisplayLog" xml:space="preserve">
     <value>Kérjük, kapcsolja ki rendellenes megszakadás esetén</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -976,7 +976,10 @@
     <value>Enable hardware acceleration (requires restart)</value>
   </data>
   <data name="SpeedtestingWait" xml:space="preserve">
-    <value>Waiting for testing (press ESC to terminate)...</value>
+    <value>Waiting...</value>
+  </data>
+  <data name="SpeedtestingPressEscToExit" xml:space="preserve">
+    <value>Press ESC to terminate the test</value>
   </data>
   <data name="TipDisplayLog" xml:space="preserve">
     <value>Please turn off when there is an abnormal disconnection</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -976,7 +976,10 @@
     <value>Включить аппаратное ускорение (требуется перезагрузка)</value>
   </data>
   <data name="SpeedtestingWait" xml:space="preserve">
-    <value>Ожидание тестирования (нажмите ESC для отмены)…</value>
+    <value>Ожидание тестирования…</value>
+  </data>
+  <data name="SpeedtestingPressEscToExit" xml:space="preserve">
+    <value>нажмите ESC для отмены</value>
   </data>
   <data name="TipDisplayLog" xml:space="preserve">
     <value>Отключите при аномальном разрыве соединения</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -976,7 +976,10 @@
     <value>启用硬件加速 (需重启)</value>
   </data>
   <data name="SpeedtestingWait" xml:space="preserve">
-    <value>等待测试中 (按 ESC 终止)...</value>
+    <value>等待测试...</value>
+  </data>
+  <data name="SpeedtestingPressEscToExit" xml:space="preserve">
+    <value>按 ESC 可终止测试</value>
   </data>
   <data name="TipDisplayLog" xml:space="preserve">
     <value>当有异常断流时请关闭</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -976,7 +976,10 @@
     <value>啟用硬體加速 (需重啟)</value>
   </data>
   <data name="SpeedtestingWait" xml:space="preserve">
-    <value>等待測試中（按 ESC 終止）...</value>
+    <value>等待測試中...</value>
+  </data>
+  <data name="SpeedtestingPressEscToExit" xml:space="preserve">
+    <value>按 ECS 以終止測試</value>
   </data>
   <data name="TipDisplayLog" xml:space="preserve">
     <value>當有異常斷流時請關閉</value>

--- a/v2rayN/ServiceLib/Services/SpeedtestService.cs
+++ b/v2rayN/ServiceLib/Services/SpeedtestService.cs
@@ -103,6 +103,11 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
             }
         }
 
+        if (lstSelected.Count > 1 && (actionType == ESpeedActionType.Speedtest || actionType == ESpeedActionType.Mixedtest))
+        {
+            NoticeManager.Instance.Enqueue(ResUI.SpeedtestingPressEscToExit);
+        }
+
         return lstSelected;
     }
 

--- a/v2rayN/ServiceLib/Services/SpeedtestService.cs
+++ b/v2rayN/ServiceLib/Services/SpeedtestService.cs
@@ -19,12 +19,17 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
 
     public void ExitLoop()
     {
-        if (_lstExitLoop.Count > 0)
+        if (!_lstExitLoop.IsEmpty)
         {
             _ = UpdateFunc("", ResUI.SpeedtestingStop);
 
             _lstExitLoop.Clear();
         }
+    }
+
+    private static bool ShouldStopTest(string exitLoopKey)
+    {
+        return !_lstExitLoop.Any(p => p == exitLoopKey);
     }
 
     private async Task RunAsync(ESpeedActionType actionType, List<ProfileItem> selecteds)
@@ -157,7 +162,7 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
         var pageSizeNext = pageSize / 2;
         if (lstFailed.Count > 0 && pageSizeNext > 0)
         {
-            if (_lstExitLoop.Any(p => p == exitLoopKey) == false)
+            if (ShouldStopTest(exitLoopKey))
             {
                 await UpdateFunc("", ResUI.SpeedtestingSkip);
                 return;
@@ -195,6 +200,12 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
                 {
                     continue;
                 }
+
+                if (ShouldStopTest(exitLoopKey))
+                {
+                    return false;
+                }
+
                 tasks.Add(Task.Run(async () =>
                 {
                     await DoRealPing(it);
@@ -223,7 +234,7 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
         List<Task> tasks = new();
         foreach (var it in selecteds)
         {
-            if (_lstExitLoop.Any(p => p == exitLoopKey) == false)
+            if (ShouldStopTest(exitLoopKey))
             {
                 await UpdateFunc(it.IndexId, "", ResUI.SpeedtestingSkip);
                 continue;
@@ -239,21 +250,27 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
                     if (processService is null)
                     {
                         await UpdateFunc(it.IndexId, "", ResUI.FailedToRunCore);
+                        return;
                     }
-                    else
+
+                    await Task.Delay(1000);
+
+                    var delay = await DoRealPing(it);
+                    if (blSpeedTest)
                     {
-                        await Task.Delay(1000);
-                        var delay = await DoRealPing(it);
-                        if (blSpeedTest)
+                        if (ShouldStopTest(exitLoopKey))
                         {
-                            if (delay > 0)
-                            {
-                                await DoSpeedTest(downloadHandle, it);
-                            }
-                            else
-                            {
-                                await UpdateFunc(it.IndexId, "", ResUI.SpeedtestingSkip);
-                            }
+                            await UpdateFunc(it.IndexId, "", ResUI.SpeedtestingSkip);
+                            return;
+                        }
+
+                        if (delay > 0)
+                        {
+                            await DoSpeedTest(downloadHandle, it);
+                        }
+                        else
+                        {
+                            await UpdateFunc(it.IndexId, "", ResUI.SpeedtestingSkip);
                         }
                     }
                 }


### PR DESCRIPTION
### Summary

This PR:

1. Shortens the string `Waiting for testing (press ESC to terminate)...` to `Waiting for testing...`, since a loooong string displayed in the table cell is hard to read. For a better solution, `Press ECS to terminate` now will be displayed in the notification toast (and if the items to test >1).
2. Fixes the latency that if the user pressed ESC to terminate the test, the next one or two queued test will still be proceeded.

### Demo

Before the PR:

https://github.com/user-attachments/assets/913eb83b-39c2-492f-bc4f-2ca9c0b51715

After the PR:

https://github.com/user-attachments/assets/4e7361fa-ac29-41c2-8d03-9d930115f42c
