### PR TITLE
Refactor core config gen

### DIFF
--- a/v2rayN/ServiceLib/Global.cs
+++ b/v2rayN/ServiceLib/Global.cs
@@ -15,7 +15,6 @@ public class Global
     public const string CoreConfigFileName = "config.json";
     public const string CorePreConfigFileName = "configPre.json";
     public const string CoreSpeedtestConfigFileName = "configTest{0}.json";
-    public const string CoreMultipleLoadConfigFileName = "configMultipleLoad.json";
     public const string ClashMixinConfigFileName = "Mixin.yaml";
 
     public const string NamespaceSample = "ServiceLib.Sample.";

--- a/v2rayN/ServiceLib/Global.cs
+++ b/v2rayN/ServiceLib/Global.cs
@@ -88,7 +88,6 @@ public class Global
     public const string SingboxLocalDNSTag = "local_local";
     public const string SingboxHostsDNSTag = "hosts_dns";
     public const string SingboxFakeDNSTag = "fake_dns";
-    public const string SingboxEchDNSTag = "ech_dns";
 
     public const int Hysteria2DefaultHopInt = 10;
 

--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -1231,26 +1231,16 @@ public static class ConfigHandler
     /// <param name="node">Server node that might need pre-SOCKS</param>
     /// <param name="coreType">Core type being used</param>
     /// <returns>A SOCKS profile item or null if not needed</returns>
-    public static async Task<ProfileItem?> GetPreSocksItem(Config config, ProfileItem node, ECoreType coreType)
+    public static ProfileItem? GetPreSocksItem(Config config, ProfileItem node, ECoreType coreType)
     {
         ProfileItem? itemSocks = null;
         if (node.ConfigType != EConfigType.Custom && coreType != ECoreType.sing_box && config.TunModeItem.EnableTun)
         {
-            var tun2SocksAddress = node.Address;
-            if (node.ConfigType.IsGroupType())
-            {
-                var lstAddresses = (await GroupProfileManager.GetAllChildDomainAddresses(node)).ToList();
-                if (lstAddresses.Count > 0)
-                {
-                    tun2SocksAddress = Utils.List2String(lstAddresses);
-                }
-            }
             itemSocks = new ProfileItem()
             {
                 CoreType = ECoreType.sing_box,
                 ConfigType = EConfigType.SOCKS,
                 Address = Global.Loopback,
-                SpiderX = tun2SocksAddress, // Tun2SocksAddress
                 Port = AppManager.Instance.GetLocalPort(EInboundProtocol.socks)
             };
         }
@@ -1265,7 +1255,6 @@ public static class ConfigHandler
                 Port = node.PreSocksPort.Value,
             };
         }
-        await Task.CompletedTask;
         return itemSocks;
     }
 

--- a/v2rayN/ServiceLib/Handler/CoreConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/CoreConfigHandler.cs
@@ -98,9 +98,9 @@ public static class CoreConfigHandler
         var ids = selecteds.Where(serverTestItem => !serverTestItem.IndexId.IsNullOrEmpty())
             .Select(serverTestItem => serverTestItem.IndexId!)
             .ToList();
-        foreach (var id in ids)
+        var nodes = await AppManager.Instance.GetProfileItemsByIndexIds(ids);
+        foreach (var node in nodes)
         {
-            var node = await AppManager.Instance.GetProfileItem(id) ?? new();
             await FillNodeContext(context, node, false);
         }
         if (coreType == ECoreType.sing_box)

