### PR TITLE
[PR]改进Emoji字体兼容性

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@v5.0.1
       with:
         submodules: 'recursive'
         fetch-depth: '0'
@@ -110,7 +110,7 @@ jobs:
         dnf -y install sudo git rpm-build rpmdevtools dnf-plugins-core rsync findutils tar gzip unzip which
 
     - name: Checkout repo (for scripts)
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@v5.0.1
       with:
         submodules: 'recursive'
         fetch-depth: '0'

--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@v5.0.1
       with:
         submodules: 'recursive'
         fetch-depth: '0'

--- a/.github/workflows/build-windows-desktop.yml
+++ b/.github/workflows/build-windows-desktop.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@v5.0.1
       with:
         submodules: 'recursive'
         fetch-depth: '0'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5.0.0
+      uses: actions/checkout@v5.0.1
 
     - name: Setup
       uses: actions/setup-dotnet@v5.0.0

--- a/package-debian.sh
+++ b/package-debian.sh
@@ -28,7 +28,7 @@ Package: v2rayN
 Version: $Version
 Architecture: $Arch2
 Maintainer: https://github.com/2dust/v2rayN
-Depends: libc6 (>= 2.34), fontconfig (>= 2.13.1), desktop-file-utils (>= 0.26), xdg-utils (>= 1.1.3), coreutils (>= 8.32), bash (>= 5.1)
+Depends: libc6 (>= 2.34), fontconfig (>= 2.13.1), desktop-file-utils (>= 0.26), xdg-utils (>= 1.1.3), coreutils (>= 8.32), bash (>= 5.1), libfreetype6 (>= 2.11)
 Description: A GUI client for Windows and Linux, support Xray core and sing-box-core and others
 EOF
 

--- a/package-rhel.sh
+++ b/package-rhel.sh
@@ -631,13 +631,14 @@ ExclusiveArch:  aarch64 x86_64
 Source0:        __PKGROOT__.tar.gz
 
 # Runtime dependencies (Avalonia / X11 / Fonts / GL)
-Requires:       freetype, cairo, pango, openssl, mesa-libEGL, mesa-libGL
+Requires:       cairo, pango, openssl, mesa-libEGL, mesa-libGL
 Requires:       glibc >= 2.34
 Requires:       fontconfig >= 2.13.1
 Requires:       desktop-file-utils >= 0.26
 Requires:       xdg-utils >= 1.1.3
 Requires:       coreutils >= 8.32
 Requires:       bash >= 5.1
+Requires:       freetype >= 2.10
 
 %description
 v2rayN Linux for Red Hat Enterprise Linux

--- a/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
+++ b/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
@@ -1,14 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Avalonia.Media;
+
 namespace v2rayN.Desktop.Common;
 
 public static class AppBuilderExtension
 {
     public static AppBuilder WithFontByDefault(this AppBuilder appBuilder)
     {
-        var uri = Path.Combine(Global.AvaAssets, "Fonts#Noto Sans SC");
-        return appBuilder.With(new FontManagerOptions()
+        if (!OperatingSystem.IsLinux())
         {
-            //DefaultFamilyName = uri,
-            FontFallbacks = new[] { new FontFallback { FontFamily = new FontFamily(uri) } }
+            var uri = Path.Combine(Global.AvaAssets, "Fonts#Noto Sans SC");
+            return appBuilder.With(new FontManagerOptions
+            {
+                FontFallbacks = new[]
+                {
+                    new FontFallback { FontFamily = new FontFamily(uri) }
+                }
+            });
+        }
+
+        var fallbacks = new List<FontFallback>();
+
+        string? zhFont = RunFcMatch("sans:lang=zh-cn");
+
+        if (!string.IsNullOrWhiteSpace(zhFont))
+        {
+            fallbacks.Add(new FontFallback
+            {
+                FontFamily = new FontFamily(zhFont)
+            });
+        }
+
+        string? emojiFont = RunFcMatch("emoji");
+
+        if (!string.IsNullOrWhiteSpace(emojiFont))
+        {
+            fallbacks.Add(new FontFallback
+            {
+                FontFamily = new FontFamily(emojiFont)
+            });
+        }
+
+        var notoUri = Path.Combine(Global.AvaAssets, "Fonts#Noto Sans SC");
+        fallbacks.Add(new FontFallback
+        {
+            FontFamily = new FontFamily(notoUri)
         });
+
+        return appBuilder.With(new FontManagerOptions
+        {
+            FontFallbacks = fallbacks.ToArray()
+        });
+    }
+
+    private static string? RunFcMatch(string pattern)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "/bin/bash",
+                ArgumentList = { "-c", $"fc-match -f \"%{{file}}\\n\" \"{pattern}\" | head -n 1" },
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+
+            using var p = Process.Start(psi);
+            if (p == null) return null;
+
+            string output = p.StandardOutput.ReadToEnd().Trim();
+            return string.IsNullOrWhiteSpace(output) ? null : output;
+        }
+        catch
+        {
+            return null;
+        }
     }
 }

