### PR TITLE
[PR]改进Emoji字体兼容性

### DIFF
--- a/package-debian.sh
+++ b/package-debian.sh
@@ -28,7 +28,7 @@ Package: v2rayN
 Version: $Version
 Architecture: $Arch2
 Maintainer: https://github.com/2dust/v2rayN
-Depends: libc6 (>= 2.34), fontconfig (>= 2.13.1), desktop-file-utils (>= 0.26), xdg-utils (>= 1.1.3), coreutils (>= 8.32), bash (>= 5.1)
+Depends: libc6 (>= 2.34), fontconfig (>= 2.13.1), desktop-file-utils (>= 0.26), xdg-utils (>= 1.1.3), coreutils (>= 8.32), bash (>= 5.1), libfreetype6 (>= 2.11)
 Description: A GUI client for Windows and Linux, support Xray core and sing-box-core and others
 EOF
 

--- a/package-rhel.sh
+++ b/package-rhel.sh
@@ -631,13 +631,14 @@ ExclusiveArch:  aarch64 x86_64
 Source0:        __PKGROOT__.tar.gz
 
 # Runtime dependencies (Avalonia / X11 / Fonts / GL)
-Requires:       freetype, cairo, pango, openssl, mesa-libEGL, mesa-libGL
+Requires:       cairo, pango, openssl, mesa-libEGL, mesa-libGL
 Requires:       glibc >= 2.34
 Requires:       fontconfig >= 2.13.1
 Requires:       desktop-file-utils >= 0.26
 Requires:       xdg-utils >= 1.1.3
 Requires:       coreutils >= 8.32
 Requires:       bash >= 5.1
+Requires:       freetype >= 2.10
 
 %description
 v2rayN Linux for Red Hat Enterprise Linux

--- a/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
+++ b/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.IO;
 using Avalonia;
 using Avalonia.Media;
@@ -9,22 +8,22 @@ public static class AppBuilderExtension
 {
     public static AppBuilder WithFontByDefault(this AppBuilder appBuilder)
     {
-        var fallbacks = new List<FontFallback>();
-
         var notoSansSc = new FontFamily(Path.Combine(Global.AvaAssets, "Fonts#Noto Sans SC"));
-        fallbacks.Add(new FontFallback { FontFamily = notoSansSc });
 
-        if (OperatingSystem.IsLinux())
+        var fallbacks = new[]
         {
-            fallbacks.Add(new FontFallback
-            {
-                FontFamily = new FontFamily("Noto Color Emoji")
-            });
-        }
+            new FontFallback { FontFamily = notoSansSc },
+
+            OperatingSystem.IsLinux()
+                ? new FontFallback { FontFamily = new FontFamily("Noto Color Emoji") }
+                : null
+        };
+
+        var validFallbacks = fallbacks.Where(f => f is not null).ToArray()!;
 
         return appBuilder.With(new FontManagerOptions
         {
-            FontFallbacks = fallbacks.ToArray()
+            FontFallbacks = validFallbacks
         });
     }
 }

--- a/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
+++ b/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
@@ -1,68 +1,20 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using Avalonia;
-using Avalonia.Media;
-
-namespace v2rayN.Desktop.Common;
-
-public static class AppBuilderExtension
+public static AppBuilder WithFontByDefault(this AppBuilder appBuilder)
 {
-    public static AppBuilder WithFontByDefault(this AppBuilder appBuilder)
+    var fallbacks = new List<FontFallback>();
+
+    var notoSansSc = new FontFamily(Path.Combine(Global.AvaAssets, "Fonts#Noto Sans SC"));
+    fallbacks.Add(new FontFallback { FontFamily = notoSansSc });
+
+    if (OperatingSystem.IsLinux())
     {
-        var notoSansSc = new FontFamily(Path.Combine(Global.AvaAssets, "Fonts#Noto Sans SC"));
-
-        var fallbacks = new List<FontFallback>
+        fallbacks.Add(new FontFallback
         {
-            new() { FontFamily = notoSansSc }
-        };
-
-        if (OperatingSystem.IsLinux())
-        {
-            var emojiFamily = DetectLinuxEmojiFamily();
-            if (!string.IsNullOrWhiteSpace(emojiFamily))
-            {
-                fallbacks.Add(new FontFallback
-                {
-                    FontFamily = new FontFamily(emojiFamily)
-                });
-            }
-        }
-
-        return appBuilder.With(new FontManagerOptions
-        {
-            FontFallbacks = fallbacks.ToArray()
+            FontFamily = new FontFamily("Noto Color Emoji")
         });
     }
 
-    private static string? DetectLinuxEmojiFamily()
+    return appBuilder.With(new FontManagerOptions
     {
-        try
-        {
-            var psi = new ProcessStartInfo
-            {
-                FileName = "/bin/bash",
-                ArgumentList =
-                {
-                    "-c",
-                    "fc-match -f \"%{family[0]}\\n\" \"emoji\" | head -n 1"
-                },
-                RedirectStandardOutput = true,
-                RedirectStandardError = false,
-                UseShellExecute = false
-            };
-
-            using var p = Process.Start(psi);
-            if (p == null)
-                return null;
-
-            var output = p.StandardOutput.ReadToEnd().Trim();
-            return string.IsNullOrWhiteSpace(output) ? null : output;
-        }
-        catch
-        {
-            return null;
-        }
-    }
+        FontFallbacks = fallbacks.ToArray()
+    });
 }