--- a/v2rayN/ServiceLib/Handler/CoreConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/CoreConfigHandler.cs
@@ -7,27 +7,28 @@ public static class CoreConfigHandler
 {
     private static readonly string _tag = "CoreConfigHandler";
 
-    public static async Task<RetResult> GenerateClientConfig(ProfileItem node, string? fileName)
+    public static async Task<RetResult> GenerateClientConfig(CoreConfigContext context, string? fileName)
     {
         var config = AppManager.Instance.Config;
         var result = new RetResult();
+        var node = context.Node;
 
         if (node.ConfigType == EConfigType.Custom)
         {
             result = node.CoreType switch
             {
                 ECoreType.mihomo => await new CoreConfigClashService(config).GenerateClientCustomConfig(node, fileName),
-                ECoreType.sing_box => await new CoreConfigSingboxService(config).GenerateClientCustomConfig(node, fileName),
+                ECoreType.sing_box => await new CoreConfigSingboxService(context).GenerateClientCustomConfig(fileName),
                 _ => await GenerateClientCustomConfig(node, fileName)
             };
         }
         else if (AppManager.Instance.GetCoreType(node, node.ConfigType) == ECoreType.sing_box)
         {
-            result = await new CoreConfigSingboxService(config).GenerateClientConfigContent(node);
+            result = new CoreConfigSingboxService(context).GenerateClientConfigContent();
         }
         else
         {
-            result = await new CoreConfigV2rayService(config).GenerateClientConfigContent(node);
+            result = new CoreConfigV2rayService(context).GenerateClientConfigContent();
         }
         if (result.Success != true)
         {
@@ -93,13 +94,22 @@ public static class CoreConfigHandler
     public static async Task<RetResult> GenerateClientSpeedtestConfig(Config config, string fileName, List<ServerTestItem> selecteds, ECoreType coreType)
     {
         var result = new RetResult();
+        var context = await BuildCoreConfigContext(config, new());
+        foreach (var serverTestItem in selecteds.Where(serverTestItem => !serverTestItem.IndexId.IsNullOrEmpty()))
+        {
+            var node = await AppManager.Instance.GetProfileItem(serverTestItem.IndexId!);
+            if (node != null)
+            {
+                await FillNodeContext(context, node, false);
+            }
+        }
         if (coreType == ECoreType.sing_box)
         {
-            result = await new CoreConfigSingboxService(config).GenerateClientSpeedtestConfig(selecteds);
+            result = new CoreConfigSingboxService(context).GenerateClientSpeedtestConfig(selecteds);
         }
         else if (coreType == ECoreType.Xray)
         {
-            result = await new CoreConfigV2rayService(config).GenerateClientSpeedtestConfig(selecteds);
+            result = new CoreConfigV2rayService(context).GenerateClientSpeedtestConfig(selecteds);
         }
         if (result.Success != true)
         {
@@ -109,20 +119,21 @@ public static class CoreConfigHandler
         return result;
     }
 
-    public static async Task<RetResult> GenerateClientSpeedtestConfig(Config config, ProfileItem node, ServerTestItem testItem, string fileName)
+    public static async Task<RetResult> GenerateClientSpeedtestConfig(Config config, CoreConfigContext context, ServerTestItem testItem, string fileName)
     {
         var result = new RetResult();
+        var node = context.Node;
         var initPort = AppManager.Instance.GetLocalPort(EInboundProtocol.speedtest);
         var port = Utils.GetFreePort(initPort + testItem.QueueNum);
         testItem.Port = port;
 
         if (AppManager.Instance.GetCoreType(node, node.ConfigType) == ECoreType.sing_box)
         {
-            result = await new CoreConfigSingboxService(config).GenerateClientSpeedtestConfig(node, port);
+            result = new CoreConfigSingboxService(context).GenerateClientSpeedtestConfig(port);
         }
         else
         {
-            result = await new CoreConfigV2rayService(config).GenerateClientSpeedtestConfig(node, port);
+            result = new CoreConfigV2rayService(context).GenerateClientSpeedtestConfig(port);
         }
         if (result.Success != true)
         {
@@ -131,5 +142,121 @@ public static class CoreConfigHandler
 
         await File.WriteAllTextAsync(fileName, result.Data.ToString());
         return result;
+    }
+
+    public static async Task<CoreConfigContext> BuildCoreConfigContext(Config config, ProfileItem node)
+    {
+        var coreType = AppManager.Instance.GetCoreType(node, node.ConfigType) == ECoreType.sing_box ? ECoreType.sing_box : ECoreType.Xray;
+        var context = new CoreConfigContext()
+        {
+            Node = node,
+            AllProxiesMap = [],
+            AppConfig = config,
+            FullConfigTemplate = await AppManager.Instance.GetFullConfigTemplateItem(coreType),
+            IsTunEnabled = config.TunModeItem.EnableTun,
+            SimpleDnsItem = config.SimpleDNSItem,
+            ProtectDomainList = [],
+            ProtectSocksPort = 0,
+            RawDnsItem = await AppManager.Instance.GetDNSItem(coreType),
+            RoutingItem = await ConfigHandler.GetDefaultRouting(config),
+        };
+        context = context with
+        {
+            Node = await FillNodeContext(context, node)
+        };
+        if (!(context.RoutingItem?.RuleSet.IsNullOrEmpty() ?? true))
+        {
+            var rules = JsonUtils.Deserialize<List<RulesItem>>(context.RoutingItem?.RuleSet);
+            foreach (var ruleItem in rules.Where(ruleItem => !Global.OutboundTags.Contains(ruleItem.OutboundTag)))
+            {
+                var ruleOutboundNode = await AppManager.Instance.GetProfileItemViaRemarks(ruleItem.OutboundTag);
+                if (ruleOutboundNode != null)
+                {
+                    await FillNodeContext(context, ruleOutboundNode);
+                }
+            }
+        }
+        return context;
+    }
+
+    private static async Task<ProfileItem> FillNodeContext(CoreConfigContext context, ProfileItem node, bool includeSubChain = true)
+    {
+        if (node.IndexId.IsNullOrEmpty())
+        {
+            return node;
+        }
+        context.AllProxiesMap[node.IndexId] = node;
+        if (node.ConfigType.IsGroupType())
+        {
+            var groupChildList = await GroupProfileManager.GetAllChildProfileItems(node);
+            foreach (var childItem in groupChildList)
+            {
+                context.AllProxiesMap[childItem.IndexId] = childItem;
+            }
+        }
+
+        foreach (var profileItemPair in context.AllProxiesMap)
+        {
+            var address = profileItemPair.Value.Address;
+            if (Utils.IsDomain(address))
+            {
+                context.ProtectDomainList.Add(address);
+            }
+
+            if (profileItemPair.Value.EchConfigList.IsNullOrEmpty())
+            {
+                continue;
+            }
+
+            var echQuerySni = profileItemPair.Value.Sni;
+            if (profileItemPair.Value.StreamSecurity == Global.StreamSecurity
+                && profileItemPair.Value.EchConfigList?.Contains("://") == true)
+            {
+                var idx = profileItemPair.Value.EchConfigList.IndexOf('+');
+                echQuerySni = idx > 0 ? profileItemPair.Value.EchConfigList[..idx] : profileItemPair.Value.Sni;
+            }
+            if (!Utils.IsDomain(echQuerySni))
+            {
+                continue;
+            }
+            context.ProtectDomainList.Add(echQuerySni);
+        }
+
+        if (!includeSubChain || node.Subid.IsNullOrEmpty())
+        {
+            return node;
+        }
+
+        var subItem = await AppManager.Instance.GetSubItem(node.Subid);
+        if (subItem == null)
+        {
+            return node;
+        }
+        var prevNode = await AppManager.Instance.GetProfileItemViaRemarks(subItem.PrevProfile);
+        var nextNode = await AppManager.Instance.GetProfileItemViaRemarks(subItem.NextProfile);
+        if (prevNode is null && nextNode is null)
+        {
+            return node;
+        }
+
+        var prevNodeAct = prevNode is null ? null : await FillNodeContext(context, prevNode, false);
+        var nextNodeAct = nextNode is null ? null : await FillNodeContext(context, nextNode, false);
+
+        // Build new proxy chain node
+        var chainNode = new ProfileItem()
+        {
+            IndexId = $"inner-{Utils.GetGuid(false)}",
+            ConfigType = EConfigType.ProxyChain,
+            CoreType = node.CoreType ?? ECoreType.Xray,
+        };
+        List<string?> childItems = [prevNodeAct?.IndexId, node.IndexId, nextNodeAct?.IndexId];
+        var chainExtraItem = chainNode.GetProtocolExtra() with
+        {
+            GroupType = chainNode.ConfigType.ToString(),
+            ChildItems = string.Join(",", childItems.Where(x => !x.IsNullOrEmpty())),
+        };
+        chainNode.SetProtocolExtra(chainExtraItem);
+        context.AllProxiesMap[chainNode.IndexId] = chainNode;
+        return chainNode;
     }
 }

--- a/v2rayN/ServiceLib/Manager/AppManager.cs
+++ b/v2rayN/ServiceLib/Manager/AppManager.cs
@@ -230,6 +230,18 @@ public sealed class AppManager
         return await SQLiteHelper.Instance.TableAsync<ProfileItem>().FirstOrDefaultAsync(it => it.IndexId == indexId);
     }
 
+    public async Task<List<ProfileItem>> GetProfileItemsByIndexIds(List<string> indexIds)
+    {
+        var ids = indexIds.Where(id => id.IsNotEmpty()).Distinct().ToList();
+        if (ids.Count == 0)
+        {
+            return [];
+        }
+        return await SQLiteHelper.Instance.TableAsync<ProfileItem>()
+            .Where(it => ids.Contains(it.IndexId))
+            .ToListAsync();
+    }
+
     public async Task<ProfileItem?> GetProfileItemViaRemarks(string? remarks)
     {
         if (remarks.IsNullOrEmpty())

--- a/v2rayN/ServiceLib/Manager/AppManager.cs
+++ b/v2rayN/ServiceLib/Manager/AppManager.cs
@@ -230,9 +230,9 @@ public sealed class AppManager
         return await SQLiteHelper.Instance.TableAsync<ProfileItem>().FirstOrDefaultAsync(it => it.IndexId == indexId);
     }
 
-    public async Task<List<ProfileItem>> GetProfileItemsByIndexIds(List<string> indexIds)
+    public async Task<List<ProfileItem>> GetProfileItemsByIndexIds(IEnumerable<string> indexIds)
     {
-        var ids = indexIds.Where(id => id.IsNotEmpty()).Distinct().ToList();
+        var ids = indexIds.Where(id => !id.IsNullOrEmpty()).Distinct().ToList();
         if (ids.Count == 0)
         {
             return [];

--- a/v2rayN/ServiceLib/Models/CoreConfigContext.cs
+++ b/v2rayN/ServiceLib/Models/CoreConfigContext.cs
@@ -1,0 +1,17 @@
+namespace ServiceLib.Models;
+
+public record CoreConfigContext
+{
+    public required ProfileItem Node { get; init; }
+    public RoutingItem? RoutingItem { get; init; }
+    public DNSItem? RawDnsItem { get; init; }
+    public SimpleDNSItem SimpleDnsItem { get; init; } = new();
+    public Dictionary<string, ProfileItem> AllProxiesMap { get; init; } = new();
+    public Config AppConfig { get; init; } = new();
+    public FullConfigTemplateItem? FullConfigTemplate { get; init; } = new();
+
+    // TUN Compatibility
+    public bool IsTunEnabled { get; init; } = false;
+    public HashSet<string> ProtectDomainList { get; init; } = new();
+    public int ProtectSocksPort { get; init; } = 0;
+}

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -254,14 +254,6 @@ public class Server4Sbox : BaseServer4Sbox
 
     // public List<string>? path { get; set; } // hosts
     public Dictionary<string, List<string>>? predefined { get; set; }
-
-    // Deprecated
-    public string? address { get; set; }
-
-    public string? address_resolver { get; set; }
-    public string? address_strategy { get; set; }
-    public string? strategy { get; set; }
-    // Deprecated End
 }
 
 public class Experimental4Sbox

--- a/v2rayN/ServiceLib/Models/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/SingboxConfig.cs
@@ -254,6 +254,13 @@ public class Server4Sbox : BaseServer4Sbox
 
     // public List<string>? path { get; set; } // hosts
     public Dictionary<string, List<string>>? predefined { get; set; }
+
+    // Deprecated in sing-box 1.12.0 , kept for backward compatibility
+    public string? address { get; set; }
+    public string? address_resolver { get; set; }
+    public string? address_strategy { get; set; }
+    public string? strategy { get; set; }
+    // Deprecated End
 }
 
 public class Experimental4Sbox

--- a/v2rayN/ServiceLib/Sample/SampleClientConfig
+++ b/v2rayN/ServiceLib/Sample/SampleClientConfig
@@ -1,4 +1,4 @@
-﻿{
+{
 	"log": {
 		"access": "Vaccess.log",
 		"error": "Verror.log",
@@ -6,34 +6,6 @@
 	},
 	"inbounds": [],
 	"outbounds": [
-		{
-			"tag": "proxy",
-			"protocol": "vmess",
-			"settings": {
-				"vnext": [{
-					"address": "",
-					"port": 0,
-					"users": [{
-						"id": "",
-						"security": "auto"
-					}]
-				}],
-				"servers": [{
-					"address": "",
-					"method": "",
-					"ota": false,
-					"password": "",
-					"port": 0,
-					"level": 1
-				}]
-			},
-			"streamSettings": {
-				"network": "tcp"
-			},
-			"mux": {
-				"enabled": false
-			}
-		},
 		{
 			"protocol": "freedom",
 			"tag": "direct"

--- a/v2rayN/ServiceLib/Sample/SingboxSampleClientConfig
+++ b/v2rayN/ServiceLib/Sample/SingboxSampleClientConfig
@@ -6,18 +6,11 @@
 	"inbounds": [],
 	"outbounds": [
 		{
-			"type": "vless",
-			"tag": "proxy",
-			"server": "",
-			"server_port": 443
-		},
-		{
 			"type": "direct",
 			"tag": "direct"
 		}
 	],
 	"route": {
-		"rules": [
-		]
+		"rules": []
 	}
 }

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxConfigTemplateService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxConfigTemplateService.cs
@@ -2,29 +2,29 @@ namespace ServiceLib.Services.CoreConfig;
 
 public partial class CoreConfigSingboxService
 {
-    private async Task<string> ApplyFullConfigTemplate(SingboxConfig singboxConfig)
+    private string ApplyFullConfigTemplate()
     {
-        var fullConfigTemplate = await AppManager.Instance.GetFullConfigTemplateItem(ECoreType.sing_box);
-        if (fullConfigTemplate == null || !fullConfigTemplate.Enabled)
+        var fullConfigTemplate = context.FullConfigTemplate;
+        if (fullConfigTemplate is not { Enabled: true })
         {
-            return JsonUtils.Serialize(singboxConfig);
+            return JsonUtils.Serialize(_coreConfig);
         }
 
-        var fullConfigTemplateItem = _config.TunModeItem.EnableTun ? fullConfigTemplate.TunConfig : fullConfigTemplate.Config;
+        var fullConfigTemplateItem = context.IsTunEnabled ? fullConfigTemplate.TunConfig : fullConfigTemplate.Config;
         if (fullConfigTemplateItem.IsNullOrEmpty())
         {
-            return JsonUtils.Serialize(singboxConfig);
+            return JsonUtils.Serialize(_coreConfig);
         }
 
         var fullConfigTemplateNode = JsonNode.Parse(fullConfigTemplateItem);
         if (fullConfigTemplateNode == null)
         {
-            return JsonUtils.Serialize(singboxConfig);
+            return JsonUtils.Serialize(_coreConfig);
         }
 
         // Process outbounds
         var customOutboundsNode = fullConfigTemplateNode["outbounds"] is JsonArray outbounds ? outbounds : new JsonArray();
-        foreach (var outbound in singboxConfig.outbounds)
+        foreach (var outbound in _coreConfig.outbounds)
         {
             if (outbound.type.ToLower() is "direct" or "block")
             {
@@ -42,10 +42,10 @@ public partial class CoreConfigSingboxService
         fullConfigTemplateNode["outbounds"] = customOutboundsNode;
 
         // Process endpoints
-        if (singboxConfig.endpoints != null && singboxConfig.endpoints.Count > 0)
+        if (_coreConfig.endpoints != null && _coreConfig.endpoints.Count > 0)
         {
             var customEndpointsNode = fullConfigTemplateNode["endpoints"] is JsonArray endpoints ? endpoints : new JsonArray();
-            foreach (var endpoint in singboxConfig.endpoints)
+            foreach (var endpoint in _coreConfig.endpoints)
             {
                 if (endpoint.detour.IsNullOrEmpty() && !fullConfigTemplate.ProxyDetour.IsNullOrEmpty())
                 {
@@ -56,6 +56,6 @@ public partial class CoreConfigSingboxService
             fullConfigTemplateNode["endpoints"] = customEndpointsNode;
         }
 
-        return await Task.FromResult(JsonUtils.Serialize(fullConfigTemplateNode));
+        return JsonUtils.Serialize(fullConfigTemplateNode);
     }
 }

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxConfigTemplateService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxConfigTemplateService.cs
@@ -23,7 +23,7 @@ public partial class CoreConfigSingboxService
         }
 
         // Process outbounds
-        var customOutboundsNode = fullConfigTemplateNode["outbounds"] is JsonArray outbounds ? outbounds : new JsonArray();
+        var customOutboundsNode = fullConfigTemplateNode["outbounds"] is JsonArray outbounds ? outbounds : [];
         foreach (var outbound in _coreConfig.outbounds)
         {
             if (outbound.type.ToLower() is "direct" or "block")
@@ -44,7 +44,7 @@ public partial class CoreConfigSingboxService
         // Process endpoints
         if (_coreConfig.endpoints != null && _coreConfig.endpoints.Count > 0)
         {
-            var customEndpointsNode = fullConfigTemplateNode["endpoints"] is JsonArray endpoints ? endpoints : new JsonArray();
+            var customEndpointsNode = fullConfigTemplateNode["endpoints"] is JsonArray endpoints ? endpoints : [];
             foreach (var endpoint in _coreConfig.endpoints)
             {
                 if (endpoint.detour.IsNullOrEmpty() && !fullConfigTemplate.ProxyDetour.IsNullOrEmpty())

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxDnsService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxDnsService.cs
@@ -2,25 +2,25 @@ namespace ServiceLib.Services.CoreConfig;
 
 public partial class CoreConfigSingboxService
 {
-    private async Task<int> GenDns(ProfileItem? node, SingboxConfig singboxConfig)
+    private void GenDns()
     {
         try
         {
-            var item = await AppManager.Instance.GetDNSItem(ECoreType.sing_box);
-            if (item != null && item.Enabled == true)
+            var item = context.RawDnsItem;
+            if (item is { Enabled: true })
             {
-                return await GenDnsCompatible(node, singboxConfig);
+                GenDnsCustom();
+                return;
             }
 
-            var simpleDNSItem = _config.SimpleDNSItem;
-            await GenDnsServers(node, singboxConfig, simpleDNSItem);
-            await GenDnsRules(node, singboxConfig, simpleDNSItem);
+            GenDnsServers();
+            GenDnsRules();
 
-            singboxConfig.dns ??= new Dns4Sbox();
-            singboxConfig.dns.independent_cache = true;
+            _coreConfig.dns ??= new Dns4Sbox();
+            _coreConfig.dns.independent_cache = true;
 
             // final dns
-            var routing = await ConfigHandler.GetDefaultRouting(_config);
+            var routing = context.RoutingItem;
             var useDirectDns = false;
             if (routing != null)
             {
@@ -32,35 +32,34 @@ public partial class CoreConfigSingboxService
                                    lastRule.Network == "tcp,udp" ||
                                    lastRule.Ip?.Contains("0.0.0.0/0") == true);
             }
-            singboxConfig.dns.final = useDirectDns ? Global.SingboxDirectDNSTag : Global.SingboxRemoteDNSTag;
-            if ((!useDirectDns) && simpleDNSItem.FakeIP == true && simpleDNSItem.GlobalFakeIp == false)
+            _coreConfig.dns.final = useDirectDns ? Global.SingboxDirectDNSTag : Global.SingboxRemoteDNSTag;
+            var simpleDnsItem = context.SimpleDnsItem;
+            if ((!useDirectDns) && simpleDnsItem.FakeIP == true && simpleDnsItem.GlobalFakeIp == false)
             {
-                singboxConfig.dns.rules.Add(new()
+                _coreConfig.dns.rules.Add(new()
                 {
                     server = Global.SingboxFakeDNSTag,
                     query_type = new List<int> { 1, 28 }, // A and AAAA
                     rewrite_ttl = 1,
                 });
             }
-
-            await GenOutboundDnsRule(node, singboxConfig);
         }
         catch (Exception ex)
         {
             Logging.SaveLog(_tag, ex);
         }
-        return 0;
     }
 
-    private async Task<int> GenDnsServers(ProfileItem? node, SingboxConfig singboxConfig, SimpleDNSItem simpleDNSItem)
+    private void GenDnsServers()
     {
-        var finalDns = await GenDnsDomains(singboxConfig, simpleDNSItem);
+        var simpleDnsItem = context.SimpleDnsItem;
+        var finalDns = GenBootstrapDns();
 
-        var directDns = ParseDnsAddress(simpleDNSItem.DirectDNS);
+        var directDns = ParseDnsAddress(simpleDnsItem.DirectDNS ?? Global.DomainDirectDNSAddress.First());
         directDns.tag = Global.SingboxDirectDNSTag;
         directDns.domain_resolver = Global.SingboxLocalDNSTag;
 
-        var remoteDns = ParseDnsAddress(simpleDNSItem.RemoteDNS);
+        var remoteDns = ParseDnsAddress(simpleDnsItem.RemoteDNS ?? Global.DomainRemoteDNSAddress.First());
         remoteDns.tag = Global.SingboxRemoteDNSTag;
         remoteDns.detour = Global.ProxyTag;
         remoteDns.domain_resolver = Global.SingboxLocalDNSTag;
@@ -71,12 +70,12 @@ public partial class CoreConfigSingboxService
             type = "hosts",
             predefined = new(),
         };
-        if (simpleDNSItem.AddCommonHosts == true)
+        if (simpleDnsItem.AddCommonHosts == true)
         {
             hostsDns.predefined = Global.PredefinedHosts;
         }
 
-        if (simpleDNSItem.UseSystemHosts == true)
+        if (simpleDnsItem.UseSystemHosts == true)
         {
             var systemHosts = Utils.GetSystemHosts();
             if (systemHosts != null && systemHosts.Count > 0)
@@ -88,9 +87,9 @@ public partial class CoreConfigSingboxService
             }
         }
 
-        foreach (var kvp in Utils.ParseHostsToDictionary(simpleDNSItem.Hosts))
+        foreach (var kvp in Utils.ParseHostsToDictionary(simpleDnsItem.Hosts))
         {
-            hostsDns.predefined[kvp.Key] = kvp.Value.Where(s => Utils.IsIpAddress(s)).ToList();
+            hostsDns.predefined[kvp.Key] = kvp.Value.Where(Utils.IsIpAddress).ToList();
         }
 
         foreach (var host in hostsDns.predefined)
@@ -109,14 +108,14 @@ public partial class CoreConfigSingboxService
             }
         }
 
-        singboxConfig.dns ??= new Dns4Sbox();
-        singboxConfig.dns.servers ??= [];
-        singboxConfig.dns.servers.Add(remoteDns);
-        singboxConfig.dns.servers.Add(directDns);
-        singboxConfig.dns.servers.Add(hostsDns);
+        _coreConfig.dns ??= new Dns4Sbox();
+        _coreConfig.dns.servers ??= [];
+        _coreConfig.dns.servers.Add(remoteDns);
+        _coreConfig.dns.servers.Add(directDns);
+        _coreConfig.dns.servers.Add(hostsDns);
 
         // fake ip
-        if (simpleDNSItem.FakeIP == true)
+        if (simpleDnsItem.FakeIP == true)
         {
             var fakeip = new Server4Sbox
             {
@@ -125,68 +124,50 @@ public partial class CoreConfigSingboxService
                 inet4_range = "198.18.0.0/15",
                 inet6_range = "fc00::/18",
             };
-            singboxConfig.dns.servers.Add(fakeip);
+            _coreConfig.dns.servers.Add(fakeip);
         }
-
-        // ech
-        var (_, dnsServer) = ParseEchParam(node?.EchConfigList);
-        if (dnsServer is not null)
-        {
-            dnsServer.tag = Global.SingboxEchDNSTag;
-            if (dnsServer.server is not null
-                && hostsDns.predefined.ContainsKey(dnsServer.server))
-            {
-                dnsServer.domain_resolver = Global.SingboxHostsDNSTag;
-            }
-            else
-            {
-                dnsServer.domain_resolver = Global.SingboxLocalDNSTag;
-            }
-            singboxConfig.dns.servers.Add(dnsServer);
-        }
-        else if (node?.ConfigType.IsGroupType() == true)
-        {
-            var echDnsObject = JsonUtils.DeepCopy(directDns);
-            echDnsObject.tag = Global.SingboxEchDNSTag;
-            singboxConfig.dns.servers.Add(echDnsObject);
-        }
-
-        return await Task.FromResult(0);
     }
 
-    private async Task<Server4Sbox> GenDnsDomains(SingboxConfig singboxConfig, SimpleDNSItem? simpleDNSItem)
+    private Server4Sbox GenBootstrapDns()
     {
-        var finalDns = ParseDnsAddress(simpleDNSItem.BootstrapDNS);
+        var finalDns = ParseDnsAddress(context.SimpleDnsItem?.BootstrapDNS ?? Global.DomainPureIPDNSAddress.First());
         finalDns.tag = Global.SingboxLocalDNSTag;
-        singboxConfig.dns ??= new Dns4Sbox();
-        singboxConfig.dns.servers ??= new List<Server4Sbox>();
-        singboxConfig.dns.servers.Add(finalDns);
-        return await Task.FromResult(finalDns);
+        _coreConfig.dns ??= new Dns4Sbox();
+        _coreConfig.dns.servers ??= [];
+        _coreConfig.dns.servers.Add(finalDns);
+        return finalDns;
     }
 
-    private async Task<int> GenDnsRules(ProfileItem? node, SingboxConfig singboxConfig, SimpleDNSItem simpleDNSItem)
+    private void GenDnsRules()
     {
-        singboxConfig.dns ??= new Dns4Sbox();
-        singboxConfig.dns.rules ??= new List<Rule4Sbox>();
+        var simpleDnsItem = context.SimpleDnsItem;
+        _coreConfig.dns ??= new Dns4Sbox();
+        _coreConfig.dns.rules ??= [];
 
-        singboxConfig.dns.rules.AddRange(new[]
+        _coreConfig.dns.rules.AddRange(new[]
         {
             new Rule4Sbox { ip_accept_any = true, server = Global.SingboxHostsDNSTag },
             new Rule4Sbox
             {
+                server = Global.SingboxDirectDNSTag,
+                strategy = Utils.DomainStrategy4Sbox(simpleDnsItem.Strategy4Freedom),
+                domain = context.ProtectDomainList.ToList(),
+            },
+            new Rule4Sbox
+            {
                 server = Global.SingboxRemoteDNSTag,
-                strategy = Utils.DomainStrategy4Sbox(simpleDNSItem.Strategy4Proxy),
+                strategy = Utils.DomainStrategy4Sbox(simpleDnsItem.Strategy4Proxy),
                 clash_mode = ERuleMode.Global.ToString()
             },
             new Rule4Sbox
             {
                 server = Global.SingboxDirectDNSTag,
-                strategy = Utils.DomainStrategy4Sbox(simpleDNSItem.Strategy4Freedom),
+                strategy = Utils.DomainStrategy4Sbox(simpleDnsItem.Strategy4Freedom),
                 clash_mode = ERuleMode.Direct.ToString()
             }
         });
 
-        foreach (var kvp in Utils.ParseHostsToDictionary(simpleDNSItem.Hosts))
+        foreach (var kvp in Utils.ParseHostsToDictionary(simpleDnsItem.Hosts))
         {
             var predefined = kvp.Value.First();
             if (predefined.IsNullOrEmpty() || Utils.IsIpAddress(predefined))
@@ -197,7 +178,7 @@ public partial class CoreConfigSingboxService
             {
                 // xray syntactic sugar for predefined
                 // etc. #0 -> NOERROR
-                singboxConfig.dns.rules.Add(new()
+                _coreConfig.dns.rules.Add(new()
                 {
                     query_type = [1, 28],
                     domain = [kvp.Key],
@@ -225,38 +206,13 @@ public partial class CoreConfigSingboxService
             };
             if (ParseV2Domain(kvp.Key, rule))
             {
-                singboxConfig.dns.rules.Add(rule);
+                _coreConfig.dns.rules.Add(rule);
             }
         }
 
-        var (ech, _) = ParseEchParam(node?.EchConfigList);
-        if (ech is not null)
+        if (simpleDnsItem.BlockBindingQuery == true)
         {
-            var echDomain = ech.query_server_name ?? node?.Sni;
-            singboxConfig.dns.rules.Add(new()
-            {
-                query_type = [64, 65],
-                server = Global.SingboxEchDNSTag,
-                domain = echDomain is not null ? new List<string> { echDomain } : null,
-            });
-        }
-        else if (node?.ConfigType.IsGroupType() == true)
-        {
-            var queryServerNames = (await GroupProfileManager.GetAllChildEchQuerySni(node)).ToList();
-            if (queryServerNames.Count > 0)
-            {
-                singboxConfig.dns.rules.Add(new()
-                {
-                    query_type = [64, 65],
-                    server = Global.SingboxEchDNSTag,
-                    domain = queryServerNames,
-                });
-            }
-        }
-
-        if (simpleDNSItem.BlockBindingQuery == true)
-        {
-            singboxConfig.dns.rules.Add(new()
+            _coreConfig.dns.rules.Add(new()
             {
                 query_type = [64, 65],
                 action = "predefined",
@@ -264,7 +220,7 @@ public partial class CoreConfigSingboxService
             });
         }
 
-        if (simpleDNSItem.FakeIP == true && simpleDNSItem.GlobalFakeIp == true)
+        if (simpleDnsItem.FakeIP == true && simpleDnsItem.GlobalFakeIp == true)
         {
             var fakeipFilterRule = JsonUtils.Deserialize<Rule4Sbox>(EmbedUtils.GetEmbedText(Global.SingboxFakeIPFilterFileName));
             fakeipFilterRule.invert = true;
@@ -284,13 +240,13 @@ public partial class CoreConfigSingboxService
                 ]
             };
 
-            singboxConfig.dns.rules.Add(rule4Fake);
+            _coreConfig.dns.rules.Add(rule4Fake);
         }
 
-        var routing = await ConfigHandler.GetDefaultRouting(_config);
+        var routing = context.RoutingItem;
         if (routing == null)
         {
-            return 0;
+            return;
         }
 
         var rules = JsonUtils.Deserialize<List<RulesItem>>(routing.RuleSet) ?? [];
@@ -298,9 +254,9 @@ public partial class CoreConfigSingboxService
         var expectedIPsRegions = new List<string>();
         var regionNames = new HashSet<string>();
 
-        if (!string.IsNullOrEmpty(simpleDNSItem?.DirectExpectedIPs))
+        if (!string.IsNullOrEmpty(simpleDnsItem?.DirectExpectedIPs))
         {
-            var ipItems = simpleDNSItem.DirectExpectedIPs
+            var ipItems = simpleDnsItem.DirectExpectedIPs
                 .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(s => s.Trim())
                 .Where(s => !string.IsNullOrEmpty(s))
@@ -348,7 +304,7 @@ public partial class CoreConfigSingboxService
             if (item.OutboundTag == Global.DirectTag)
             {
                 rule.server = Global.SingboxDirectDNSTag;
-                rule.strategy = Utils.DomainStrategy4Sbox(simpleDNSItem.Strategy4Freedom);
+                rule.strategy = Utils.DomainStrategy4Sbox(simpleDnsItem.Strategy4Freedom);
 
                 if (expectedIPsRegions.Count > 0 && rule.geosite?.Count > 0)
                 {
@@ -373,31 +329,41 @@ public partial class CoreConfigSingboxService
             }
             else
             {
-                if (simpleDNSItem.FakeIP == true && simpleDNSItem.GlobalFakeIp == false)
+                if (simpleDnsItem.FakeIP == true && simpleDnsItem.GlobalFakeIp == false)
                 {
                     var rule4Fake = JsonUtils.DeepCopy(rule);
                     rule4Fake.server = Global.SingboxFakeDNSTag;
                     rule4Fake.query_type = new List<int> { 1, 28 }; // A and AAAA
                     rule4Fake.rewrite_ttl = 1;
-                    singboxConfig.dns.rules.Add(rule4Fake);
+                    _coreConfig.dns.rules.Add(rule4Fake);
                 }
                 rule.server = Global.SingboxRemoteDNSTag;
-                rule.strategy = Utils.DomainStrategy4Sbox(simpleDNSItem.Strategy4Proxy);
+                rule.strategy = Utils.DomainStrategy4Sbox(simpleDnsItem.Strategy4Proxy);
             }
 
-            singboxConfig.dns.rules.Add(rule);
+            _coreConfig.dns.rules.Add(rule);
         }
-
-        return 0;
     }
 
-    private async Task<int> GenDnsCompatible(ProfileItem? node, SingboxConfig singboxConfig)
+    private void GenMinimizedDns()
+    {
+        GenDnsServers();
+        _coreConfig.dns ??= new();
+        _coreConfig.dns.rules.Clear();
+        _coreConfig.dns.final = Global.SingboxDirectDNSTag;
+        _coreConfig.route.default_domain_resolver = new()
+        {
+            server = Global.SingboxDirectDNSTag,
+        };
+    }
+
+    private void GenDnsCustom()
     {
         try
         {
-            var item = await AppManager.Instance.GetDNSItem(ECoreType.sing_box);
+            var item = context.RawDnsItem;
             var strDNS = string.Empty;
-            if (_config.TunModeItem.EnableTun)
+            if (context.IsTunEnabled)
             {
                 strDNS = string.IsNullOrEmpty(item?.TunDNS) ? EmbedUtils.GetEmbedText(Global.TunSingboxDNSFileName) : item?.TunDNS;
             }
@@ -409,31 +375,22 @@ public partial class CoreConfigSingboxService
             var dns4Sbox = JsonUtils.Deserialize<Dns4Sbox>(strDNS);
             if (dns4Sbox is null)
             {
-                return 0;
+                return;
             }
-            singboxConfig.dns = dns4Sbox;
+            _coreConfig.dns = dns4Sbox;
 
-            if (dns4Sbox.servers != null && dns4Sbox.servers.Count > 0 && dns4Sbox.servers.First().address.IsNullOrEmpty())
-            {
-                await GenDnsDomainsCompatible(singboxConfig, item);
-            }
-            else
-            {
-                await GenDnsDomainsLegacyCompatible(singboxConfig, item);
-            }
-
-            await GenOutboundDnsRule(node, singboxConfig);
+            GenDnsProtectCustom();
         }
         catch (Exception ex)
         {
             Logging.SaveLog(_tag, ex);
         }
-        return 0;
     }
 
-    private async Task<int> GenDnsDomainsCompatible(SingboxConfig singboxConfig, DNSItem? dnsItem)
+    private void GenDnsProtectCustom()
     {
-        var dns4Sbox = singboxConfig.dns ?? new();
+        var dnsItem = context.RawDnsItem;
+        var dns4Sbox = _coreConfig.dns ?? new();
         dns4Sbox.servers ??= [];
         dns4Sbox.rules ??= [];
 
@@ -445,86 +402,18 @@ public partial class CoreConfigSingboxService
         localDnsServer.tag = tag;
 
         dns4Sbox.servers.Add(localDnsServer);
+        dns4Sbox.rules.Insert(0, BuildProtectDomainRule());
 
-        singboxConfig.dns = dns4Sbox;
-        return await Task.FromResult(0);
+        _coreConfig.dns = dns4Sbox;
     }
 
-    private async Task<int> GenDnsDomainsLegacyCompatible(SingboxConfig singboxConfig, DNSItem? dnsItem)
+    private Rule4Sbox BuildProtectDomainRule()
     {
-        var dns4Sbox = singboxConfig.dns ?? new();
-        dns4Sbox.servers ??= [];
-        dns4Sbox.rules ??= [];
-
-        var tag = Global.SingboxLocalDNSTag;
-        dns4Sbox.servers.Add(new()
-        {
-            tag = tag,
-            address = string.IsNullOrEmpty(dnsItem?.DomainDNSAddress) ? Global.DomainPureIPDNSAddress.FirstOrDefault() : dnsItem?.DomainDNSAddress,
-            detour = Global.DirectTag,
-            strategy = string.IsNullOrEmpty(dnsItem?.DomainStrategy4Freedom) ? null : dnsItem?.DomainStrategy4Freedom,
-        });
-        dns4Sbox.rules.Insert(0, new()
-        {
-            server = tag,
-            clash_mode = ERuleMode.Direct.ToString()
-        });
-        dns4Sbox.rules.Insert(0, new()
-        {
-            server = dns4Sbox.servers.Where(t => t.detour == Global.ProxyTag).Select(t => t.tag).FirstOrDefault() ?? "remote",
-            clash_mode = ERuleMode.Global.ToString()
-        });
-
-        var lstDomain = singboxConfig.outbounds
-                       .Where(t => t.server.IsNotEmpty() && Utils.IsDomain(t.server))
-                       .Select(t => t.server)
-                       .Distinct()
-                       .ToList();
-        if (lstDomain != null && lstDomain.Count > 0)
-        {
-            dns4Sbox.rules.Insert(0, new()
-            {
-                server = tag,
-                domain = lstDomain
-            });
-        }
-
-        singboxConfig.dns = dns4Sbox;
-        return await Task.FromResult(0);
-    }
-
-    private async Task<int> GenOutboundDnsRule(ProfileItem? node, SingboxConfig singboxConfig)
-    {
-        if (node == null)
-        {
-            return 0;
-        }
-
-        List<string> domain = new();
-        if (Utils.IsDomain(node.Address)) // normal outbound
-        {
-            domain.Add(node.Address);
-        }
-        if (node.Address == Global.Loopback && node.SpiderX.IsNotEmpty()) // Tun2SocksAddress
-        {
-            domain.AddRange(Utils.String2List(node.SpiderX)
-                .Where(Utils.IsDomain)
-                .Distinct()
-                .ToList());
-        }
-        if (domain.Count == 0)
-        {
-            return 0;
-        }
-
-        singboxConfig.dns.rules ??= new List<Rule4Sbox>();
-        singboxConfig.dns.rules.Insert(0, new Rule4Sbox
+        return new()
         {
             server = Global.SingboxLocalDNSTag,
-            domain = domain,
-        });
-
-        return await Task.FromResult(0);
+            domain = context.ProtectDomainList.ToList(),
+        };
     }
 
     private static Server4Sbox? ParseDnsAddress(string address)

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxDnsService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxDnsService.cs
@@ -349,6 +349,7 @@ public partial class CoreConfigSingboxService
     {
         GenDnsServers();
         _coreConfig.dns ??= new();
+        _coreConfig.dns.rules ??= [];
         _coreConfig.dns.rules.Clear();
         _coreConfig.dns.final = Global.SingboxDirectDNSTag;
         _coreConfig.route.default_domain_resolver = new()

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxInboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxInboundService.cs
@@ -2,15 +2,15 @@ namespace ServiceLib.Services.CoreConfig;
 
 public partial class CoreConfigSingboxService
 {
-    private async Task<int> GenInbounds(SingboxConfig singboxConfig)
+    private void GenInbounds()
     {
         try
         {
             var listen = "0.0.0.0";
-            singboxConfig.inbounds = [];
+            _coreConfig.inbounds = [];
 
-            if (!_config.TunModeItem.EnableTun
-                || (_config.TunModeItem.EnableTun && _config.TunModeItem.EnableExInbound && AppManager.Instance.RunningCoreType == ECoreType.sing_box))
+            if (!context.AppConfig.TunModeItem.EnableTun
+                || (context.AppConfig.TunModeItem.EnableTun && context.AppConfig.TunModeItem.EnableExInbound && AppManager.Instance.RunningCoreType == ECoreType.sing_box))
             {
                 var inbound = new Inbound4Sbox()
                 {
@@ -18,28 +18,28 @@ public partial class CoreConfigSingboxService
                     tag = EInboundProtocol.socks.ToString(),
                     listen = Global.Loopback,
                 };
-                singboxConfig.inbounds.Add(inbound);
+                _coreConfig.inbounds.Add(inbound);
 
                 inbound.listen_port = AppManager.Instance.GetLocalPort(EInboundProtocol.socks);
 
-                if (_config.Inbound.First().SecondLocalPortEnabled)
+                if (context.AppConfig.Inbound.First().SecondLocalPortEnabled)
                 {
-                    var inbound2 = GetInbound(inbound, EInboundProtocol.socks2, true);
-                    singboxConfig.inbounds.Add(inbound2);
+                    var inbound2 = BuildInbound(inbound, EInboundProtocol.socks2, true);
+                    _coreConfig.inbounds.Add(inbound2);
                 }
 
-                if (_config.Inbound.First().AllowLANConn)
+                if (context.AppConfig.Inbound.First().AllowLANConn)
                 {
-                    if (_config.Inbound.First().NewPort4LAN)
+                    if (context.AppConfig.Inbound.First().NewPort4LAN)
                     {
-                        var inbound3 = GetInbound(inbound, EInboundProtocol.socks3, true);
+                        var inbound3 = BuildInbound(inbound, EInboundProtocol.socks3, true);
                         inbound3.listen = listen;
-                        singboxConfig.inbounds.Add(inbound3);
+                        _coreConfig.inbounds.Add(inbound3);
 
                         //auth
-                        if (_config.Inbound.First().User.IsNotEmpty() && _config.Inbound.First().Pass.IsNotEmpty())
+                        if (context.AppConfig.Inbound.First().User.IsNotEmpty() && context.AppConfig.Inbound.First().Pass.IsNotEmpty())
                         {
-                            inbound3.users = new() { new() { username = _config.Inbound.First().User, password = _config.Inbound.First().Pass } };
+                            inbound3.users = new() { new() { username = context.AppConfig.Inbound.First().User, password = context.AppConfig.Inbound.First().Pass } };
                         }
                     }
                     else
@@ -49,39 +49,38 @@ public partial class CoreConfigSingboxService
                 }
             }
 
-            if (_config.TunModeItem.EnableTun)
+            if (context.AppConfig.TunModeItem.EnableTun)
             {
-                if (_config.TunModeItem.Mtu <= 0)
+                if (context.AppConfig.TunModeItem.Mtu <= 0)
                 {
-                    _config.TunModeItem.Mtu = Global.TunMtus.First();
+                    context.AppConfig.TunModeItem.Mtu = Global.TunMtus.First();
                 }
-                if (_config.TunModeItem.Stack.IsNullOrEmpty())
+                if (context.AppConfig.TunModeItem.Stack.IsNullOrEmpty())
                 {
-                    _config.TunModeItem.Stack = Global.TunStacks.First();
+                    context.AppConfig.TunModeItem.Stack = Global.TunStacks.First();
                 }
 
                 var tunInbound = JsonUtils.Deserialize<Inbound4Sbox>(EmbedUtils.GetEmbedText(Global.TunSingboxInboundFileName)) ?? new Inbound4Sbox { };
                 tunInbound.interface_name = Utils.IsMacOS() ? $"utun{new Random().Next(99)}" : "singbox_tun";
-                tunInbound.mtu = _config.TunModeItem.Mtu;
-                tunInbound.auto_route = _config.TunModeItem.AutoRoute;
-                tunInbound.strict_route = _config.TunModeItem.StrictRoute;
-                tunInbound.stack = _config.TunModeItem.Stack;
-                if (_config.TunModeItem.EnableIPv6Address == false)
+                tunInbound.mtu = context.AppConfig.TunModeItem.Mtu;
+                tunInbound.auto_route = context.AppConfig.TunModeItem.AutoRoute;
+                tunInbound.strict_route = context.AppConfig.TunModeItem.StrictRoute;
+                tunInbound.stack = context.AppConfig.TunModeItem.Stack;
+                if (context.AppConfig.TunModeItem.EnableIPv6Address == false)
                 {
                     tunInbound.address = ["172.18.0.1/30"];
                 }
 
-                singboxConfig.inbounds.Add(tunInbound);
+                _coreConfig.inbounds.Add(tunInbound);
             }
         }
         catch (Exception ex)
         {
             Logging.SaveLog(_tag, ex);
         }
-        return await Task.FromResult(0);
     }
 
-    private Inbound4Sbox GetInbound(Inbound4Sbox inItem, EInboundProtocol protocol, bool bSocks)
+    private Inbound4Sbox BuildInbound(Inbound4Sbox inItem, EInboundProtocol protocol, bool bSocks)
     {
         var inbound = JsonUtils.DeepCopy(inItem);
         inbound.tag = protocol.ToString();

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxInboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxInboundService.cs
@@ -9,8 +9,8 @@ public partial class CoreConfigSingboxService
             var listen = "0.0.0.0";
             _coreConfig.inbounds = [];
 
-            if (!context.AppConfig.TunModeItem.EnableTun
-                || (context.AppConfig.TunModeItem.EnableTun && context.AppConfig.TunModeItem.EnableExInbound && AppManager.Instance.RunningCoreType == ECoreType.sing_box))
+            if (!_config.TunModeItem.EnableTun
+                || (_config.TunModeItem.EnableTun && _config.TunModeItem.EnableExInbound && AppManager.Instance.RunningCoreType == ECoreType.sing_box))
             {
                 var inbound = new Inbound4Sbox()
                 {
@@ -22,24 +22,24 @@ public partial class CoreConfigSingboxService
 
                 inbound.listen_port = AppManager.Instance.GetLocalPort(EInboundProtocol.socks);
 
-                if (context.AppConfig.Inbound.First().SecondLocalPortEnabled)
+                if (_config.Inbound.First().SecondLocalPortEnabled)
                 {
                     var inbound2 = BuildInbound(inbound, EInboundProtocol.socks2, true);
                     _coreConfig.inbounds.Add(inbound2);
                 }
 
-                if (context.AppConfig.Inbound.First().AllowLANConn)
+                if (_config.Inbound.First().AllowLANConn)
                 {
-                    if (context.AppConfig.Inbound.First().NewPort4LAN)
+                    if (_config.Inbound.First().NewPort4LAN)
                     {
                         var inbound3 = BuildInbound(inbound, EInboundProtocol.socks3, true);
                         inbound3.listen = listen;
                         _coreConfig.inbounds.Add(inbound3);
 
                         //auth
-                        if (context.AppConfig.Inbound.First().User.IsNotEmpty() && context.AppConfig.Inbound.First().Pass.IsNotEmpty())
+                        if (_config.Inbound.First().User.IsNotEmpty() && _config.Inbound.First().Pass.IsNotEmpty())
                         {
-                            inbound3.users = new() { new() { username = context.AppConfig.Inbound.First().User, password = context.AppConfig.Inbound.First().Pass } };
+                            inbound3.users = new() { new() { username = _config.Inbound.First().User, password = _config.Inbound.First().Pass } };
                         }
                     }
                     else
@@ -49,24 +49,24 @@ public partial class CoreConfigSingboxService
                 }
             }
 
-            if (context.AppConfig.TunModeItem.EnableTun)
+            if (_config.TunModeItem.EnableTun)
             {
-                if (context.AppConfig.TunModeItem.Mtu <= 0)
+                if (_config.TunModeItem.Mtu <= 0)
                 {
-                    context.AppConfig.TunModeItem.Mtu = Global.TunMtus.First();
+                    _config.TunModeItem.Mtu = Global.TunMtus.First();
                 }
-                if (context.AppConfig.TunModeItem.Stack.IsNullOrEmpty())
+                if (_config.TunModeItem.Stack.IsNullOrEmpty())
                 {
-                    context.AppConfig.TunModeItem.Stack = Global.TunStacks.First();
+                    _config.TunModeItem.Stack = Global.TunStacks.First();
                 }
 
                 var tunInbound = JsonUtils.Deserialize<Inbound4Sbox>(EmbedUtils.GetEmbedText(Global.TunSingboxInboundFileName)) ?? new Inbound4Sbox { };
                 tunInbound.interface_name = Utils.IsMacOS() ? $"utun{new Random().Next(99)}" : "singbox_tun";
-                tunInbound.mtu = context.AppConfig.TunModeItem.Mtu;
-                tunInbound.auto_route = context.AppConfig.TunModeItem.AutoRoute;
-                tunInbound.strict_route = context.AppConfig.TunModeItem.StrictRoute;
-                tunInbound.stack = context.AppConfig.TunModeItem.Stack;
-                if (context.AppConfig.TunModeItem.EnableIPv6Address == false)
+                tunInbound.mtu = _config.TunModeItem.Mtu;
+                tunInbound.auto_route = _config.TunModeItem.AutoRoute;
+                tunInbound.strict_route = _config.TunModeItem.StrictRoute;
+                tunInbound.stack = _config.TunModeItem.Stack;
+                if (_config.TunModeItem.EnableIPv6Address == false)
                 {
                     tunInbound.address = ["172.18.0.1/30"];
                 }

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxLogService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxLogService.cs
@@ -6,12 +6,12 @@ public partial class CoreConfigSingboxService
     {
         try
         {
-            switch (context.AppConfig.CoreBasicItem.Loglevel)
+            switch (_config.CoreBasicItem.Loglevel)
             {
                 case "debug":
                 case "info":
                 case "error":
-                    _coreConfig.log.level = context.AppConfig.CoreBasicItem.Loglevel;
+                    _coreConfig.log.level = _config.CoreBasicItem.Loglevel;
                     break;
 
                 case "warning":
@@ -21,11 +21,11 @@ public partial class CoreConfigSingboxService
                 default:
                     break;
             }
-            if (context.AppConfig.CoreBasicItem.Loglevel == Global.None)
+            if (_config.CoreBasicItem.Loglevel == Global.None)
             {
                 _coreConfig.log.disabled = true;
             }
-            if (context.AppConfig.CoreBasicItem.LogEnabled)
+            if (_config.CoreBasicItem.LogEnabled)
             {
                 var dtNow = DateTime.Now;
                 _coreConfig.log.output = Utils.GetLogPath($"sbox_{dtNow:yyyy-MM-dd}.txt");

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxLogService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxLogService.cs
@@ -2,39 +2,38 @@ namespace ServiceLib.Services.CoreConfig;
 
 public partial class CoreConfigSingboxService
 {
-    private async Task<int> GenLog(SingboxConfig singboxConfig)
+    private void GenLog()
     {
         try
         {
-            switch (_config.CoreBasicItem.Loglevel)
+            switch (context.AppConfig.CoreBasicItem.Loglevel)
             {
                 case "debug":
                 case "info":
                 case "error":
-                    singboxConfig.log.level = _config.CoreBasicItem.Loglevel;
+                    _coreConfig.log.level = context.AppConfig.CoreBasicItem.Loglevel;
                     break;
 
                 case "warning":
-                    singboxConfig.log.level = "warn";
+                    _coreConfig.log.level = "warn";
                     break;
 
                 default:
                     break;
             }
-            if (_config.CoreBasicItem.Loglevel == Global.None)
+            if (context.AppConfig.CoreBasicItem.Loglevel == Global.None)
             {
-                singboxConfig.log.disabled = true;
+                _coreConfig.log.disabled = true;
             }
-            if (_config.CoreBasicItem.LogEnabled)
+            if (context.AppConfig.CoreBasicItem.LogEnabled)
             {
                 var dtNow = DateTime.Now;
-                singboxConfig.log.output = Utils.GetLogPath($"sbox_{dtNow:yyyy-MM-dd}.txt");
+                _coreConfig.log.output = Utils.GetLogPath($"sbox_{dtNow:yyyy-MM-dd}.txt");
             }
         }
         catch (Exception ex)
         {
             Logging.SaveLog(_tag, ex);
         }
-        return await Task.FromResult(0);
     }
 }

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -556,7 +556,7 @@ public partial class CoreConfigSingboxService
         for (var i = 0; i < nodes.Count; i++)
         {
             var node = nodes[i];
-            var currentTag = baseTagName + (i + 1).ToString();
+            var currentTag = $"{baseTagName}-{i + 1}";
 
             if (node.ConfigType.IsGroupType())
             {
@@ -587,8 +587,8 @@ public partial class CoreConfigSingboxService
         for (var i = 0; i < nodesReverse.Count; i++)
         {
             var node = nodesReverse[i];
-            var currentTag = i == 0 ? baseTagName : "chain-" + baseTagName + i.ToString();
-            var dialerProxyTag = i != nodesReverse.Count - 1 ? "chain-" + baseTagName + (i + 1).ToString() : null;
+            var currentTag = i == 0 ? baseTagName : $"chain-{baseTagName}-{i}";
+            var dialerProxyTag = i != nodesReverse.Count - 1 ? $"chain-{baseTagName}-{i + 1}" : null;
             if (node.ConfigType.IsGroupType())
             {
                 var childProfiles = new CoreConfigSingboxService(context with { Node = node, }).BuildGroupProxyOutbounds(currentTag);
@@ -612,7 +612,7 @@ public partial class CoreConfigSingboxService
                         for (var j = 0; j < existedChainNodesClone.Count; j++)
                         {
                             var existedChainNode = existedChainNodesClone[j];
-                            var cloneTag = $"{existedChainNode.tag}-clone{j}";
+                            var cloneTag = $"{existedChainNode.tag}-clone-{j + 1}";
                             existedChainNode.tag = cloneTag;
                             var previousDialerProxyTag = existedChainNode.detour;
                             existedChainNode.detour = (previousDialerProxyTag == currentTag)

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
@@ -7,7 +7,7 @@ public partial class CoreConfigSingboxService
         try
         {
             _coreConfig.route.final = Global.ProxyTag;
-            var simpleDnsItem = context.AppConfig.SimpleDNSItem;
+            var simpleDnsItem = context.SimpleDnsItem;
 
             var defaultDomainResolverTag = Global.SingboxDirectDNSTag;
             var directDnsStrategy = Utils.DomainStrategy4Sbox(simpleDnsItem.Strategy4Freedom);
@@ -24,7 +24,7 @@ public partial class CoreConfigSingboxService
                 strategy = directDnsStrategy
             };
 
-            if (context.AppConfig.TunModeItem.EnableTun)
+            if (_config.TunModeItem.EnableTun)
             {
                 _coreConfig.route.auto_detect_interface = true;
 
@@ -49,7 +49,7 @@ public partial class CoreConfigSingboxService
                 });
             }
 
-            if (context.AppConfig.Inbound.First().SniffingEnabled)
+            if (_config.Inbound.First().SniffingEnabled)
             {
                 _coreConfig.route.rules.Add(new()
                 {
@@ -102,7 +102,7 @@ public partial class CoreConfigSingboxService
                 clash_mode = ERuleMode.Global.ToString()
             });
 
-            var domainStrategy = context.AppConfig.RoutingBasicItem.DomainStrategy4Singbox.NullIfEmpty();
+            var domainStrategy = _config.RoutingBasicItem.DomainStrategy4Singbox.NullIfEmpty();
             var routing = context.RoutingItem;
             if (routing.DomainStrategy4Singbox.IsNotEmpty())
             {
@@ -113,7 +113,7 @@ public partial class CoreConfigSingboxService
                 action = "resolve",
                 strategy = domainStrategy
             };
-            if (context.AppConfig.RoutingBasicItem.DomainStrategy == Global.IPOnDemand)
+            if (_config.RoutingBasicItem.DomainStrategy == Global.IPOnDemand)
             {
                 _coreConfig.route.rules.Add(resolveRule);
             }
@@ -142,7 +142,7 @@ public partial class CoreConfigSingboxService
                     }
                 }
             }
-            if (context.AppConfig.RoutingBasicItem.DomainStrategy == Global.IPIfNonMatch)
+            if (_config.RoutingBasicItem.DomainStrategy == Global.IPIfNonMatch)
             {
                 _coreConfig.route.rules.Add(resolveRule);
                 foreach (var item2 in ipRules)
@@ -413,8 +413,8 @@ public partial class CoreConfigSingboxService
         }
 
         var tag = $"{node.IndexId}-{Global.ProxyTag}";
-        if (_coreConfig.outbounds.Any(o => o.tag == tag)
-            || (_coreConfig.endpoints != null && _coreConfig.endpoints.Any(e => e.tag == tag)))
+        if (_coreConfig.outbounds.Any(o => o.tag.StartsWith(tag))
+            || (_coreConfig.endpoints != null && _coreConfig.endpoints.Any(e => e.tag.StartsWith(tag))))
         {
             return tag;
         }

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
@@ -2,127 +2,122 @@ namespace ServiceLib.Services.CoreConfig;
 
 public partial class CoreConfigSingboxService
 {
-    private async Task<int> GenRouting(SingboxConfig singboxConfig)
+    private void GenRouting()
     {
         try
         {
-            singboxConfig.route.final = Global.ProxyTag;
-            var simpleDnsItem = _config.SimpleDNSItem;
+            _coreConfig.route.final = Global.ProxyTag;
+            var simpleDnsItem = context.AppConfig.SimpleDNSItem;
 
             var defaultDomainResolverTag = Global.SingboxDirectDNSTag;
             var directDnsStrategy = Utils.DomainStrategy4Sbox(simpleDnsItem.Strategy4Freedom);
 
-            var rawDNSItem = await AppManager.Instance.GetDNSItem(ECoreType.sing_box);
+            var rawDNSItem = context.RawDnsItem;
             if (rawDNSItem is { Enabled: true })
             {
                 defaultDomainResolverTag = Global.SingboxLocalDNSTag;
                 directDnsStrategy = rawDNSItem.DomainStrategy4Freedom.IsNullOrEmpty() ? null : rawDNSItem.DomainStrategy4Freedom;
             }
-            singboxConfig.route.default_domain_resolver = new()
+            _coreConfig.route.default_domain_resolver = new()
             {
                 server = defaultDomainResolverTag,
                 strategy = directDnsStrategy
             };
 
-            if (_config.TunModeItem.EnableTun)
+            if (context.AppConfig.TunModeItem.EnableTun)
             {
-                singboxConfig.route.auto_detect_interface = true;
+                _coreConfig.route.auto_detect_interface = true;
 
                 var tunRules = JsonUtils.Deserialize<List<Rule4Sbox>>(EmbedUtils.GetEmbedText(Global.TunSingboxRulesFileName));
                 if (tunRules != null)
                 {
-                    singboxConfig.route.rules.AddRange(tunRules);
+                    _coreConfig.route.rules.AddRange(tunRules);
                 }
 
-                GenRoutingDirectExe(out var lstDnsExe, out var lstDirectExe);
-                singboxConfig.route.rules.Add(new()
+                var (lstDnsExe, lstDirectExe) = BuildRoutingDirectExe();
+                _coreConfig.route.rules.Add(new()
                 {
-                    port = new() { 53 },
+                    port = [53],
                     action = "hijack-dns",
                     process_name = lstDnsExe
                 });
 
-                singboxConfig.route.rules.Add(new()
+                _coreConfig.route.rules.Add(new()
                 {
                     outbound = Global.DirectTag,
                     process_name = lstDirectExe
                 });
             }
 
-            if (_config.Inbound.First().SniffingEnabled)
+            if (context.AppConfig.Inbound.First().SniffingEnabled)
             {
-                singboxConfig.route.rules.Add(new()
+                _coreConfig.route.rules.Add(new()
                 {
                     action = "sniff"
                 });
-                singboxConfig.route.rules.Add(new()
+                _coreConfig.route.rules.Add(new()
                 {
-                    protocol = new() { "dns" },
+                    protocol = ["dns"],
                     action = "hijack-dns"
                 });
             }
             else
             {
-                singboxConfig.route.rules.Add(new()
+                _coreConfig.route.rules.Add(new()
                 {
-                    port = new() { 53 },
-                    network = new() { "udp" },
+                    port = [53],
+                    network = ["udp"],
                     action = "hijack-dns"
                 });
             }
 
             var hostsDomains = new List<string>();
-            var dnsItem = await AppManager.Instance.GetDNSItem(ECoreType.sing_box);
-            if (dnsItem == null || !dnsItem.Enabled)
+            if (rawDNSItem is not { Enabled: true })
             {
                 var userHostsMap = Utils.ParseHostsToDictionary(simpleDnsItem.Hosts);
                 hostsDomains.AddRange(userHostsMap.Select(kvp => kvp.Key));
                 if (simpleDnsItem.UseSystemHosts == true)
                 {
                     var systemHostsMap = Utils.GetSystemHosts();
-                    foreach (var kvp in systemHostsMap)
-                    {
-                        hostsDomains.Add(kvp.Key);
-                    }
+                    hostsDomains.AddRange(systemHostsMap.Select(kvp => kvp.Key));
                 }
             }
             if (hostsDomains.Count > 0)
             {
-                singboxConfig.route.rules.Add(new()
+                _coreConfig.route.rules.Add(new()
                 {
                     action = "resolve",
                     domain = hostsDomains,
                 });
             }
 
-            singboxConfig.route.rules.Add(new()
+            _coreConfig.route.rules.Add(new()
             {
                 outbound = Global.DirectTag,
                 clash_mode = ERuleMode.Direct.ToString()
             });
-            singboxConfig.route.rules.Add(new()
+            _coreConfig.route.rules.Add(new()
             {
                 outbound = Global.ProxyTag,
                 clash_mode = ERuleMode.Global.ToString()
             });
 
-            var domainStrategy = _config.RoutingBasicItem.DomainStrategy4Singbox.NullIfEmpty();
-            var defaultRouting = await ConfigHandler.GetDefaultRouting(_config);
-            if (defaultRouting.DomainStrategy4Singbox.IsNotEmpty())
+            var domainStrategy = context.AppConfig.RoutingBasicItem.DomainStrategy4Singbox.NullIfEmpty();
+            var routing = context.RoutingItem;
+            if (routing.DomainStrategy4Singbox.IsNotEmpty())
             {
-                domainStrategy = defaultRouting.DomainStrategy4Singbox;
+                domainStrategy = routing.DomainStrategy4Singbox;
             }
             var resolveRule = new Rule4Sbox
             {
                 action = "resolve",
                 strategy = domainStrategy
             };
-            if (_config.RoutingBasicItem.DomainStrategy == Global.IPOnDemand)
+            if (context.AppConfig.RoutingBasicItem.DomainStrategy == Global.IPOnDemand)
             {
-                singboxConfig.route.rules.Add(resolveRule);
+                _coreConfig.route.rules.Add(resolveRule);
             }
 
-            var routing = await ConfigHandler.GetDefaultRouting(_config);
             var ipRules = new List<RulesItem>();
             if (routing != null)
             {
@@ -139,7 +134,7 @@ public partial class CoreConfigSingboxService
                         continue;
                     }
 
-                    await GenRoutingUserRule(item1, singboxConfig);
+                    GenRoutingUserRule(item1);
 
                     if (item1.Ip?.Count > 0)
                     {
@@ -147,12 +142,12 @@ public partial class CoreConfigSingboxService
                     }
                 }
             }
-            if (_config.RoutingBasicItem.DomainStrategy == Global.IPIfNonMatch)
+            if (context.AppConfig.RoutingBasicItem.DomainStrategy == Global.IPIfNonMatch)
             {
-                singboxConfig.route.rules.Add(resolveRule);
+                _coreConfig.route.rules.Add(resolveRule);
                 foreach (var item2 in ipRules)
                 {
-                    await GenRoutingUserRule(item2, singboxConfig);
+                    GenRoutingUserRule(item2);
                 }
             }
         }
@@ -160,10 +155,9 @@ public partial class CoreConfigSingboxService
         {
             Logging.SaveLog(_tag, ex);
         }
-        return 0;
     }
 
-    private void GenRoutingDirectExe(out List<string> lstDnsExe, out List<string> lstDirectExe)
+    private static (List<string> lstDnsExe, List<string> lstDirectExe) BuildRoutingDirectExe()
     {
         var dnsExeSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var directExeSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -187,20 +181,22 @@ public partial class CoreConfigSingboxService
             }
         }
 
-        lstDnsExe = new List<string>(dnsExeSet);
-        lstDirectExe = new List<string>(directExeSet);
+        var lstDnsExe = new List<string>(dnsExeSet);
+        var lstDirectExe = new List<string>(directExeSet);
+
+        return (lstDnsExe, lstDirectExe);
     }
 
-    private async Task<int> GenRoutingUserRule(RulesItem item, SingboxConfig singboxConfig)
+    private void GenRoutingUserRule(RulesItem? item)
     {
         try
         {
             if (item == null)
             {
-                return 0;
+                return;
             }
-            item.OutboundTag = await GenRoutingUserRuleOutbound(item.OutboundTag, singboxConfig);
-            var rules = singboxConfig.route.rules;
+            item.OutboundTag = GenRoutingUserRuleOutbound(item.OutboundTag ?? Global.ProxyTag);
+            var rules = _coreConfig.route.rules;
 
             var rule = new Rule4Sbox();
             if (item.OutboundTag == "block")
@@ -326,10 +322,9 @@ public partial class CoreConfigSingboxService
         {
             Logging.SaveLog(_tag, ex);
         }
-        return await Task.FromResult(0);
     }
 
-    private bool ParseV2Domain(string domain, Rule4Sbox rule)
+    private static bool ParseV2Domain(string domain, Rule4Sbox rule)
     {
         if (domain.StartsWith('#') || domain.StartsWith("ext:") || domain.StartsWith("ext-domain:"))
         {
@@ -368,7 +363,7 @@ public partial class CoreConfigSingboxService
         return true;
     }
 
-    private bool ParseV2Address(string address, Rule4Sbox rule)
+    private static bool ParseV2Address(string address, Rule4Sbox rule)
     {
         if (address.StartsWith("ext:") || address.StartsWith("ext-ip:"))
         {
@@ -401,14 +396,14 @@ public partial class CoreConfigSingboxService
         return true;
     }
 
-    private async Task<string?> GenRoutingUserRuleOutbound(string outboundTag, SingboxConfig singboxConfig)
+    private string GenRoutingUserRuleOutbound(string outboundTag)
     {
         if (Global.OutboundTags.Contains(outboundTag))
         {
             return outboundTag;
         }
 
-        var node = await AppManager.Instance.GetProfileItemViaRemarks(outboundTag);
+        var node = context.AllProxiesMap.GetValueOrDefault($"remark:{outboundTag}");
 
         if (node == null
             || (!Global.SingboxSupportConfigType.Contains(node.ConfigType)
@@ -418,39 +413,15 @@ public partial class CoreConfigSingboxService
         }
 
         var tag = $"{node.IndexId}-{Global.ProxyTag}";
-        if (singboxConfig.outbounds.Any(o => o.tag == tag)
-            || (singboxConfig.endpoints != null && singboxConfig.endpoints.Any(e => e.tag == tag)))
+        if (_coreConfig.outbounds.Any(o => o.tag == tag)
+            || (_coreConfig.endpoints != null && _coreConfig.endpoints.Any(e => e.tag == tag)))
         {
             return tag;
         }
 
-        if (node.ConfigType.IsGroupType())
-        {
-            var ret = await GenGroupOutbound(node, singboxConfig, tag);
-            if (ret == 0)
-            {
-                return tag;
-            }
-            return Global.ProxyTag;
-        }
+        var proxyOutbounds = new CoreConfigSingboxService(context with { Node = node, }).BuildAllProxyOutbounds(tag);
+        FillRangeProxy(proxyOutbounds, _coreConfig, false);
 
-        var server = await GenServer(node);
-        if (server is null)
-        {
-            return Global.ProxyTag;
-        }
-
-        server.tag = tag;
-        if (server is Endpoints4Sbox endpoint)
-        {
-            singboxConfig.endpoints ??= new();
-            singboxConfig.endpoints.Add(endpoint);
-        }
-        else if (server is Outbound4Sbox outbound)
-        {
-            singboxConfig.outbounds.Add(outbound);
-        }
-
-        return server.tag;
+        return tag;
     }
 }

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRulesetService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRulesetService.cs
@@ -99,9 +99,9 @@ public partial class CoreConfigSingboxService
                 }
                 else
                 {
-                    var srsUrl = string.IsNullOrEmpty(context.AppConfig.ConstItem.SrsSourceUrl)
+                    var srsUrl = string.IsNullOrEmpty(_config.ConstItem.SrsSourceUrl)
                         ? Global.SingboxRulesetUrl
-                        : context.AppConfig.ConstItem.SrsSourceUrl;
+                        : _config.ConstItem.SrsSourceUrl;
 
                     customRuleset = new()
                     {

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxStatisticService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxStatisticService.cs
@@ -13,14 +13,14 @@ public partial class CoreConfigSingboxService
             };
         }
 
-        if (context.AppConfig.CoreBasicItem.EnableCacheFile4Sbox)
+        if (_config.CoreBasicItem.EnableCacheFile4Sbox)
         {
             _coreConfig.experimental ??= new Experimental4Sbox();
             _coreConfig.experimental.cache_file = new CacheFile4Sbox()
             {
                 enabled = true,
                 path = Utils.GetBinPath("cache.db"),
-                store_fakeip = context.AppConfig.SimpleDNSItem.FakeIP == true
+                store_fakeip = context.SimpleDnsItem.FakeIP == true
             };
         }
     }

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxStatisticService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxStatisticService.cs
@@ -2,28 +2,26 @@ namespace ServiceLib.Services.CoreConfig;
 
 public partial class CoreConfigSingboxService
 {
-    private async Task<int> GenExperimental(SingboxConfig singboxConfig)
+    private void GenExperimental()
     {
         //if (_config.guiItem.enableStatistics)
         {
-            singboxConfig.experimental ??= new Experimental4Sbox();
-            singboxConfig.experimental.clash_api = new Clash_Api4Sbox()
+            _coreConfig.experimental ??= new Experimental4Sbox();
+            _coreConfig.experimental.clash_api = new Clash_Api4Sbox()
             {
                 external_controller = $"{Global.Loopback}:{AppManager.Instance.StatePort2}",
             };
         }
 
-        if (_config.CoreBasicItem.EnableCacheFile4Sbox)
+        if (context.AppConfig.CoreBasicItem.EnableCacheFile4Sbox)
         {
-            singboxConfig.experimental ??= new Experimental4Sbox();
-            singboxConfig.experimental.cache_file = new CacheFile4Sbox()
+            _coreConfig.experimental ??= new Experimental4Sbox();
+            _coreConfig.experimental.cache_file = new CacheFile4Sbox()
             {
                 enabled = true,
                 path = Utils.GetBinPath("cache.db"),
-                store_fakeip = _config.SimpleDNSItem.FakeIP == true
+                store_fakeip = context.AppConfig.SimpleDNSItem.FakeIP == true
             };
         }
-
-        return await Task.FromResult(0);
     }
 }

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
@@ -1,17 +1,19 @@
 namespace ServiceLib.Services.CoreConfig;
 
-public partial class CoreConfigV2rayService(Config config)
+public partial class CoreConfigV2rayService(CoreConfigContext context)
 {
-    private readonly Config _config = config;
     private static readonly string _tag = "CoreConfigV2rayService";
+
+    private V2rayConfig _coreConfig = new();
 
     #region public gen function
 
-    public async Task<RetResult> GenerateClientConfigContent(ProfileItem node)
+    public RetResult GenerateClientConfigContent()
     {
         var ret = new RetResult();
         try
         {
+            var node = context?.Node;
             if (node == null
                 || !node.IsValid())
             {
@@ -27,18 +29,6 @@ public partial class CoreConfigV2rayService(Config config)
 
             ret.Msg = ResUI.InitialConfiguration;
 
-            if (node.ConfigType.IsGroupType())
-            {
-                switch (node.ConfigType)
-                {
-                    case EConfigType.PolicyGroup:
-                        return await GenerateClientMultipleLoadConfig(node);
-
-                    case EConfigType.ProxyChain:
-                        return await GenerateClientChainConfig(node);
-                }
-            }
-
             var result = EmbedUtils.GetEmbedText(Global.V2raySampleClient);
             if (result.IsNullOrEmpty())
             {
@@ -46,30 +36,28 @@ public partial class CoreConfigV2rayService(Config config)
                 return ret;
             }
 
-            var v2rayConfig = JsonUtils.Deserialize<V2rayConfig>(result);
-            if (v2rayConfig == null)
+            _coreConfig = JsonUtils.Deserialize<V2rayConfig>(result);
+            if (_coreConfig == null)
             {
                 ret.Msg = ResUI.FailedGenDefaultConfiguration;
                 return ret;
             }
 
-            await GenLog(v2rayConfig);
+            GenLog();
 
-            await GenInbounds(v2rayConfig);
+            GenInbounds();
 
-            await GenOutbound(node, v2rayConfig.outbounds.First());
+            GenOutbounds();
 
-            await GenMoreOutbounds(node, v2rayConfig);
+            GenRouting();
 
-            await GenRouting(v2rayConfig);
+            GenDns();
 
-            await GenDns(node, v2rayConfig);
-
-            await GenStatistic(v2rayConfig);
+            GenStatistic();
 
             ret.Msg = string.Format(ResUI.SuccessfulConfiguration, "");
             ret.Success = true;
-            ret.Data = await ApplyFullConfigTemplate(v2rayConfig);
+            ret.Data = ApplyFullConfigTemplate();
             return ret;
         }
         catch (Exception ex)
@@ -80,182 +68,11 @@ public partial class CoreConfigV2rayService(Config config)
         }
     }
 
-    public async Task<RetResult> GenerateClientMultipleLoadConfig(ProfileItem parentNode)
-    {
-        var ret = new RetResult();
-
-        try
-        {
-            if (_config == null)
-            {
-                ret.Msg = ResUI.CheckServerSettings;
-                return ret;
-            }
-
-            ret.Msg = ResUI.InitialConfiguration;
-
-            var result = EmbedUtils.GetEmbedText(Global.V2raySampleClient);
-            var txtOutbound = EmbedUtils.GetEmbedText(Global.V2raySampleOutbound);
-            if (result.IsNullOrEmpty() || txtOutbound.IsNullOrEmpty())
-            {
-                ret.Msg = ResUI.FailedGetDefaultConfiguration;
-                return ret;
-            }
-
-            var v2rayConfig = JsonUtils.Deserialize<V2rayConfig>(result);
-            if (v2rayConfig == null)
-            {
-                ret.Msg = ResUI.FailedGenDefaultConfiguration;
-                return ret;
-            }
-            v2rayConfig.outbounds.RemoveAt(0);
-
-            await GenLog(v2rayConfig);
-            await GenInbounds(v2rayConfig);
-
-            var groupRet = await GenGroupOutbound(parentNode, v2rayConfig);
-            if (groupRet != 0)
-            {
-                ret.Msg = ResUI.FailedGenDefaultConfiguration;
-                return ret;
-            }
-
-            await GenRouting(v2rayConfig);
-            await GenDns(null, v2rayConfig);
-            await GenStatistic(v2rayConfig);
-
-            var defaultBalancerTag = $"{Global.ProxyTag}{Global.BalancerTagSuffix}";
-
-            //add rule
-            var rules = v2rayConfig.routing.rules;
-            if (rules?.Count > 0 && ((v2rayConfig.routing.balancers?.Count ?? 0) > 0))
-            {
-                var balancerTagSet = v2rayConfig.routing.balancers
-                    .Select(b => b.tag)
-                    .ToHashSet();
-
-                foreach (var rule in rules)
-                {
-                    if (rule.outboundTag == null)
-                    {
-                        continue;
-                    }
-
-                    if (balancerTagSet.Contains(rule.outboundTag))
-                    {
-                        rule.balancerTag = rule.outboundTag;
-                        rule.outboundTag = null;
-                        continue;
-                    }
-
-                    var outboundWithSuffix = rule.outboundTag + Global.BalancerTagSuffix;
-                    if (balancerTagSet.Contains(outboundWithSuffix))
-                    {
-                        rule.balancerTag = outboundWithSuffix;
-                        rule.outboundTag = null;
-                    }
-                }
-            }
-            if (v2rayConfig.routing.domainStrategy == Global.IPIfNonMatch)
-            {
-                v2rayConfig.routing.rules.Add(new()
-                {
-                    ip = ["0.0.0.0/0", "::/0"],
-                    balancerTag = defaultBalancerTag,
-                    type = "field"
-                });
-            }
-            else
-            {
-                v2rayConfig.routing.rules.Add(new()
-                {
-                    network = "tcp,udp",
-                    balancerTag = defaultBalancerTag,
-                    type = "field"
-                });
-            }
-
-            ret.Success = true;
-
-            ret.Data = await ApplyFullConfigTemplate(v2rayConfig);
-            return ret;
-        }
-        catch (Exception ex)
-        {
-            Logging.SaveLog(_tag, ex);
-            ret.Msg = ResUI.FailedGenDefaultConfiguration;
-            return ret;
-        }
-    }
-
-    public async Task<RetResult> GenerateClientChainConfig(ProfileItem parentNode)
-    {
-        var ret = new RetResult();
-
-        try
-        {
-            if (_config == null)
-            {
-                ret.Msg = ResUI.CheckServerSettings;
-                return ret;
-            }
-
-            ret.Msg = ResUI.InitialConfiguration;
-
-            var result = EmbedUtils.GetEmbedText(Global.V2raySampleClient);
-            var txtOutbound = EmbedUtils.GetEmbedText(Global.V2raySampleOutbound);
-            if (result.IsNullOrEmpty() || txtOutbound.IsNullOrEmpty())
-            {
-                ret.Msg = ResUI.FailedGetDefaultConfiguration;
-                return ret;
-            }
-
-            var v2rayConfig = JsonUtils.Deserialize<V2rayConfig>(result);
-            if (v2rayConfig == null)
-            {
-                ret.Msg = ResUI.FailedGenDefaultConfiguration;
-                return ret;
-            }
-            v2rayConfig.outbounds.RemoveAt(0);
-
-            await GenLog(v2rayConfig);
-            await GenInbounds(v2rayConfig);
-
-            var groupRet = await GenGroupOutbound(parentNode, v2rayConfig);
-            if (groupRet != 0)
-            {
-                ret.Msg = ResUI.FailedGenDefaultConfiguration;
-                return ret;
-            }
-
-            await GenRouting(v2rayConfig);
-            await GenDns(null, v2rayConfig);
-            await GenStatistic(v2rayConfig);
-
-            ret.Success = true;
-
-            ret.Data = await ApplyFullConfigTemplate(v2rayConfig);
-            return ret;
-        }
-        catch (Exception ex)
-        {
-            Logging.SaveLog(_tag, ex);
-            ret.Msg = ResUI.FailedGenDefaultConfiguration;
-            return ret;
-        }
-    }
-
-    public async Task<RetResult> GenerateClientSpeedtestConfig(List<ServerTestItem> selecteds)
+    public RetResult GenerateClientSpeedtestConfig(List<ServerTestItem> selecteds)
     {
         var ret = new RetResult();
         try
         {
-            if (_config == null)
-            {
-                ret.Msg = ResUI.CheckServerSettings;
-                return ret;
-            }
-
             ret.Msg = ResUI.InitialConfiguration;
 
             var result = EmbedUtils.GetEmbedText(Global.V2raySampleClient);
@@ -285,7 +102,7 @@ public partial class CoreConfigV2rayService(Config config)
                 Logging.SaveLog(_tag, ex);
             }
 
-            await GenLog(v2rayConfig);
+            GenLog();
             v2rayConfig.inbounds.Clear();
             v2rayConfig.outbounds.Clear();
             v2rayConfig.routing.rules.Clear();
@@ -302,7 +119,7 @@ public partial class CoreConfigV2rayService(Config config)
                 {
                     continue;
                 }
-                var item = await AppManager.Instance.GetProfileItem(it.IndexId);
+                var item = context.AllProxiesMap.GetValueOrDefault(it.IndexId);
                 if (item is null || item.IsComplex() || !item.IsValid())
                 {
                     continue;
@@ -344,19 +161,31 @@ public partial class CoreConfigV2rayService(Config config)
                 inbound.tag = inbound.protocol + inbound.port.ToString();
                 v2rayConfig.inbounds.Add(inbound);
 
+                var tag = Global.ProxyTag + inbound.port.ToString();
+                var isBalancer = false;
                 //outbound
-                var outbound = JsonUtils.Deserialize<Outbounds4Ray>(txtOutbound);
-                await GenOutbound(item, outbound);
-                outbound.tag = Global.ProxyTag + inbound.port.ToString();
-                v2rayConfig.outbounds.Add(outbound);
+                var proxyOutbounds = BuildAllProxyOutbounds(tag);
+                v2rayConfig.outbounds.AddRange(proxyOutbounds);
+                if (proxyOutbounds.Count(n => n.tag.StartsWith(tag)) > 1)
+                {
+                    isBalancer = true;
+                    var multipleLoad = context.Node.GetProtocolExtra().MultipleLoad ?? EMultipleLoad.LeastPing;
+                    GenObservatory(multipleLoad, tag);
+                    GenBalancer(multipleLoad, tag);
+                }
 
                 //rule
                 RulesItem4Ray rule = new()
                 {
                     inboundTag = new List<string> { inbound.tag },
-                    outboundTag = outbound.tag,
+                    outboundTag = tag,
                     type = "field"
                 };
+                if (isBalancer)
+                {
+                    rule.balancerTag = tag;
+                    rule.outboundTag = null;
+                }
                 v2rayConfig.routing.rules.Add(rule);
             }
 
@@ -373,11 +202,12 @@ public partial class CoreConfigV2rayService(Config config)
         }
     }
 
-    public async Task<RetResult> GenerateClientSpeedtestConfig(ProfileItem node, int port)
+    public RetResult GenerateClientSpeedtestConfig(int port)
     {
         var ret = new RetResult();
         try
         {
+            var node = context.Node;
             if (node == null
                 || !node.IsValid())
             {
@@ -405,9 +235,8 @@ public partial class CoreConfigV2rayService(Config config)
                 return ret;
             }
 
-            await GenLog(v2rayConfig);
-            await GenOutbound(node, v2rayConfig.outbounds.First());
-            await GenMoreOutbounds(node, v2rayConfig);
+            GenLog();
+            GenOutbounds();
 
             v2rayConfig.routing.rules.Clear();
             v2rayConfig.inbounds.Clear();

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
@@ -3,6 +3,8 @@ namespace ServiceLib.Services.CoreConfig;
 public partial class CoreConfigV2rayService(CoreConfigContext context)
 {
     private static readonly string _tag = "CoreConfigV2rayService";
+    private readonly Config _config = context.AppConfig;
+    private readonly ProfileItem _node = context.Node;
 
     private V2rayConfig _coreConfig = new();
 
@@ -13,17 +15,16 @@ public partial class CoreConfigV2rayService(CoreConfigContext context)
         var ret = new RetResult();
         try
         {
-            var node = context?.Node;
-            if (node == null
-                || !node.IsValid())
+            if (_node == null
+                || !_node.IsValid())
             {
                 ret.Msg = ResUI.CheckServerSettings;
                 return ret;
             }
 
-            if (node.GetNetwork() is nameof(ETransport.quic))
+            if (_node.GetNetwork() is nameof(ETransport.quic))
             {
-                ret.Msg = ResUI.Incorrectconfiguration + $" - {node.GetNetwork()}";
+                ret.Msg = ResUI.Incorrectconfiguration + $" - {_node.GetNetwork()}";
                 return ret;
             }
 
@@ -170,7 +171,7 @@ public partial class CoreConfigV2rayService(CoreConfigContext context)
                 if (proxyOutbounds.Count(n => n.tag.StartsWith(tag)) > 1)
                 {
                     isBalancer = true;
-                    var multipleLoad = context.Node.GetProtocolExtra().MultipleLoad ?? EMultipleLoad.LeastPing;
+                    var multipleLoad = _node.GetProtocolExtra().MultipleLoad ?? EMultipleLoad.LeastPing;
                     GenObservatory(multipleLoad, tag);
                     GenBalancer(multipleLoad, tag);
                 }
@@ -208,17 +209,16 @@ public partial class CoreConfigV2rayService(CoreConfigContext context)
         var ret = new RetResult();
         try
         {
-            var node = context.Node;
-            if (node == null
-                || !node.IsValid())
+            if (_node == null
+                || !_node.IsValid())
             {
                 ret.Msg = ResUI.CheckServerSettings;
                 return ret;
             }
 
-            if (node.GetNetwork() is nameof(ETransport.quic))
+            if (_node.GetNetwork() is nameof(ETransport.quic))
             {
-                ret.Msg = ResUI.Incorrectconfiguration + $" - {node.GetNetwork()}";
+                ret.Msg = ResUI.Incorrectconfiguration + $" - {_node.GetNetwork()}";
                 return ret;
             }
 

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayConfigTemplateService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayConfigTemplateService.cs
@@ -2,24 +2,24 @@ namespace ServiceLib.Services.CoreConfig;
 
 public partial class CoreConfigV2rayService
 {
-    private async Task<string> ApplyFullConfigTemplate(V2rayConfig v2rayConfig)
+    private string ApplyFullConfigTemplate()
     {
-        var fullConfigTemplate = await AppManager.Instance.GetFullConfigTemplateItem(ECoreType.Xray);
+        var fullConfigTemplate = context.FullConfigTemplate;
         if (fullConfigTemplate == null || !fullConfigTemplate.Enabled || fullConfigTemplate.Config.IsNullOrEmpty())
         {
-            return JsonUtils.Serialize(v2rayConfig);
+            return JsonUtils.Serialize(_coreConfig);
         }
 
         var fullConfigTemplateNode = JsonNode.Parse(fullConfigTemplate.Config);
         if (fullConfigTemplateNode == null)
         {
-            return JsonUtils.Serialize(v2rayConfig);
+            return JsonUtils.Serialize(_coreConfig);
         }
 
         // Handle balancer and rules modifications (for multiple load scenarios)
-        if (v2rayConfig.routing?.balancers?.Count > 0)
+        if (_coreConfig.routing?.balancers?.Count > 0)
         {
-            var balancer = v2rayConfig.routing.balancers.First();
+            var balancer = _coreConfig.routing.balancers.First();
 
             // Modify existing rules in custom config
             var rulesNode = fullConfigTemplateNode["routing"]?["rules"];
@@ -44,7 +44,7 @@ public partial class CoreConfigV2rayService
             // Handle balancers - append instead of override
             if (fullConfigTemplateNode["routing"]["balancers"] is JsonArray customBalancersNode)
             {
-                if (JsonNode.Parse(JsonUtils.Serialize(v2rayConfig.routing.balancers)) is JsonArray newBalancers)
+                if (JsonNode.Parse(JsonUtils.Serialize(_coreConfig.routing.balancers)) is JsonArray newBalancers)
                 {
                     foreach (var balancerNode in newBalancers)
                     {
@@ -54,33 +54,33 @@ public partial class CoreConfigV2rayService
             }
             else
             {
-                fullConfigTemplateNode["routing"]["balancers"] = JsonNode.Parse(JsonUtils.Serialize(v2rayConfig.routing.balancers));
+                fullConfigTemplateNode["routing"]["balancers"] = JsonNode.Parse(JsonUtils.Serialize(_coreConfig.routing.balancers));
             }
         }
 
-        if (v2rayConfig.observatory != null)
+        if (_coreConfig.observatory != null)
         {
             if (fullConfigTemplateNode["observatory"] == null)
             {
-                fullConfigTemplateNode["observatory"] = JsonNode.Parse(JsonUtils.Serialize(v2rayConfig.observatory));
+                fullConfigTemplateNode["observatory"] = JsonNode.Parse(JsonUtils.Serialize(_coreConfig.observatory));
             }
             else
             {
-                var subjectSelector = v2rayConfig.observatory.subjectSelector;
+                var subjectSelector = _coreConfig.observatory.subjectSelector;
                 subjectSelector.AddRange(fullConfigTemplateNode["observatory"]?["subjectSelector"]?.AsArray()?.Select(x => x?.GetValue<string>()) ?? []);
                 fullConfigTemplateNode["observatory"]["subjectSelector"] = JsonNode.Parse(JsonUtils.Serialize(subjectSelector.Distinct().ToList()));
             }
         }
 
-        if (v2rayConfig.burstObservatory != null)
+        if (_coreConfig.burstObservatory != null)
         {
             if (fullConfigTemplateNode["burstObservatory"] == null)
             {
-                fullConfigTemplateNode["burstObservatory"] = JsonNode.Parse(JsonUtils.Serialize(v2rayConfig.burstObservatory));
+                fullConfigTemplateNode["burstObservatory"] = JsonNode.Parse(JsonUtils.Serialize(_coreConfig.burstObservatory));
             }
             else
             {
-                var subjectSelector = v2rayConfig.burstObservatory.subjectSelector;
+                var subjectSelector = _coreConfig.burstObservatory.subjectSelector;
                 subjectSelector.AddRange(fullConfigTemplateNode["burstObservatory"]?["subjectSelector"]?.AsArray()?.Select(x => x?.GetValue<string>()) ?? []);
                 fullConfigTemplateNode["burstObservatory"]["subjectSelector"] = JsonNode.Parse(JsonUtils.Serialize(subjectSelector.Distinct().ToList()));
             }
@@ -88,7 +88,7 @@ public partial class CoreConfigV2rayService
 
         var customOutboundsNode = new JsonArray();
 
-        foreach (var outbound in v2rayConfig.outbounds)
+        foreach (var outbound in _coreConfig.outbounds)
         {
             if (outbound.protocol.ToLower() is "blackhole" or "dns" or "freedom")
             {
@@ -123,6 +123,6 @@ public partial class CoreConfigV2rayService
 
         fullConfigTemplateNode["outbounds"] = customOutboundsNode;
 
-        return await Task.FromResult(JsonUtils.Serialize(fullConfigTemplateNode));
+        return JsonUtils.Serialize(fullConfigTemplateNode);
     }
 }

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayConfigTemplateService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayConfigTemplateService.cs
@@ -19,18 +19,22 @@ public partial class CoreConfigV2rayService
         // Handle balancer and rules modifications (for multiple load scenarios)
         if (_coreConfig.routing?.balancers?.Count > 0)
         {
-            var balancer = _coreConfig.routing.balancers.First();
+            var balancer =
+                _coreConfig.routing.balancers.FirstOrDefault(b => b.tag == Global.ProxyTag + Global.BalancerTagSuffix, null);
 
             // Modify existing rules in custom config
-            var rulesNode = fullConfigTemplateNode["routing"]?["rules"];
-            if (rulesNode != null)
+            if (balancer != null)
             {
-                foreach (var rule in rulesNode.AsArray())
+                var rulesNode = fullConfigTemplateNode["routing"]?["rules"];
+                if (rulesNode != null)
                 {
-                    if (rule["outboundTag"]?.GetValue<string>() == Global.ProxyTag)
+                    foreach (var rule in rulesNode.AsArray())
                     {
-                        rule.AsObject().Remove("outboundTag");
-                        rule["balancerTag"] = balancer.tag;
+                        if (rule["outboundTag"]?.GetValue<string>() == Global.ProxyTag)
+                        {
+                            rule.AsObject().Remove("outboundTag");
+                            rule["balancerTag"] = balancer.tag;
+                        }
                     }
                 }
             }
@@ -97,8 +101,8 @@ public partial class CoreConfigV2rayService
                     continue;
                 }
             }
-            else if ((!fullConfigTemplate.ProxyDetour.IsNullOrEmpty())
-                && ((outbound.streamSettings?.sockopt?.dialerProxy.IsNullOrEmpty() ?? true) == true))
+            else if (!fullConfigTemplate.ProxyDetour.IsNullOrEmpty()
+                && (outbound.streamSettings?.sockopt?.dialerProxy.IsNullOrEmpty() ?? true))
             {
                 var outboundAddress = outbound.settings?.servers?.FirstOrDefault()?.address
                     ?? outbound.settings?.vnext?.FirstOrDefault()?.address

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayDnsService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayDnsService.cs
@@ -92,7 +92,6 @@ public partial class CoreConfigV2rayService
 
     private void FillDnsServers(Dns4Ray dnsItem)
     {
-        var node = context.Node;
         var simpleDNSItem = context.SimpleDnsItem;
         static List<string> ParseDnsAddresses(string? dnsInput, string defaultAddress)
         {
@@ -244,11 +243,6 @@ public partial class CoreConfigV2rayService
                     }
                 }
             }
-        }
-
-        if (Utils.IsDomain(node?.Address))
-        {
-            directDomainList.Add(node.Address);
         }
 
         if (context.ProtectDomainList.Count > 0)
@@ -407,7 +401,6 @@ public partial class CoreConfigV2rayService
 
     private void FillDnsDomainsCustom(JsonNode dns)
     {
-        var node = context.Node;
         var servers = dns["servers"];
         if (servers == null)
         {

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayInboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayInboundService.cs
@@ -2,35 +2,36 @@ namespace ServiceLib.Services.CoreConfig;
 
 public partial class CoreConfigV2rayService
 {
-    private async Task<int> GenInbounds(V2rayConfig v2rayConfig)
+    private void GenInbounds()
     {
         try
         {
+            var config = context.AppConfig;
             var listen = "0.0.0.0";
-            v2rayConfig.inbounds = [];
+            _coreConfig.inbounds = [];
 
-            var inbound = GetInbound(_config.Inbound.First(), EInboundProtocol.socks, true);
-            v2rayConfig.inbounds.Add(inbound);
+            var inbound = BuildInbound(config.Inbound.First(), EInboundProtocol.socks, true);
+            _coreConfig.inbounds.Add(inbound);
 
-            if (_config.Inbound.First().SecondLocalPortEnabled)
+            if (config.Inbound.First().SecondLocalPortEnabled)
             {
-                var inbound2 = GetInbound(_config.Inbound.First(), EInboundProtocol.socks2, true);
-                v2rayConfig.inbounds.Add(inbound2);
+                var inbound2 = BuildInbound(config.Inbound.First(), EInboundProtocol.socks2, true);
+                _coreConfig.inbounds.Add(inbound2);
             }
 
-            if (_config.Inbound.First().AllowLANConn)
+            if (config.Inbound.First().AllowLANConn)
             {
-                if (_config.Inbound.First().NewPort4LAN)
+                if (config.Inbound.First().NewPort4LAN)
                 {
-                    var inbound3 = GetInbound(_config.Inbound.First(), EInboundProtocol.socks3, true);
+                    var inbound3 = BuildInbound(config.Inbound.First(), EInboundProtocol.socks3, true);
                     inbound3.listen = listen;
-                    v2rayConfig.inbounds.Add(inbound3);
+                    _coreConfig.inbounds.Add(inbound3);
 
                     //auth
-                    if (_config.Inbound.First().User.IsNotEmpty() && _config.Inbound.First().Pass.IsNotEmpty())
+                    if (config.Inbound.First().User.IsNotEmpty() && config.Inbound.First().Pass.IsNotEmpty())
                     {
                         inbound3.settings.auth = "password";
-                        inbound3.settings.accounts = new List<AccountsItem4Ray> { new AccountsItem4Ray() { user = _config.Inbound.First().User, pass = _config.Inbound.First().Pass } };
+                        inbound3.settings.accounts = new List<AccountsItem4Ray> { new() { user = config.Inbound.First().User, pass = config.Inbound.First().Pass } };
                     }
                 }
                 else
@@ -43,10 +44,9 @@ public partial class CoreConfigV2rayService
         {
             Logging.SaveLog(_tag, ex);
         }
-        return await Task.FromResult(0);
     }
 
-    private Inbounds4Ray GetInbound(InItem inItem, EInboundProtocol protocol, bool bSocks)
+    private Inbounds4Ray BuildInbound(InItem inItem, EInboundProtocol protocol, bool bSocks)
     {
         var result = EmbedUtils.GetEmbedText(Global.V2raySampleInbound);
         if (result.IsNullOrEmpty())

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayInboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayInboundService.cs
@@ -6,32 +6,31 @@ public partial class CoreConfigV2rayService
     {
         try
         {
-            var config = context.AppConfig;
             var listen = "0.0.0.0";
             _coreConfig.inbounds = [];
 
-            var inbound = BuildInbound(config.Inbound.First(), EInboundProtocol.socks, true);
+            var inbound = BuildInbound(_config.Inbound.First(), EInboundProtocol.socks, true);
             _coreConfig.inbounds.Add(inbound);
 
-            if (config.Inbound.First().SecondLocalPortEnabled)
+            if (_config.Inbound.First().SecondLocalPortEnabled)
             {
-                var inbound2 = BuildInbound(config.Inbound.First(), EInboundProtocol.socks2, true);
+                var inbound2 = BuildInbound(_config.Inbound.First(), EInboundProtocol.socks2, true);
                 _coreConfig.inbounds.Add(inbound2);
             }
 
-            if (config.Inbound.First().AllowLANConn)
+            if (_config.Inbound.First().AllowLANConn)
             {
-                if (config.Inbound.First().NewPort4LAN)
+                if (_config.Inbound.First().NewPort4LAN)
                 {
-                    var inbound3 = BuildInbound(config.Inbound.First(), EInboundProtocol.socks3, true);
+                    var inbound3 = BuildInbound(_config.Inbound.First(), EInboundProtocol.socks3, true);
                     inbound3.listen = listen;
                     _coreConfig.inbounds.Add(inbound3);
 
                     //auth
-                    if (config.Inbound.First().User.IsNotEmpty() && config.Inbound.First().Pass.IsNotEmpty())
+                    if (_config.Inbound.First().User.IsNotEmpty() && _config.Inbound.First().Pass.IsNotEmpty())
                     {
                         inbound3.settings.auth = "password";
-                        inbound3.settings.accounts = new List<AccountsItem4Ray> { new() { user = config.Inbound.First().User, pass = config.Inbound.First().Pass } };
+                        inbound3.settings.accounts = new List<AccountsItem4Ray> { new() { user = _config.Inbound.First().User, pass = _config.Inbound.First().Pass } };
                     }
                 }
                 else

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayLogService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayLogService.cs
@@ -2,28 +2,28 @@ namespace ServiceLib.Services.CoreConfig;
 
 public partial class CoreConfigV2rayService
 {
-    private async Task<int> GenLog(V2rayConfig v2rayConfig)
+    private void GenLog()
     {
         try
         {
-            if (_config.CoreBasicItem.LogEnabled)
+            var config = context.AppConfig;
+            if (config.CoreBasicItem.LogEnabled)
             {
                 var dtNow = DateTime.Now;
-                v2rayConfig.log.loglevel = _config.CoreBasicItem.Loglevel;
-                v2rayConfig.log.access = Utils.GetLogPath($"Vaccess_{dtNow:yyyy-MM-dd}.txt");
-                v2rayConfig.log.error = Utils.GetLogPath($"Verror_{dtNow:yyyy-MM-dd}.txt");
+                _coreConfig.log.loglevel = config.CoreBasicItem.Loglevel;
+                _coreConfig.log.access = Utils.GetLogPath($"Vaccess_{dtNow:yyyy-MM-dd}.txt");
+                _coreConfig.log.error = Utils.GetLogPath($"Verror_{dtNow:yyyy-MM-dd}.txt");
             }
             else
             {
-                v2rayConfig.log.loglevel = _config.CoreBasicItem.Loglevel;
-                v2rayConfig.log.access = null;
-                v2rayConfig.log.error = null;
+                _coreConfig.log.loglevel = config.CoreBasicItem.Loglevel;
+                _coreConfig.log.access = null;
+                _coreConfig.log.error = null;
             }
         }
         catch (Exception ex)
         {
             Logging.SaveLog(_tag, ex);
         }
-        return await Task.FromResult(0);
     }
 }

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayLogService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayLogService.cs
@@ -6,17 +6,16 @@ public partial class CoreConfigV2rayService
     {
         try
         {
-            var config = context.AppConfig;
-            if (config.CoreBasicItem.LogEnabled)
+            if (_config.CoreBasicItem.LogEnabled)
             {
                 var dtNow = DateTime.Now;
-                _coreConfig.log.loglevel = config.CoreBasicItem.Loglevel;
+                _coreConfig.log.loglevel = _config.CoreBasicItem.Loglevel;
                 _coreConfig.log.access = Utils.GetLogPath($"Vaccess_{dtNow:yyyy-MM-dd}.txt");
                 _coreConfig.log.error = Utils.GetLogPath($"Verror_{dtNow:yyyy-MM-dd}.txt");
             }
             else
             {
-                _coreConfig.log.loglevel = config.CoreBasicItem.Loglevel;
+                _coreConfig.log.loglevel = _config.CoreBasicItem.Loglevel;
                 _coreConfig.log.access = null;
                 _coreConfig.log.error = null;
             }

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
@@ -8,7 +8,7 @@ public partial class CoreConfigV2rayService
         _coreConfig.outbounds.InsertRange(0, proxyOutboundList);
         if (proxyOutboundList.Count(n => n.tag.StartsWith(Global.ProxyTag)) > 1)
         {
-            var multipleLoad = context.Node.GetProtocolExtra().MultipleLoad ?? EMultipleLoad.LeastPing;
+            var multipleLoad = _node.GetProtocolExtra().MultipleLoad ?? EMultipleLoad.LeastPing;
             GenObservatory(multipleLoad);
             GenBalancer(multipleLoad);
         }
@@ -17,8 +17,7 @@ public partial class CoreConfigV2rayService
     private List<Outbounds4Ray> BuildAllProxyOutbounds(string baseTagName = Global.ProxyTag)
     {
         var proxyOutboundList = new List<Outbounds4Ray>();
-        var node = context.Node;
-        if (node.ConfigType.IsGroupType())
+        if (_node.ConfigType.IsGroupType())
         {
             proxyOutboundList.AddRange(BuildGroupProxyOutbounds(baseTagName));
         }
@@ -27,7 +26,7 @@ public partial class CoreConfigV2rayService
             proxyOutboundList.Add(BuildProxyOutbound(baseTagName));
         }
 
-        if (context.AppConfig.CoreBasicItem.EnableFragment)
+        if (_config.CoreBasicItem.EnableFragment)
         {
             var fragmentOutbound = new Outbounds4Ray
             {
@@ -37,9 +36,9 @@ public partial class CoreConfigV2rayService
                 {
                     fragment = new()
                     {
-                        packets = context.AppConfig.Fragment4RayItem?.Packets,
-                        length = context.AppConfig.Fragment4RayItem?.Length,
-                        interval = context.AppConfig.Fragment4RayItem?.Interval
+                        packets = _config.Fragment4RayItem?.Packets,
+                        length = _config.Fragment4RayItem?.Length,
+                        interval = _config.Fragment4RayItem?.Interval
                     }
                 }
             };
@@ -63,8 +62,7 @@ public partial class CoreConfigV2rayService
     private List<Outbounds4Ray> BuildGroupProxyOutbounds(string baseTagName = Global.ProxyTag)
     {
         var proxyOutboundList = new List<Outbounds4Ray>();
-        var node = context.Node;
-        switch (node.ConfigType)
+        switch (_node.ConfigType)
         {
             case EConfigType.PolicyGroup:
                 proxyOutboundList.AddRange(BuildOutboundsList(baseTagName));
@@ -89,10 +87,9 @@ public partial class CoreConfigV2rayService
     {
         try
         {
-            var node = context.Node;
-            var protocolExtra = node.GetProtocolExtra();
-            var muxEnabled = node.MuxEnabled ?? context.AppConfig.CoreBasicItem.MuxEnabled;
-            switch (node.ConfigType)
+            var protocolExtra = _node.GetProtocolExtra();
+            var muxEnabled = _node.MuxEnabled ?? _config.CoreBasicItem.MuxEnabled;
+            switch (_node.ConfigType)
             {
                 case EConfigType.VMess:
                     {
@@ -106,8 +103,8 @@ public partial class CoreConfigV2rayService
                         {
                             vnextItem = outbound.settings.vnext.First();
                         }
-                        vnextItem.address = node.Address;
-                        vnextItem.port = node.Port;
+                        vnextItem.address = _node.Address;
+                        vnextItem.port = _node.Port;
 
                         UsersItem4Ray usersItem;
                         if (vnextItem.users.Count <= 0)
@@ -120,7 +117,7 @@ public partial class CoreConfigV2rayService
                             usersItem = vnextItem.users.First();
                         }
 
-                        usersItem.id = node.Password;
+                        usersItem.id = _node.Password;
                         usersItem.alterId = int.TryParse(protocolExtra?.AlterId, out var result) ? result : 0;
                         usersItem.email = Global.UserEMail;
                         if (Global.VmessSecurities.Contains(protocolExtra.VmessSecurity))
@@ -149,10 +146,10 @@ public partial class CoreConfigV2rayService
                         {
                             serversItem = outbound.settings.servers.First();
                         }
-                        serversItem.address = node.Address;
-                        serversItem.port = node.Port;
-                        serversItem.password = node.Password;
-                        serversItem.method = AppManager.Instance.GetShadowsocksSecurities(node).Contains(protocolExtra.SsMethod)
+                        serversItem.address = _node.Address;
+                        serversItem.port = _node.Port;
+                        serversItem.password = _node.Password;
+                        serversItem.method = AppManager.Instance.GetShadowsocksSecurities(_node).Contains(protocolExtra.SsMethod)
                             ? protocolExtra.SsMethod : "none";
 
                         serversItem.ota = false;
@@ -176,18 +173,18 @@ public partial class CoreConfigV2rayService
                         {
                             serversItem = outbound.settings.servers.First();
                         }
-                        serversItem.address = node.Address;
-                        serversItem.port = node.Port;
+                        serversItem.address = _node.Address;
+                        serversItem.port = _node.Port;
                         serversItem.method = null;
                         serversItem.password = null;
 
-                        if (node.Username.IsNotEmpty()
-                            && node.Password.IsNotEmpty())
+                        if (_node.Username.IsNotEmpty()
+                            && _node.Password.IsNotEmpty())
                         {
                             SocksUsersItem4Ray socksUsersItem = new()
                             {
-                                user = node.Username ?? "",
-                                pass = node.Password,
+                                user = _node.Username ?? "",
+                                pass = _node.Password,
                                 level = 1
                             };
 
@@ -211,8 +208,8 @@ public partial class CoreConfigV2rayService
                         {
                             vnextItem = outbound.settings.vnext.First();
                         }
-                        vnextItem.address = node.Address;
-                        vnextItem.port = node.Port;
+                        vnextItem.address = _node.Address;
+                        vnextItem.port = _node.Port;
 
                         UsersItem4Ray usersItem;
                         if (vnextItem.users.Count <= 0)
@@ -224,7 +221,7 @@ public partial class CoreConfigV2rayService
                         {
                             usersItem = vnextItem.users.First();
                         }
-                        usersItem.id = node.Password;
+                        usersItem.id = _node.Password;
                         usersItem.email = Global.UserEMail;
                         usersItem.encryption = protocolExtra.VlessEncryption;
 
@@ -251,9 +248,9 @@ public partial class CoreConfigV2rayService
                         {
                             serversItem = outbound.settings.servers.First();
                         }
-                        serversItem.address = node.Address;
-                        serversItem.port = node.Port;
-                        serversItem.password = node.Password;
+                        serversItem.address = _node.Address;
+                        serversItem.port = _node.Port;
+                        serversItem.password = _node.Password;
 
                         serversItem.ota = false;
                         serversItem.level = 1;
@@ -268,8 +265,8 @@ public partial class CoreConfigV2rayService
                         outbound.settings = new()
                         {
                             version = 2,
-                            address = node.Address,
-                            port = node.Port,
+                            address = _node.Address,
+                            port = _node.Port,
                         };
                         outbound.settings.vnext = null;
                         outbound.settings.servers = null;
@@ -277,7 +274,7 @@ public partial class CoreConfigV2rayService
                     }
                 case EConfigType.WireGuard:
                     {
-                        var address = node.Address;
+                        var address = _node.Address;
                         if (Utils.IsIpv6(address))
                         {
                             address = $"[{address}]";
@@ -285,12 +282,12 @@ public partial class CoreConfigV2rayService
                         var peer = new WireguardPeer4Ray
                         {
                             publicKey = protocolExtra.WgPublicKey ?? "",
-                            endpoint = address + ":" + node.Port.ToString()
+                            endpoint = address + ":" + _node.Port.ToString()
                         };
                         var setting = new Outboundsettings4Ray
                         {
                             address = Utils.String2List(protocolExtra.WgInterfaceAddress),
-                            secretKey = node.Password,
+                            secretKey = _node.Password,
                             reserved = Utils.String2List(protocolExtra.WgReserved)?.Select(int.Parse).ToList(),
                             mtu = protocolExtra.WgMtu > 0 ? protocolExtra.WgMtu : Global.TunMtus.First(),
                             peers = [peer]
@@ -302,8 +299,8 @@ public partial class CoreConfigV2rayService
                     }
             }
 
-            outbound.protocol = Global.ProtocolTypes[node.ConfigType];
-            if (node.ConfigType == EConfigType.Hysteria2)
+            outbound.protocol = Global.ProtocolTypes[_node.ConfigType];
+            if (_node.ConfigType == EConfigType.Hysteria2)
             {
                 outbound.protocol = "hysteria";
             }
@@ -325,13 +322,13 @@ public partial class CoreConfigV2rayService
             if (enabledTCP)
             {
                 outbound.mux.enabled = true;
-                outbound.mux.concurrency = context.AppConfig.Mux4RayItem.Concurrency;
+                outbound.mux.concurrency = _config.Mux4RayItem.Concurrency;
             }
             else if (enabledUDP)
             {
                 outbound.mux.enabled = true;
-                outbound.mux.xudpConcurrency = context.AppConfig.Mux4RayItem.XudpConcurrency;
-                outbound.mux.xudpProxyUDP443 = context.AppConfig.Mux4RayItem.XudpProxyUDP443;
+                outbound.mux.xudpConcurrency = _config.Mux4RayItem.XudpConcurrency;
+                outbound.mux.xudpProxyUDP443 = _config.Mux4RayItem.XudpProxyUDP443;
             }
         }
         catch (Exception ex)
@@ -344,43 +341,41 @@ public partial class CoreConfigV2rayService
     {
         try
         {
-            var node = context.Node;
-            var config = context.AppConfig;
             var streamSettings = outbound.streamSettings;
-            var network = node.GetNetwork();
-            if (node.ConfigType == EConfigType.Hysteria2)
+            var network = _node.GetNetwork();
+            if (_node.ConfigType == EConfigType.Hysteria2)
             {
                 network = "hysteria";
             }
             streamSettings.network = network;
-            var host = node.RequestHost.TrimEx();
-            var path = node.Path.TrimEx();
-            var sni = node.Sni.TrimEx();
+            var host = _node.RequestHost.TrimEx();
+            var path = _node.Path.TrimEx();
+            var sni = _node.Sni.TrimEx();
             var useragent = "";
-            if (!config.CoreBasicItem.DefUserAgent.IsNullOrEmpty())
+            if (!_config.CoreBasicItem.DefUserAgent.IsNullOrEmpty())
             {
                 try
                 {
-                    useragent = Global.UserAgentTexts[config.CoreBasicItem.DefUserAgent];
+                    useragent = Global.UserAgentTexts[_config.CoreBasicItem.DefUserAgent];
                 }
                 catch (KeyNotFoundException)
                 {
-                    useragent = config.CoreBasicItem.DefUserAgent;
+                    useragent = _config.CoreBasicItem.DefUserAgent;
                 }
             }
 
             //if tls
-            if (node.StreamSecurity == Global.StreamSecurity)
+            if (_node.StreamSecurity == Global.StreamSecurity)
             {
-                streamSettings.security = node.StreamSecurity;
+                streamSettings.security = _node.StreamSecurity;
 
                 TlsSettings4Ray tlsSettings = new()
                 {
-                    allowInsecure = Utils.ToBool(node.AllowInsecure.IsNullOrEmpty() ? config.CoreBasicItem.DefAllowInsecure.ToString().ToLower() : node.AllowInsecure),
-                    alpn = node.GetAlpn(),
-                    fingerprint = node.Fingerprint.IsNullOrEmpty() ? config.CoreBasicItem.DefFingerprint : node.Fingerprint,
-                    echConfigList = node.EchConfigList.NullIfEmpty(),
-                    echForceQuery = node.EchForceQuery.NullIfEmpty()
+                    allowInsecure = Utils.ToBool(_node.AllowInsecure.IsNullOrEmpty() ? _config.CoreBasicItem.DefAllowInsecure.ToString().ToLower() : _node.AllowInsecure),
+                    alpn = _node.GetAlpn(),
+                    fingerprint = _node.Fingerprint.IsNullOrEmpty() ? _config.CoreBasicItem.DefFingerprint : _node.Fingerprint,
+                    echConfigList = _node.EchConfigList.NullIfEmpty(),
+                    echForceQuery = _node.EchForceQuery.NullIfEmpty()
                 };
                 if (sni.IsNotEmpty())
                 {
@@ -390,7 +385,7 @@ public partial class CoreConfigV2rayService
                 {
                     tlsSettings.serverName = Utils.String2List(host)?.First();
                 }
-                var certs = CertPemManager.ParsePemChain(node.Cert);
+                var certs = CertPemManager.ParsePemChain(_node.Cert);
                 if (certs.Count > 0)
                 {
                     var certsettings = new List<CertificateSettings4Ray>();
@@ -407,27 +402,27 @@ public partial class CoreConfigV2rayService
                     tlsSettings.disableSystemRoot = true;
                     tlsSettings.allowInsecure = false;
                 }
-                else if (!node.CertSha.IsNullOrEmpty())
+                else if (!_node.CertSha.IsNullOrEmpty())
                 {
-                    tlsSettings.pinnedPeerCertSha256 = node.CertSha;
+                    tlsSettings.pinnedPeerCertSha256 = _node.CertSha;
                     tlsSettings.allowInsecure = false;
                 }
                 streamSettings.tlsSettings = tlsSettings;
             }
 
             //if Reality
-            if (node.StreamSecurity == Global.StreamSecurityReality)
+            if (_node.StreamSecurity == Global.StreamSecurityReality)
             {
-                streamSettings.security = node.StreamSecurity;
+                streamSettings.security = _node.StreamSecurity;
 
                 TlsSettings4Ray realitySettings = new()
                 {
-                    fingerprint = node.Fingerprint.IsNullOrEmpty() ? config.CoreBasicItem.DefFingerprint : node.Fingerprint,
+                    fingerprint = _node.Fingerprint.IsNullOrEmpty() ? _config.CoreBasicItem.DefFingerprint : _node.Fingerprint,
                     serverName = sni,
-                    publicKey = node.PublicKey,
-                    shortId = node.ShortId,
-                    spiderX = node.SpiderX,
-                    mldsa65Verify = node.Mldsa65Verify,
+                    publicKey = _node.PublicKey,
+                    shortId = _node.ShortId,
+                    spiderX = _node.SpiderX,
+                    mldsa65Verify = _node.Mldsa65Verify,
                     show = false,
                 };
 
@@ -440,25 +435,25 @@ public partial class CoreConfigV2rayService
                 case nameof(ETransport.kcp):
                     KcpSettings4Ray kcpSettings = new()
                     {
-                        mtu = config.KcpItem.Mtu,
-                        tti = config.KcpItem.Tti
+                        mtu = _config.KcpItem.Mtu,
+                        tti = _config.KcpItem.Tti
                     };
 
-                    kcpSettings.uplinkCapacity = config.KcpItem.UplinkCapacity;
-                    kcpSettings.downlinkCapacity = config.KcpItem.DownlinkCapacity;
+                    kcpSettings.uplinkCapacity = _config.KcpItem.UplinkCapacity;
+                    kcpSettings.downlinkCapacity = _config.KcpItem.DownlinkCapacity;
 
-                    kcpSettings.congestion = config.KcpItem.Congestion;
-                    kcpSettings.readBufferSize = config.KcpItem.ReadBufferSize;
-                    kcpSettings.writeBufferSize = config.KcpItem.WriteBufferSize;
+                    kcpSettings.congestion = _config.KcpItem.Congestion;
+                    kcpSettings.readBufferSize = _config.KcpItem.ReadBufferSize;
+                    kcpSettings.writeBufferSize = _config.KcpItem.WriteBufferSize;
                     streamSettings.finalmask ??= new();
-                    if (Global.KcpHeaderMaskMap.TryGetValue(node.HeaderType, out var header))
+                    if (Global.KcpHeaderMaskMap.TryGetValue(_node.HeaderType, out var header))
                     {
                         streamSettings.finalmask.udp =
                         [
                             new Mask4Ray
                             {
                                 type = header,
-                                settings = node.HeaderType == "dns" && !host.IsNullOrEmpty() ? new MaskSettings4Ray { domain = host } : null
+                                settings = _node.HeaderType == "dns" && !host.IsNullOrEmpty() ? new MaskSettings4Ray { domain = host } : null
                             }
                         ];
                     }
@@ -528,13 +523,13 @@ public partial class CoreConfigV2rayService
                     {
                         xhttpSettings.host = host;
                     }
-                    if (node.HeaderType.IsNotEmpty() && Global.XhttpMode.Contains(node.HeaderType))
+                    if (_node.HeaderType.IsNotEmpty() && Global.XhttpMode.Contains(_node.HeaderType))
                     {
-                        xhttpSettings.mode = node.HeaderType;
+                        xhttpSettings.mode = _node.HeaderType;
                     }
-                    if (node.Extra.IsNotEmpty())
+                    if (_node.Extra.IsNotEmpty())
                     {
-                        xhttpSettings.extra = JsonUtils.ParseJson(node.Extra);
+                        xhttpSettings.extra = JsonUtils.ParseJson(_node.Extra);
                     }
 
                     streamSettings.xhttpSettings = xhttpSettings;
@@ -562,11 +557,11 @@ public partial class CoreConfigV2rayService
                         key = path,
                         header = new Header4Ray
                         {
-                            type = node.HeaderType
+                            type = _node.HeaderType
                         }
                     };
                     streamSettings.quicSettings = quicsettings;
-                    if (node.StreamSecurity == Global.StreamSecurity)
+                    if (_node.StreamSecurity == Global.StreamSecurity)
                     {
                         if (sni.IsNotEmpty())
                         {
@@ -574,7 +569,7 @@ public partial class CoreConfigV2rayService
                         }
                         else
                         {
-                            streamSettings.tlsSettings.serverName = node.Address;
+                            streamSettings.tlsSettings.serverName = _node.Address;
                         }
                     }
                     break;
@@ -584,28 +579,28 @@ public partial class CoreConfigV2rayService
                     {
                         authority = host.NullIfEmpty(),
                         serviceName = path,
-                        multiMode = node.HeaderType == Global.GrpcMultiMode,
-                        idle_timeout = config.GrpcItem.IdleTimeout,
-                        health_check_timeout = config.GrpcItem.HealthCheckTimeout,
-                        permit_without_stream = config.GrpcItem.PermitWithoutStream,
-                        initial_windows_size = config.GrpcItem.InitialWindowsSize,
+                        multiMode = _node.HeaderType == Global.GrpcMultiMode,
+                        idle_timeout = _config.GrpcItem.IdleTimeout,
+                        health_check_timeout = _config.GrpcItem.HealthCheckTimeout,
+                        permit_without_stream = _config.GrpcItem.PermitWithoutStream,
+                        initial_windows_size = _config.GrpcItem.InitialWindowsSize,
                     };
                     streamSettings.grpcSettings = grpcSettings;
                     break;
 
                 case "hysteria":
-                    var protocolExtra = node.GetProtocolExtra();
+                    var protocolExtra = _node.GetProtocolExtra();
                     var ports = protocolExtra?.Ports;
                     int? upMbps = protocolExtra?.UpMbps is { } su and >= 0
                         ? su
-                        : config.HysteriaItem.UpMbps;
+                        : _config.HysteriaItem.UpMbps;
                     int? downMbps = protocolExtra?.DownMbps is { } sd and >= 0
                         ? sd
-                        : config.HysteriaItem.UpMbps;
+                        : _config.HysteriaItem.UpMbps;
                     var hopInterval = !protocolExtra.HopInterval.IsNullOrEmpty()
                         ? protocolExtra.HopInterval
-                        : (config.HysteriaItem.HopInterval >= 5
-                            ? config.HysteriaItem.HopInterval
+                        : (_config.HysteriaItem.HopInterval >= 5
+                            ? _config.HysteriaItem.HopInterval
                             : Global.Hysteria2DefaultHopInt).ToString();
                     HysteriaUdpHop4Ray? udpHop = null;
                     if (!ports.IsNullOrEmpty() &&
@@ -620,7 +615,7 @@ public partial class CoreConfigV2rayService
                     streamSettings.hysteriaSettings = new()
                     {
                         version = 2,
-                        auth = node.Password,
+                        auth = _node.Password,
                         up = upMbps > 0 ? $"{upMbps}mbps" : null,
                         down = downMbps > 0 ? $"{downMbps}mbps" : null,
                         udphop = udpHop,
@@ -641,13 +636,13 @@ public partial class CoreConfigV2rayService
 
                 default:
                     //tcp
-                    if (node.HeaderType == Global.TcpHeaderHttp)
+                    if (_node.HeaderType == Global.TcpHeaderHttp)
                     {
                         TcpSettings4Ray tcpSettings = new()
                         {
                             header = new Header4Ray
                             {
-                                type = node.HeaderType
+                                type = _node.HeaderType
                             }
                         };
 
@@ -681,7 +676,7 @@ public partial class CoreConfigV2rayService
     private List<Outbounds4Ray> BuildOutboundsList(string baseTagName = Global.ProxyTag)
     {
         var nodes = new List<ProfileItem>();
-        foreach (var nodeId in Utils.String2List(context.Node.GetProtocolExtra().ChildItems) ?? [])
+        foreach (var nodeId in Utils.String2List(_node.GetProtocolExtra().ChildItems) ?? [])
         {
             if (context.AllProxiesMap.TryGetValue(nodeId, out var node))
             {
@@ -710,7 +705,7 @@ public partial class CoreConfigV2rayService
     private List<Outbounds4Ray> BuildChainOutboundsList(string baseTagName = Global.ProxyTag)
     {
         var nodes = new List<ProfileItem>();
-        foreach (var nodeId in Utils.String2List(context.Node.GetProtocolExtra().ChildItems) ?? [])
+        foreach (var nodeId in Utils.String2List(_node.GetProtocolExtra().ChildItems) ?? [])
         {
             if (context.AllProxiesMap.TryGetValue(nodeId, out var node))
             {

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
@@ -692,7 +692,7 @@ public partial class CoreConfigV2rayService
         for (var i = 0; i < nodes.Count; i++)
         {
             var node = nodes[i];
-            var currentTag = baseTagName + (i + 1).ToString();
+            var currentTag = $"{baseTagName}-{i + 1}";
 
             if (node.ConfigType.IsGroupType())
             {
@@ -723,8 +723,8 @@ public partial class CoreConfigV2rayService
         for (var i = 0; i < nodesReverse.Count; i++)
         {
             var node = nodesReverse[i];
-            var currentTag = i == 0 ? baseTagName : "chain-" + baseTagName + i.ToString();
-            var dialerProxyTag = i != nodesReverse.Count - 1 ? "chain-" + baseTagName + (i + 1).ToString() : null;
+            var currentTag = i == 0 ? baseTagName : $"chain-{baseTagName}-{i}";
+            var dialerProxyTag = i != nodesReverse.Count - 1 ? $"chain-{baseTagName}-{i + 1}" : null;
             if (node.ConfigType.IsGroupType())
             {
                 var childProfiles = new CoreConfigV2rayService(context with { Node = node, }).BuildGroupProxyOutbounds(currentTag);
@@ -751,7 +751,7 @@ public partial class CoreConfigV2rayService
                         for (var j = 0; j < existedChainNodesClone.Count; j++)
                         {
                             var existedChainNode = existedChainNodesClone[j];
-                            var cloneTag = $"{existedChainNode.tag}-clone{j}";
+                            var cloneTag = $"{existedChainNode.tag}-clone-{j + 1}";
                             existedChainNode.tag = cloneTag;
                             var previousDialerProxyTag = existedChainNode.streamSettings?.sockopt?.dialerProxy;
                             existedChainNode.streamSettings.sockopt = new()

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayRoutingService.cs
@@ -8,7 +8,7 @@ public partial class CoreConfigV2rayService
         {
             if (_coreConfig.routing?.rules != null)
             {
-                _coreConfig.routing.domainStrategy = context.AppConfig.RoutingBasicItem.DomainStrategy;
+                _coreConfig.routing.domainStrategy = _config.RoutingBasicItem.DomainStrategy;
 
                 var routing = context.RoutingItem;
                 if (routing != null)
@@ -165,7 +165,7 @@ public partial class CoreConfigV2rayService
         }
 
         var tag = $"{node.IndexId}-{Global.ProxyTag}";
-        if (_coreConfig.outbounds.Any(p => p.tag == tag))
+        if (_coreConfig.outbounds.Any(p => p.tag.StartsWith(tag)))
         {
             return tag;
         }

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayRoutingService.cs
@@ -39,9 +39,9 @@ public partial class CoreConfigV2rayService
                     .ToList() ?? [];
                 if (balancerTagList.Count > 0)
                 {
-                    foreach (var rulesItem in _coreConfig.routing.rules.Where(r => balancerTagList.Contains(r.outboundTag)))
+                    foreach (var rulesItem in _coreConfig.routing.rules.Where(r => balancerTagList.Contains(r.outboundTag + Global.BalancerTagSuffix)))
                     {
-                        rulesItem.balancerTag = rulesItem.outboundTag;
+                        rulesItem.balancerTag = rulesItem.outboundTag + Global.BalancerTagSuffix;
                         rulesItem.outboundTag = null;
                     }
                 }

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayStatisticService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayStatisticService.cs
@@ -4,7 +4,7 @@ public partial class CoreConfigV2rayService
 {
     private void GenStatistic()
     {
-        if (context.AppConfig.GuiItem.EnableStatistics || context.AppConfig.GuiItem.DisplayRealTimeSpeed)
+        if (_config.GuiItem.EnableStatistics || _config.GuiItem.DisplayRealTimeSpeed)
         {
             var tag = EInboundProtocol.api.ToString();
             Metrics4Ray apiObj = new();

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayStatisticService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayStatisticService.cs
@@ -2,26 +2,26 @@ namespace ServiceLib.Services.CoreConfig;
 
 public partial class CoreConfigV2rayService
 {
-    private async Task<int> GenStatistic(V2rayConfig v2rayConfig)
+    private void GenStatistic()
     {
-        if (_config.GuiItem.EnableStatistics || _config.GuiItem.DisplayRealTimeSpeed)
+        if (context.AppConfig.GuiItem.EnableStatistics || context.AppConfig.GuiItem.DisplayRealTimeSpeed)
         {
             var tag = EInboundProtocol.api.ToString();
             Metrics4Ray apiObj = new();
             Policy4Ray policyObj = new();
             SystemPolicy4Ray policySystemSetting = new();
 
-            v2rayConfig.stats = new Stats4Ray();
+            _coreConfig.stats = new Stats4Ray();
 
             apiObj.tag = tag;
-            v2rayConfig.metrics = apiObj;
+            _coreConfig.metrics = apiObj;
 
             policySystemSetting.statsOutboundDownlink = true;
             policySystemSetting.statsOutboundUplink = true;
             policyObj.system = policySystemSetting;
-            v2rayConfig.policy = policyObj;
+            _coreConfig.policy = policyObj;
 
-            if (!v2rayConfig.inbounds.Exists(item => item.tag == tag))
+            if (!_coreConfig.inbounds.Exists(item => item.tag == tag))
             {
                 Inbounds4Ray apiInbound = new();
                 Inboundsettings4Ray apiInboundSettings = new();
@@ -31,10 +31,10 @@ public partial class CoreConfigV2rayService
                 apiInbound.protocol = Global.InboundAPIProtocol;
                 apiInboundSettings.address = Global.Loopback;
                 apiInbound.settings = apiInboundSettings;
-                v2rayConfig.inbounds.Add(apiInbound);
+                _coreConfig.inbounds.Add(apiInbound);
             }
 
-            if (!v2rayConfig.routing.rules.Exists(item => item.outboundTag == tag))
+            if (!_coreConfig.routing.rules.Exists(item => item.outboundTag == tag))
             {
                 RulesItem4Ray apiRoutingRule = new()
                 {
@@ -43,9 +43,8 @@ public partial class CoreConfigV2rayService
                     type = "field"
                 };
 
-                v2rayConfig.routing.rules.Add(apiRoutingRule);
+                _coreConfig.routing.rules.Add(apiRoutingRule);
             }
         }
-        return await Task.FromResult(0);
     }
 }

--- a/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
@@ -801,7 +801,8 @@ public class ProfilesViewModel : MyReactiveObject
 
         if (blClipboard)
         {
-            var result = await CoreConfigHandler.GenerateClientConfig(item, null);
+            var context = await CoreConfigHandler.BuildCoreConfigContext(_config, item);
+            var result = await CoreConfigHandler.GenerateClientConfig(context, null);
             if (result.Success != true)
             {
                 NoticeManager.Instance.Enqueue(result.Msg);
@@ -824,7 +825,8 @@ public class ProfilesViewModel : MyReactiveObject
         {
             return;
         }
-        var result = await CoreConfigHandler.GenerateClientConfig(item, fileName);
+        var context = await CoreConfigHandler.BuildCoreConfigContext(_config, item);
+        var result = await CoreConfigHandler.GenerateClientConfig(context, fileName);
         if (result.Success != true)
         {
             NoticeManager.Instance.Enqueue(result.Msg);


### PR DESCRIPTION
重构配置生成代码

一个 ProfileItem 可能对应多个节点，所以做出了如下简化重构

- 删除 outbound 生成里杂七杂八的函数，只留下三种基本生成：普通单配置，策略组，链式
- 添加 CoreConfigContext , 提供配置生成所需所有的信息，而不是 await 就地获取或参数传递。由此可以传递更多信息，并且未来可以写测试什么的
- 函数重命名，因为全程操作的只有一个 config dto，所以将其放到成员变量中 _coreConfig。Gen 函数表示直接对 _coreConfig 直接操作，Build 函数生成 dto 对象，Fill 函数则是修改传入引用参数。
- 生成其他 outbound 使用新实例化一个 CoreConfigService 和 Context, 调用他的私有函数实现
- 订阅分组的前置/落地代理统一为链式代理