### PR TITLE
Disable insecure when cert pinned

### DIFF
--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
@@ -325,6 +325,7 @@ public partial class CoreConfigV2rayService
                 else if (!node.CertSha.IsNullOrEmpty())
                 {
                     tlsSettings.pinnedPeerCertSha256 = node.CertSha;
+                    tlsSettings.allowInsecure = false;
                 }
                 streamSettings.tlsSettings = tlsSettings;
             }


### PR DESCRIPTION
设置了证书指纹时，`allowInsecure` 设为 false

xray v26.1.31 中，如果 allowInsecure == true 直接 FATAL 禁止启动
https://github.com/XTLS/Xray-core/blob/20cf00c27159aea831584ffa08db63c54fbc5f54/infra/conf/transport_internet.go#L747-L749