--- a/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
+++ b/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
@@ -1,20 +1,29 @@
-public static AppBuilder WithFontByDefault(this AppBuilder appBuilder)
+using System.IO;
+using Avalonia;
+using Avalonia.Media;
+
+namespace v2rayN.Desktop.Common;
+
+public static class AppBuilderExtension
 {
-    var fallbacks = new List<FontFallback>();
-
-    var notoSansSc = new FontFamily(Path.Combine(Global.AvaAssets, "Fonts#Noto Sans SC"));
-    fallbacks.Add(new FontFallback { FontFamily = notoSansSc });
-
-    if (OperatingSystem.IsLinux())
+    public static AppBuilder WithFontByDefault(this AppBuilder appBuilder)
     {
-        fallbacks.Add(new FontFallback
+        var notoSansSc = new FontFamily(Path.Combine(Global.AvaAssets, "Fonts#Noto Sans SC"));
+
+        var fallbacks = new[]
         {
-            FontFamily = new FontFamily("Noto Color Emoji")
+            new FontFallback { FontFamily = notoSansSc },
+
+            OperatingSystem.IsLinux()
+                ? new FontFallback { FontFamily = new FontFamily("Noto Color Emoji") }
+                : null
+        };
+
+        var validFallbacks = fallbacks.Where(f => f is not null).ToArray()!;
+
+        return appBuilder.With(new FontManagerOptions
+        {
+            FontFallbacks = validFallbacks
         });
     }
-
-    return appBuilder.With(new FontManagerOptions
-    {
-        FontFallbacks = fallbacks.ToArray()
-    });
 }

--- a/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
+++ b/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using Avalonia;
 using Avalonia.Media;
@@ -8,22 +9,22 @@ public static class AppBuilderExtension
 {
     public static AppBuilder WithFontByDefault(this AppBuilder appBuilder)
     {
+        var fallbacks = new List<FontFallback>();
+
         var notoSansSc = new FontFamily(Path.Combine(Global.AvaAssets, "Fonts#Noto Sans SC"));
+        fallbacks.Add(new FontFallback { FontFamily = notoSansSc });
 
-        var fallbacks = new[]
+        if (OperatingSystem.IsLinux())
         {
-            new FontFallback { FontFamily = notoSansSc },
-
-            OperatingSystem.IsLinux()
-                ? new FontFallback { FontFamily = new FontFamily("Noto Color Emoji") }
-                : null
-        };
-
-        var validFallbacks = fallbacks.Where(f => f is not null).ToArray()!;
+            fallbacks.Add(new FontFallback
+            {
+                FontFamily = new FontFamily("Noto Color Emoji")
+            });
+        }
 
         return appBuilder.With(new FontManagerOptions
         {
-            FontFallbacks = validFallbacks
+            FontFallbacks = fallbacks.ToArray()
         });
     }
 }

--- a/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
+++ b/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
 using Avalonia;
 using Avalonia.Media;
@@ -8,22 +10,22 @@ public static class AppBuilderExtension
 {
     public static AppBuilder WithFontByDefault(this AppBuilder appBuilder)
     {
+        var fallbacks = new List<FontFallback>();
+        
         var notoSansSc = new FontFamily(Path.Combine(Global.AvaAssets, "Fonts#Noto Sans SC"));
+        fallbacks.Add(new FontFallback { FontFamily = notoSansSc });
 
-        var fallbacks = new[]
+        if (OperatingSystem.IsLinux())
         {
-            new FontFallback { FontFamily = notoSansSc },
-
-            OperatingSystem.IsLinux()
-                ? new FontFallback { FontFamily = new FontFamily("Noto Color Emoji") }
-                : null
-        };
-
-        var validFallbacks = fallbacks.Where(f => f is not null).ToArray()!;
+            fallbacks.Add(new FontFallback
+            {
+                FontFamily = new FontFamily("Noto Color Emoji")
+            });
+        }
 
         return appBuilder.With(new FontManagerOptions
         {
-            FontFallbacks = validFallbacks
+            FontFallbacks = fallbacks.ToArray()
         });
     }
 }

