### PR TITLE
Add Cert SHA-256 pinning support

### DIFF
--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -253,6 +253,7 @@ public static class ConfigHandler
             item.Extra = profileItem.Extra;
             item.MuxEnabled = profileItem.MuxEnabled;
             item.Cert = profileItem.Cert;
+            item.CertSha = profileItem.CertSha;
             item.EchConfigList = profileItem.EchConfigList;
             item.EchForceQuery = profileItem.EchForceQuery;
         }

--- a/v2rayN/ServiceLib/Handler/Fmt/BaseFmt.cs
+++ b/v2rayN/ServiceLib/Handler/Fmt/BaseFmt.cs
@@ -74,6 +74,10 @@ public class BaseFmt
         {
             dicQuery.Add("ech", Utils.UrlEncode(item.EchConfigList));
         }
+        if (item.CertSha.IsNotEmpty())
+        {
+            dicQuery.Add("pcs", Utils.UrlEncode(item.CertSha));
+        }
 
         dicQuery.Add("type", item.Network.IsNotEmpty() ? item.Network : nameof(ETransport.tcp));
 
@@ -214,6 +218,7 @@ public class BaseFmt
         item.SpiderX = GetQueryDecoded(query, "spx");
         item.Mldsa65Verify = GetQueryDecoded(query, "pqv");
         item.EchConfigList = GetQueryDecoded(query, "ech");
