### PR TITLE
Fix sing-box ws

### DIFF
--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -216,6 +216,8 @@ public class Transport4Sbox
     public string? idle_timeout { get; set; }
     public string? ping_timeout { get; set; }
     public bool? permit_without_stream { get; set; }
+    public int? max_early_data { get; set; }
+    public string? early_data_header_name { get; set; }
 }
 
 public class Headers4Sbox


### PR DESCRIPTION
修复 sing-box 无法与兼容 xray ws 服务端通信

读取 ed 参数填入 max_early_data, 将 early_data_header_name 赋值为 Sec-WebSocket-Protocol, 并从 path 中删除
https://github.com/XTLS/Xray-core/blob/9ebd6ada62720b15c6fd335f419b7951eec25104/infra/conf/transport_internet.go#L161

读取 eh 参数填入 early_data_header_name