--- a/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
+++ b/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
@@ -1,14 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Avalonia;
+using Avalonia.Media;
+
 namespace v2rayN.Desktop.Common;
 
 public static class AppBuilderExtension
 {
     public static AppBuilder WithFontByDefault(this AppBuilder appBuilder)
     {
-        var uri = Path.Combine(Global.AvaAssets, "Fonts#Noto Sans SC");
-        return appBuilder.With(new FontManagerOptions()
+        var notoSansSc = new FontFamily(Path.Combine(Global.AvaAssets, "Fonts#Noto Sans SC"));
+
+        var fallbacks = new List<FontFallback>
         {
-            //DefaultFamilyName = uri,
-            FontFallbacks = new[] { new FontFallback { FontFamily = new FontFamily(uri) } }
+            new() { FontFamily = notoSansSc }
+        };
+
+        if (OperatingSystem.IsLinux())
+        {
+            var emojiFamily = DetectLinuxEmojiFamily();
+            if (!string.IsNullOrWhiteSpace(emojiFamily))
+            {
+                fallbacks.Add(new FontFallback
+                {
+                    FontFamily = new FontFamily(emojiFamily)
+                });
+            }
+        }
+
+        return appBuilder.With(new FontManagerOptions
+        {
+            FontFallbacks = fallbacks.ToArray()
         });
+    }
+
+    private static string? DetectLinuxEmojiFamily()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "/bin/bash",
+                ArgumentList =
+                {
+                    "-c",
+                    "fc-match -f \"%{family[0]}\\n\" \"emoji\" | head -n 1"
+                },
+                RedirectStandardOutput = true,
+                RedirectStandardError = false,
+                UseShellExecute = false
+            };
+
+            using var p = Process.Start(psi);
+            if (p == null)
+                return null;
+
+            var output = p.StandardOutput.ReadToEnd().Trim();
+            return string.IsNullOrWhiteSpace(output) ? null : output;
+        }
+        catch
+        {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## 内容
此PR旨在改进部分Linux发行版的字体兼容性

### 已知缺陷
> 此次修改未涉及这些问题

**1、此方案在部分配置换乱、字体劫持的发行版中无效**

需要和对应发行版取得支持
或者Linux版打包字体文件，强制指定字体（可能会增加打包占用空间）

**2、在采用COLRv1字体的发行版中，无法显示Emoji**

Fedora 43 用户需要降级字体包
```bash
sudo dnf install */NotoColorEmoji.ttf --releasever=42
```
需要等上游将渲染器完全适配COLRv1字体
或者Linux版打包字体文件，强制指定字体（可能会增加打包占用空间）

**3、用户在安装个人字体后会导致字体默认选择行为出错**
用户可以指定显示的字体

**4、更改字体后，部分区域的字体将不会改变**

### 测试通过系统
Red Hat Enterprise Linux 10
![截屏2025-11-18 21 29 59](https://github.com/user-attachments/assets/2965a12b-6111-4398-be3e-a8f032875dd7)
Rocky Linux 10
![截屏2025-11-18 21 28 58](https://github.com/user-attachments/assets/4042f74e-2896-4905-8ee4-e77abd554ba7)
Rocky Linux 10
![截屏2025-11-18 21 30 51](https://github.com/user-attachments/assets/7243d970-4b8d-467a-bc9d-28c1d1e2101b)
AlmaLinux 10
![截屏2025-11-18 21 29 38](https://github.com/user-attachments/assets/933db90c-8ab0-422a-9caa-e3806caad435)
Fedora Linux 43
![截屏2025-11-18 21 34 32](https://github.com/user-attachments/assets/a7f5cb9e-eb54-4d36-8f09-b0ef868f884f)
Elementary OS 8
![截屏2025-11-18 21 31 17](https://github.com/user-attachments/assets/ea9ab490-930d-4ea6-9527-b469c5b0a581)
Debian Linux 12
![截屏2025-11-18 21 36 33](https://github.com/user-attachments/assets/d52e3de2-09e0-4aab-9cde-827d0f296abe)
Debian Linux 13
![截屏2025-11-18 21 26 49](https://github.com/user-attachments/assets/648dffbf-a0bc-4051-a222-dce5e3ff9e10)
Ubuntu Linux 25.10
![截屏2025-11-18 21 38 58](https://github.com/user-attachments/assets/1ae1c6d9-b0a1-4fde-893a-cdade485ed2a)
Manjaro Linux
![截屏2025-11-18 21 28 38](https://github.com/user-attachments/assets/2f9ad239-fb3a-44f1-b26d-48e8df1c284c)