--- a/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
+++ b/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using Avalonia;
 using Avalonia.Media;
 
 namespace v2rayN.Desktop.Common;
@@ -24,7 +25,7 @@ public static class AppBuilderExtension
 
         var fallbacks = new List<FontFallback>();
 
-        string? zhFamily = RunFcMatchFamily("sans:lang=zh-cn");
+        var zhFamily = RunFcFamily("sans:lang=zh-cn");
         if (!string.IsNullOrWhiteSpace(zhFamily))
         {
             fallbacks.Add(new FontFallback
@@ -33,7 +34,7 @@ public static class AppBuilderExtension
             });
         }
 
-        string? emojiFamily = RunFcMatchFamily("emoji");
+        var emojiFamily = RunFcFamily("emoji");
         if (!string.IsNullOrWhiteSpace(emojiFamily))
         {
             fallbacks.Add(new FontFallback
@@ -54,20 +55,16 @@ public static class AppBuilderExtension
         });
     }
 
-    private static string? RunFcMatchFamily(string pattern)
+    private static string? RunFcFamily(string pattern)
     {
         try
         {
             var psi = new ProcessStartInfo
             {
                 FileName = "/bin/bash",
-                ArgumentList =
-                {
-                    "-c",
-                    $"fc-match -f \"%{{family[0]}}\\n\" \"{pattern}\" | head -n 1"
-                },
+                ArgumentList = { "-c", $"fc-match -f \"%{{family}}\\n\" \"{pattern}\" | head -n 1" },
                 RedirectStandardOutput = true,
-                RedirectStandardError = false,
+                RedirectStandardError = true,
                 UseShellExecute = false
             };
 

--- a/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
+++ b/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
@@ -1,9 +1,9 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using Avalonia;
 using Avalonia.Media;
+using System.Collections.Generic;
 
 namespace v2rayN.Desktop.Common;
 
@@ -23,9 +23,11 @@ public static class AppBuilderExtension
             });
         }
 
-        var fallbacks = new List<FontFallback>();
+        List<FontFallback> fallbacks = new();
 
-        var zhFamily = RunFcFamily("sans:lang=zh-cn");
+        string? zhFamily = RunFcMatchFamily("sans:lang=zh-cn");
+        string? emojiFamily = RunFcMatchFamily("emoji");
+
         if (!string.IsNullOrWhiteSpace(zhFamily))
         {
             fallbacks.Add(new FontFallback
@@ -34,7 +36,6 @@ public static class AppBuilderExtension
             });
         }
 
-        var emojiFamily = RunFcFamily("emoji");
         if (!string.IsNullOrWhiteSpace(emojiFamily))
         {
             fallbacks.Add(new FontFallback
@@ -43,10 +44,10 @@ public static class AppBuilderExtension
             });
         }
 
