### PR TITLE
Fix edge cases

### DIFF
--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayDnsService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayDnsService.cs
@@ -197,7 +197,7 @@ public partial class CoreConfigV2rayService
 
                     if (item.OutboundTag == Global.DirectTag)
                     {
-                        if (normalizedDomain.StartsWith("geosite:"))
+                        if (normalizedDomain.StartsWith("geosite:") || normalizedDomain.StartsWith("ext:"))
                         {
                             (regionNames.Contains(normalizedDomain) ? expectedDomainList : directGeositeList).Add(normalizedDomain);
                         }
@@ -208,7 +208,7 @@ public partial class CoreConfigV2rayService
                     }
                     else if (item.OutboundTag != Global.BlockTag)
                     {
-                        if (normalizedDomain.StartsWith("geosite:"))
+                        if (normalizedDomain.StartsWith("geosite:") || normalizedDomain.StartsWith("ext:"))
                         {
                             proxyGeositeList.Add(normalizedDomain);
                         }

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
@@ -564,7 +564,7 @@ public partial class CoreConfigV2rayService
             var fragmentOutbound = new Outbounds4Ray
             {
                 protocol = "freedom",
-                tag = $"{Global.ProxyTag}3",
+                tag = $"frag-{Global.ProxyTag}",
                 settings = new()
                 {
                     fragment = new()


### PR DESCRIPTION
修复边缘情况

- dns 配置生成错误响应外部路由集文件格式 `ext:`
- 分片直连可被观测匹配，导致定期直连 google 等探测出站代理连接状态的网址