### PR TITLE
feat(Desktop): Enable color emoji flag rendering on Windows

### DIFF
--- a/v2rayN/Directory.Packages.props
+++ b/v2rayN/Directory.Packages.props
@@ -27,6 +27,8 @@
     <PackageVersion Include="TaskScheduler" Version="2.12.2" />
     <PackageVersion Include="WebDav.Client" Version="2.9.0" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
+    <PackageVersion Include="SkiaSharp" Version="3.119.0" />
+    <PackageVersion Include="HarfBuzzSharp" Version="8.3.1.1" />
     <PackageVersion Include="ZXing.Net.Bindings.SkiaSharp" Version="0.16.14" />
   </ItemGroup>
 </Project>

--- a/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
+++ b/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs
@@ -16,6 +16,13 @@ public static class AppBuilderExtension
                 FontFamily = new FontFamily("Noto Color Emoji")
             });
         }
+        else if (OperatingSystem.IsWindows())
+        {
+            fallbacks.Add(new FontFallback
+            {
+                FontFamily = new FontFamily("Segoe UI Emoji")
+            });
+        }
 
         return appBuilder.With(new FontManagerOptions
         {

--- a/v2rayN/v2rayN.Desktop/v2rayN.Desktop.csproj
+++ b/v2rayN/v2rayN.Desktop/v2rayN.Desktop.csproj
@@ -28,6 +28,8 @@
 		<PackageReference Include="ReactiveUI.Fody">
 			<TreatAsUsed>true</TreatAsUsed>
 		</PackageReference>
+		<PackageReference Include="SkiaSharp" />
+		<PackageReference Include="HarfBuzzSharp" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION

## Problem
v2rayN 不显示emoji国旗，使用[这篇文章](https://v2rayssr.com/windows-emoji.html)上提到的方法添加字体和修改注册表，能够显示国旗但是是黑白的。
v2rayN Avalonia版本在Windows上无法渲染彩色emoji国旗，只显示黑白。
## Root Cause
Avalonia 11.3.x 默认依赖的 SkiaSharp 2.88.x 对COLR彩色字体的渲染支持不完整。
## Solution
- Upgrade SkiaSharp to 3.119.0 for full COLR/CPAL color font support
- Add HarfBuzzSharp 8.3.1.1 for text shaping support
- Add Windows font fallback for Segoe UI Emoji
## Changes
- [Directory.Packages.props](cci:7://file:///c:/hqyz/code/v2rayN/v2rayN/Directory.Packages.props:0:0-0:0): Add SkiaSharp 3.119.0 and HarfBuzzSharp 8.3.1.1
- [v2rayN.Desktop.csproj](cci:7://file:///c:/hqyz/code/v2rayN/v2rayN/v2rayN.Desktop/v2rayN.Desktop.csproj:0:0-0:0): Add package references
- [AppBuilderExtension.cs](cci:7://file:///c:/hqyz/code/v2rayN/v2rayN/v2rayN.Desktop/Common/AppBuilderExtension.cs:0:0-0:0): Add Windows platform Segoe UI Emoji font fallback
## Testing
- ✅ Build successful on Windows 11
- ✅ Color emoji flags display correctly

## 修改前显示效果
<img width="199" height="175" alt="before" src="https://github.com/user-attachments/assets/d66a0860-9e7b-4217-89a1-2fb71270d88a" />

## 修改后显示效果
<img width="220" height="194" alt="after" src="https://github.com/user-attachments/assets/d0267fc1-30b4-48dd-a67a-bad02fed7567" />