### PR TITLE
Revert "Add TLS ALPN check for WS (#8469)"

### DIFF
--- a/v2rayN/ServiceLib/Manager/ActionPrecheckManager.cs
+++ b/v2rayN/ServiceLib/Manager/ActionPrecheckManager.cs
@@ -193,19 +193,6 @@ public class ActionPrecheckManager
             }
         }
 
-        // ws with tls, tls alpn should contain "http/1.1" in xray core
-        // rfc6455
-        // https://github.com/XTLS/Xray-core/blob/81f8f398c7b2b845853b1e85087c6122acc6db0b/transport/internet/tls/tls.go#L95-L116
-        if (item.Network == nameof(ETransport.ws)
-            && item.StreamSecurity == Global.StreamSecurity)
-        {
-            var alpnList = Utils.String2List(item.Alpn) ?? [];
-            if (alpnList.Count > 0 && !alpnList.Contains("http/1.1"))
-            {
-                errors.Add(ResUI.AlpnMustContainHttp11ForWsTls);
-            }
-        }
-
         return errors;
     }
 

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -19,7 +19,7 @@ namespace ServiceLib.Resx {
     // 类通过类似于 ResGen 或 Visual Studio 的工具自动生成的。
     // 若要添加或移除成员，请编辑 .ResX 文件，然后重新运行 ResGen
     // (以 /str 作为命令选项)，或重新生成 VS 项目。
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class ResUI {
@@ -75,15 +75,6 @@ namespace ServiceLib.Resx {
         public static string AllGroupServers {
             get {
                 return ResourceManager.GetString("AllGroupServers", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   查找类似 ALPN must contain &apos;http/1.1&apos; when using WebSocket with TLS. 的本地化字符串。
-        /// </summary>
-        public static string AlpnMustContainHttp11ForWsTls {
-            get {
-                return ResourceManager.GetString("AlpnMustContainHttp11ForWsTls", resourceCulture);
             }
         }
         

--- a/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
@@ -1641,7 +1641,4 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
   <data name="menuServerList2" xml:space="preserve">
     <value>Configuration Item 2, Select and add from self-built</value>
   </data>
-  <data name="AlpnMustContainHttp11ForWsTls" xml:space="preserve">
-    <value>ALPN must contain 'http/1.1' when using WebSocket with TLS.</value>
-  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.fr.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fr.resx
@@ -1638,7 +1638,4 @@ Si un certificat auto-signé est utilisé ou si le système contient une CA non 
   <data name="menuServerList2" xml:space="preserve">
     <value>Élément de config 2 : choisir et ajouter depuis self-hosted</value>
   </data>
-  <data name="AlpnMustContainHttp11ForWsTls" xml:space="preserve">
-    <value>Avec WebSocket et TLS, l’ALPN doit inclure ‘http/1.1’.</value>
-  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.hu.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.hu.resx
@@ -1641,7 +1641,4 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
   <data name="menuServerList2" xml:space="preserve">
     <value>Configuration Item 2, Select and add from self-built</value>
   </data>
-  <data name="AlpnMustContainHttp11ForWsTls" xml:space="preserve">
-    <value>ALPN must contain 'http/1.1' when using WebSocket with TLS.</value>
-  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1641,7 +1641,4 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
   <data name="menuServerList2" xml:space="preserve">
     <value>Configuration Item 2, Select and add from self-built</value>
   </data>
-  <data name="AlpnMustContainHttp11ForWsTls" xml:space="preserve">
-    <value>ALPN must contain 'http/1.1' when using WebSocket with TLS.</value>
-  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1641,7 +1641,4 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
   <data name="menuServerList2" xml:space="preserve">
     <value>Configuration Item 2, Select and add from self-built</value>
   </data>
-  <data name="AlpnMustContainHttp11ForWsTls" xml:space="preserve">
-    <value>ALPN must contain 'http/1.1' when using WebSocket with TLS.</value>
-  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1638,7 +1638,4 @@
   <data name="menuServerList2" xml:space="preserve">
     <value>子配置项二，从自建中选择添加</value>
   </data>
-  <data name="AlpnMustContainHttp11ForWsTls" xml:space="preserve">
-    <value>使用 WebSocket+TLS 时，ALPN 必须包含 'http/1.1'。</value>
-  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -1638,7 +1638,4 @@
   <data name="menuServerList2" xml:space="preserve">
     <value>子配置項二，從自建中選擇新增</value>
   </data>
-  <data name="AlpnMustContainHttp11ForWsTls" xml:space="preserve">
-    <value>ALPN must contain 'http/1.1' when using WebSocket with TLS.</value>
-  </data>
 </root>


### PR DESCRIPTION
This reverts commit 6e27dca6cd833a5742d02ea5f1711f5b1483d56d.

#8514

部分脚本硬编码 alpn=h3：

```js
const rules = hosts.split('\n').filter(i => i.trim()).map(host => {
    return `trojan://bpb-trojan@www.vpslook.com:443?security=tls&sni=${host}&alpn=h3&fp=randomized&allowlnsecure=1&type=ws&host=${host}&path=%2Ftr%3Fed%3D2560#${host}`
}).join('\n')
```