-        var notoUri = Path.Combine(Global.AvaAssets, "Fonts#Noto Sans SC");
+        var localFont = Path.Combine(Global.AvaAssets, "Fonts#Noto Sans SC");
         fallbacks.Add(new FontFallback
         {
-            FontFamily = new FontFamily(notoUri)
+            FontFamily = new FontFamily(localFont)
         });
 
         return appBuilder.With(new FontManagerOptions
@@ -55,7 +56,7 @@ public static class AppBuilderExtension
         });
     }
 
-    private static string? RunFcFamily(string pattern)
+    private static string? RunFcMatchFamily(string pattern)
     {
         try
         {
@@ -64,15 +65,13 @@ public static class AppBuilderExtension
                 FileName = "/bin/bash",
                 ArgumentList = { "-c", $"fc-match -f \"%{{family}}\\n\" \"{pattern}\" | head -n 1" },
                 RedirectStandardOutput = true,
-                RedirectStandardError = true,
                 UseShellExecute = false
             };
 
             using var p = Process.Start(psi);
-            if (p == null)
-                return null;
+            if (p == null) return null;
 
-            var output = p.StandardOutput.ReadToEnd().Trim();
+            string output = p.StandardOutput.ReadToEnd().Trim();
             return string.IsNullOrWhiteSpace(output) ? null : output;
         }
         catch


### PR DESCRIPTION
## 内容
此PR旨在改进部分Linux发行版的字体兼容性

### 已知缺陷
**1、此方案在部分配置换乱、字体劫持的发行版中无效**

需要和对应发行版取得支持
或者Linux版打包字体文件，强制指定字体（可能会增加打包占用空间）

**2、在采用COLRv1字体的发行版中，无法显示Emoji**

Fedora 43 用户需要降级字体包
```bash
sudo dnf install */NotoColorEmoji.ttf --releasever=42
```
需要等上游将渲染器完全适配COLRv1字体
或者Linux版打包字体文件，强制指定字体（可能会增加打包占用空间）
### 测试通过系统
Rocky Linux 10
![截屏2025-11-18 00 14 33](https://github.com/user-attachments/assets/2f7b3260-871d-4901-ad63-d10232e33d2a)
Red Hat Enterprise Linux 10
![截屏2025-11-18 00 14 09](https://github.com/user-attachments/assets/14a48062-317c-4686-bd38-e9a17768cf14)
Ubuntu Linux 25.10
![截屏2025-11-18 00 13 47](https://github.com/user-attachments/assets/9abed057-9390-4274-b8ee-a0375943b196)
Debian Linux 12
![截屏2025-11-18 00 13 17](https://github.com/user-attachments/assets/8c801924-3717-47ff-b32d-b3291e0fc1d3)
Debian Linux 13
![截屏2025-11-18 00 12 37](https://github.com/user-attachments/assets/f3053bf0-a64e-4191-9c5a-b6165bcb496c)
Rocky Linux 10
![截屏2025-11-18 00 12 03](https://github.com/user-attachments/assets/ec93c0e8-b11c-42ef-ae83-ff51c1437299)
Elementary OS 8
![截屏2025-11-18 00 11 18](https://github.com/user-attachments/assets/a11be5da-3b22-4334-a456-61a708002469)
Fedora Linux 42
![截屏2025-11-18 00 11 01 1](https://github.com/user-attachments/assets/ca9717f8-e60b-4a28-a68c-f03914fc1435)
AlmaLinux 10
![截屏2025-11-18 01 25 26](https://github.com/user-attachments/assets/51f692da-c227-43aa-80d2-a246fe2144dc)
Fedora Linux 43
![截屏2025-11-18 16 29 06](https://github.com/user-attachments/assets/e0e112dd-ed72-489f-a3e2-658ba05aacbb)
Manjaro Linux
![截屏2025-11-18 16 56 35](https://github.com/user-attachments/assets/81c6be07-de55-46aa-bc86-20e985fdeb6b)