### PR TITLE
fix: mux not applied to trojan inbound

### DIFF
--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
@@ -173,7 +173,7 @@ public partial class CoreConfigV2rayService
                         serversItem.ota = false;
                         serversItem.level = 1;
 
-                        await GenOutboundMux(node, outbound);
+                        await GenOutboundMux(node, outbound, muxEnabled, muxEnabled);
 
                         outbound.settings.vnext = null;
                         break;


### PR DESCRIPTION
In the current version of v2rayN, it's impossible to override the Mux for Trojan inbound.

This small PR is aimed at fixing this issue.