+        item.CertSha = GetQueryDecoded(query, "pcs");
 
         if (_allowInsecureArray.Any(k => GetQueryDecoded(query, k) == "1"))
         {

--- a/v2rayN/ServiceLib/Manager/ActionPrecheckManager.cs
+++ b/v2rayN/ServiceLib/Manager/ActionPrecheckManager.cs
@@ -168,7 +168,9 @@ public class ActionPrecheckManager
         if (item.StreamSecurity == Global.StreamSecurity)
         {
             // check certificate validity
-            if ((!item.Cert.IsNullOrEmpty()) && (CertPemManager.ParsePemChain(item.Cert).Count == 0))
+            if (!item.Cert.IsNullOrEmpty()
+                && (CertPemManager.ParsePemChain(item.Cert).Count == 0)
+                && !item.CertSha.IsNullOrEmpty())
             {
                 errors.Add(string.Format(ResUI.InvalidProperty, "TLS Certificate"));
             }

--- a/v2rayN/ServiceLib/Manager/CertPemManager.cs
+++ b/v2rayN/ServiceLib/Manager/CertPemManager.cs
@@ -416,4 +416,22 @@ public class CertPemManager
 
         return string.Concat(pemList);
     }
+
+    public static string GetCertSha256Thumbprint(string pemCert, bool includeColon = false)
+    {
+        try
+        {
+            var cert = X509Certificate2.CreateFromPem(pemCert);
+            var thumbprint = cert.GetCertHashString(HashAlgorithmName.SHA256);
+            if (includeColon)
+            {
+                return string.Join(":", thumbprint.Chunk(2).Select(c => new string(c)));
+            }
+            return thumbprint;
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
 }

--- a/v2rayN/ServiceLib/Models/ProfileItem.cs
+++ b/v2rayN/ServiceLib/Models/ProfileItem.cs
@@ -161,6 +161,7 @@ public class ProfileItem : ReactiveObject
     public string Extra { get; set; }
     public bool? MuxEnabled { get; set; }
     public string Cert { get; set; }
+    public string CertSha { get; set; }
     public string EchConfigList { get; set; }
     public string EchForceQuery { get; set; }
 }

--- a/v2rayN/ServiceLib/Models/V2rayConfig.cs
+++ b/v2rayN/ServiceLib/Models/V2rayConfig.cs
@@ -355,6 +355,7 @@ public class TlsSettings4Ray
     public string? spiderX { get; set; }
     public string? mldsa65Verify { get; set; }
     public List<CertificateSettings4Ray>? certificates { get; set; }
+    public string? pinnedPeerCertSha256 { get; set; }
     public bool? disableSystemRoot { get; set; }
     public string? echConfigList { get; set; }
     public string? echForceQuery { get; set; }

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -2617,7 +2617,7 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
-        ///   查找类似 Server Certificate (PEM format, optional)
+        ///   查找类似 Pinned certificate (fill in either one)
         ///When specified, the certificate will be pinned, and &quot;Allow Insecure&quot; will be disabled.
         ///
         ///The &quot;Get Certificate&quot; action may fail if a self-signed certificate is used or if the system contains an untrusted or malicious CA. 的本地化字符串。
@@ -2625,6 +2625,15 @@ namespace ServiceLib.Resx {
         public static string TbCertPinningTips {
             get {
                 return ResourceManager.GetString("TbCertPinningTips", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Certificate fingerprint (SHA-256) 的本地化字符串。
+        /// </summary>
+        public static string TbCertSha256Tips {
+            get {
+                return ResourceManager.GetString("TbCertSha256Tips", resourceCulture);
             }
         }
         
@@ -2886,6 +2895,15 @@ namespace ServiceLib.Resx {
         public static string TbFlow5 {
             get {
                 return ResourceManager.GetString("TbFlow5", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Full certificate (chain), PEM format 的本地化字符串。
+        /// </summary>
+        public static string TbFullCertTips {
+            get {
+                return ResourceManager.GetString("TbFullCertTips", resourceCulture);
             }
         }
         

--- a/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
@@ -1647,4 +1647,10 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
   <data name="TbEchForceQuery" xml:space="preserve">
     <value>EchForceQuery</value>
   </data>
+  <data name="TbFullCertTips" xml:space="preserve">
+    <value>Full certificate (chain), PEM format</value>
+  </data>
+  <data name="TbCertSha256Tips" xml:space="preserve">
+    <value>Certificate fingerprint (SHA-256)</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.fr.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fr.resx
@@ -1606,10 +1606,10 @@
     <value>Certificate Pinning</value>
   </data>
   <data name="TbCertPinningTips" xml:space="preserve">
-    <value>Certificat serveur (format PEM, facultatif)
-Si le certificat est défini, il est fixé et l’option « Ignorer la vérification » est désactivée.
+    <value>Pinned certificate (fill in either one)
+When specified, the certificate will be pinned, and "Allow Insecure" will be disabled.
 
-Si un certificat auto-signé est utilisé ou si le système contient une CA non fiable ou malveillante, l’action « Obtenir le certificat » peut échouer.</value>
+The "Get Certificate" action may fail if a self-signed certificate is used or if the system contains an untrusted or malicious CA.</value>
   </data>
   <data name="TbFetchCert" xml:space="preserve">
     <value>Obtenir le certificat</value>
@@ -1643,5 +1643,11 @@ Si un certificat auto-signé est utilisé ou si le système contient une CA non 
   </data>
   <data name="TbEchForceQuery" xml:space="preserve">
     <value>EchForceQuery</value>
+  </data>
+  <data name="TbFullCertTips" xml:space="preserve">
+    <value>Full certificate (chain), PEM format</value>
+  </data>
+  <data name="TbCertSha256Tips" xml:space="preserve">
+    <value>Certificate fingerprint (SHA-256)</value>
   </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.hu.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.hu.resx
@@ -1609,7 +1609,7 @@
     <value>Certificate Pinning</value>
   </data>
   <data name="TbCertPinningTips" xml:space="preserve">
-    <value>Server Certificate (PEM format, optional)
+    <value>Pinned certificate (fill in either one)
 When specified, the certificate will be pinned, and "Allow Insecure" will be disabled.
 
 The "Get Certificate" action may fail if a self-signed certificate is used or if the system contains an untrusted or malicious CA.</value>
@@ -1646,5 +1646,11 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
   </data>
   <data name="TbEchForceQuery" xml:space="preserve">
     <value>EchForceQuery</value>
+  </data>
+  <data name="TbFullCertTips" xml:space="preserve">
+    <value>Full certificate (chain), PEM format</value>
+  </data>
+  <data name="TbCertSha256Tips" xml:space="preserve">
+    <value>Certificate fingerprint (SHA-256)</value>
   </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1609,7 +1609,7 @@
     <value>Certificate Pinning</value>
   </data>
   <data name="TbCertPinningTips" xml:space="preserve">
-    <value>Server Certificate (PEM format, optional)
+    <value>Pinned certificate (fill in either one)
 When specified, the certificate will be pinned, and "Allow Insecure" will be disabled.
 
 The "Get Certificate" action may fail if a self-signed certificate is used or if the system contains an untrusted or malicious CA.</value>
@@ -1646,5 +1646,11 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
   </data>
   <data name="TbEchForceQuery" xml:space="preserve">
     <value>EchForceQuery</value>
+  </data>
+  <data name="TbFullCertTips" xml:space="preserve">
+    <value>Full certificate (chain), PEM format</value>
+  </data>
+  <data name="TbCertSha256Tips" xml:space="preserve">
+    <value>Certificate fingerprint (SHA-256)</value>
   </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1609,7 +1609,7 @@
     <value>Certificate Pinning</value>
   </data>
   <data name="TbCertPinningTips" xml:space="preserve">
-    <value>Server Certificate (PEM format, optional)
+    <value>Pinned certificate (fill in either one)
 When specified, the certificate will be pinned, and "Allow Insecure" will be disabled.
 
 The "Get Certificate" action may fail if a self-signed certificate is used or if the system contains an untrusted or malicious CA.</value>
@@ -1646,5 +1646,11 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
   </data>
   <data name="TbEchForceQuery" xml:space="preserve">
     <value>EchForceQuery</value>
+  </data>
+  <data name="TbFullCertTips" xml:space="preserve">
+    <value>Full certificate (chain), PEM format</value>
+  </data>
+  <data name="TbCertSha256Tips" xml:space="preserve">
+    <value>Certificate fingerprint (SHA-256)</value>
   </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1606,10 +1606,10 @@
     <value>固定证书</value>
   </data>
   <data name="TbCertPinningTips" xml:space="preserve">
-    <value>服务器证书（PEM 格式，可选）
+    <value>固定证书（二选一填写即可）
 当指定此证书后，将固定该证书，并禁用“跳过证书验证”选项。
 
-“获取证书”操作可能失败，原因可能是使用了自签证书，或系统中存在不受信任或恶意的 CA。</value>
+“获取证书”操作可能失败，原因包括使用了自签名证书，或系统中存在不受信任甚至恶意的 CA。</value>
   </data>
   <data name="TbFetchCert" xml:space="preserve">
     <value>获取证书</value>
@@ -1643,5 +1643,11 @@
   </data>
   <data name="TbEchForceQuery" xml:space="preserve">
     <value>EchForceQuery</value>
+  </data>
+  <data name="TbFullCertTips" xml:space="preserve">
+    <value>完整证书（链），PEM 格式</value>
+  </data>
+  <data name="TbCertSha256Tips" xml:space="preserve">
+    <value>证书指纹（SHA-256）</value>
   </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -1606,7 +1606,7 @@
     <value>憑證綁定</value>
   </data>
   <data name="TbCertPinningTips" xml:space="preserve">
-    <value>伺服器憑證（PEM 格式，可選）
+    <value>固定憑證（二選一填寫即可）
 若已指定，憑證將會被綁定，並且「跳過憑證驗證」將被停用。
 
 若使用自簽憑證，或系統中存在不受信任或惡意的 CA，「取得憑證」動作可能會失敗。</value>
@@ -1643,5 +1643,11 @@
   </data>
   <data name="TbEchForceQuery" xml:space="preserve">
     <value>EchForceQuery</value>
+  </data>
+  <data name="TbFullCertTips" xml:space="preserve">
+    <value>Full certificate (chain), PEM format</value>
+  </data>
+  <data name="TbCertSha256Tips" xml:space="preserve">
+    <value>Certificate fingerprint (SHA-256)</value>
   </data>
 </root>

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
@@ -301,6 +301,10 @@ public partial class CoreConfigV2rayService
                     tlsSettings.disableSystemRoot = true;
                     tlsSettings.allowInsecure = false;
                 }
+                else if (!node.CertSha.IsNullOrEmpty())
+                {
+                    tlsSettings.pinnedPeerCertSha256 = node.CertSha;
+                }
                 streamSettings.tlsSettings = tlsSettings;
             }
 

--- a/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml
@@ -841,6 +841,23 @@
                                                 Margin="{StaticResource Margin4}"
                                                 Content="{x:Static resx:ResUI.TbFetchCertChain}" />
                                         </StackPanel>
+                                        <TextBlock
+                                            Width="400"
+                                            Margin="{StaticResource Margin4}"
+                                            VerticalAlignment="Center"
+                                            Text="{x:Static resx:ResUI.TbCertSha256Tips}"
+                                            TextWrapping="Wrap" />
+                                        <TextBox
+                                            x:Name="txtCertSha256Pinning"
+                                            Width="400"
+                                            Margin="{StaticResource Margin4}"
+                                            HorizontalAlignment="Left" />
+                                        <TextBlock
+                                            Width="400"
+                                            Margin="{StaticResource Margin4}"
+                                            VerticalAlignment="Center"
+                                            Text="{x:Static resx:ResUI.TbFullCertTips}"
+                                            TextWrapping="Wrap" />
                                         <TextBox
                                             x:Name="txtCert"
                                             Width="400"

--- a/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml.cs
@@ -186,6 +186,7 @@ public partial class AddServerWindow : WindowBase<AddServerViewModel>
             this.Bind(ViewModel, vm => vm.SelectedSource.AllowInsecure, v => v.cmbAllowInsecure.SelectedValue).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Fingerprint, v => v.cmbFingerprint.SelectedValue).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Alpn, v => v.cmbAlpn.SelectedValue).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.CertSha, v => v.txtCertSha256Pinning.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.CertTip, v => v.labCertPinning.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.Cert, v => v.txtCert.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.EchConfigList, v => v.txtEchConfigList.Text).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/AddServerWindow.xaml
+++ b/v2rayN/v2rayN/Views/AddServerWindow.xaml
@@ -1072,6 +1072,26 @@
                                         Content="{x:Static resx:ResUI.TbFetchCertChain}"
                                         Style="{StaticResource DefButton}" />
                                 </StackPanel>
+                                <TextBlock
+                                    Width="400"
+                                    Margin="{StaticResource Margin4}"
+                                    VerticalAlignment="Center"
+                                    Style="{StaticResource ToolbarTextBlock}"
+                                    Text="{x:Static resx:ResUI.TbCertSha256Tips}"
+                                    TextWrapping="Wrap" />
+                                <TextBox
+                                    x:Name="txtCertSha256Pinning"
+                                    Width="400"
+                                    Margin="{StaticResource Margin4}"
+                                    HorizontalAlignment="Left"
+                                    Style="{StaticResource DefTextBox}" />
+                                <TextBlock
+                                    Width="400"
+                                    Margin="{StaticResource Margin4}"
+                                    VerticalAlignment="Center"
+                                    Style="{StaticResource ToolbarTextBlock}"
+                                    Text="{x:Static resx:ResUI.TbFullCertTips}"
+                                    TextWrapping="Wrap" />
                                 <TextBox
                                     x:Name="txtCert"
                                     Width="400"

--- a/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
@@ -181,6 +181,7 @@ public partial class AddServerWindow
             this.Bind(ViewModel, vm => vm.SelectedSource.AllowInsecure, v => v.cmbAllowInsecure.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Fingerprint, v => v.cmbFingerprint.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Alpn, v => v.cmbAlpn.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.CertSha, v => v.txtCertSha256Pinning.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.CertTip, v => v.labCertPinning.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.Cert, v => v.txtCert.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.Cert, v => v.txtCert.Text).DisposeWith(disposables);


### PR DESCRIPTION
固定证书指纹，并添加分享链接 pcs

目前的想法是：当完整证书已填写且可用时，完整证书优先
所以如果界面上填写了格式正确的完整证书，证书指纹将被生成覆盖
配置生成也是优先使用完整证书，然后是证书指纹

<img width="611" height="542" alt="image" src="https://github.com/user-attachments/assets/90b136ce-9556-4f64-a78a-b230da9e2e42" />
