### PR TITLE
Remove formatted spaces from extra JSON before URL encoding

### DIFF
--- a/v2rayN/ServiceLib/Handler/Fmt/BaseFmt.cs
+++ b/v2rayN/ServiceLib/Handler/Fmt/BaseFmt.cs
@@ -118,7 +118,23 @@ public class BaseFmt
                 }
                 if (item.Extra.IsNotEmpty())
                 {
-                    dicQuery.Add("extra", Utils.UrlEncode(item.Extra));
+                    var extra = item.Extra;
+                    try
+                    {
+                        var node = JsonNode.Parse(item.Extra);
+                        if (node != null)
+                        {
+                            extra = node.ToJsonString(new JsonSerializerOptions
+                            {
+                                WriteIndented = false,
+                                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+                            });
+                        }
+                    }
+                    catch
+                    {
+                    }
+                    dicQuery.Add("extra", Utils.UrlEncode(extra));
                 }
                 break;
 


### PR DESCRIPTION
删除 xhttp extra 分享格式化空格，减小分享链接长度

包含空格会膨胀 60% ~ 200% 左右