### PR TITLE
Tun protect

### DIFF
--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -1233,28 +1233,19 @@ public static class ConfigHandler
     /// <returns>A SOCKS profile item or null if not needed</returns>
     public static ProfileItem? GetPreSocksItem(Config config, ProfileItem node, ECoreType coreType)
     {
+        if (node.ConfigType != EConfigType.Custom || !(node.PreSocksPort > 0))
+        {
+            return null;
+        }
         ProfileItem? itemSocks = null;
-        if (node.ConfigType != EConfigType.Custom && coreType != ECoreType.sing_box && config.TunModeItem.EnableTun)
+        var preCoreType = AppManager.Instance.RunningCoreType = config.TunModeItem.EnableTun ? ECoreType.sing_box : ECoreType.Xray;
+        itemSocks = new ProfileItem()
         {
-            itemSocks = new ProfileItem()
-            {
-                CoreType = ECoreType.sing_box,
-                ConfigType = EConfigType.SOCKS,
-                Address = Global.Loopback,
-                Port = AppManager.Instance.GetLocalPort(EInboundProtocol.socks)
-            };
-        }
-        else if (node.ConfigType == EConfigType.Custom && node.PreSocksPort > 0)
-        {
-            var preCoreType = AppManager.Instance.RunningCoreType = config.TunModeItem.EnableTun ? ECoreType.sing_box : ECoreType.Xray;
-            itemSocks = new ProfileItem()
-            {
-                CoreType = preCoreType,
-                ConfigType = EConfigType.SOCKS,
-                Address = Global.Loopback,
-                Port = node.PreSocksPort.Value,
-            };
-        }
+            CoreType = preCoreType,
+            ConfigType = EConfigType.SOCKS,
+            Address = Global.Loopback,
+            Port = node.PreSocksPort.Value,
+        };
         return itemSocks;
     }
 

--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -1249,6 +1249,47 @@ public static class ConfigHandler
         return itemSocks;
     }
 
+    public static CoreConfigContext? GetPreSocksCoreConfigContext(CoreConfigContext nodeContext)
+    {
+        var config = nodeContext.AppConfig;
+        var node = nodeContext.Node;
+        var coreType = AppManager.Instance.GetCoreType(node, node.ConfigType);
+
+        var preSocksItem = GetPreSocksItem(config, node, coreType);
+        if (preSocksItem != null)
+        {
+            return nodeContext with { Node = preSocksItem, };
+        }
+
+        if ((!nodeContext.IsTunEnabled)
+            || coreType != ECoreType.Xray
+            || node.ConfigType == EConfigType.Custom)
+        {
+            return null;
+        }
+        var tunProtectSsPort = Utils.GetFreePort();
+        var proxyRelaySsPort = Utils.GetFreePort();
+        var preItem = new ProfileItem()
+        {
+            CoreType = ECoreType.sing_box,
+            ConfigType = EConfigType.Shadowsocks,
+            Address = Global.Loopback,
+            Port = proxyRelaySsPort,
+            Password = Global.None,
+        };
+        preItem.SetProtocolExtra(preItem.GetProtocolExtra() with
+        {
+            SsMethod = Global.None,
+        });
+        var preContext = nodeContext with
+        {
+            Node = preItem,
+            TunProtectSsPort = tunProtectSsPort,
+            ProxyRelaySsPort = proxyRelaySsPort,
+        };
+        return preContext;
+    }
+
     /// <summary>
     /// Remove servers with invalid test results (timeout)
     /// Useful for cleaning up subscription lists

--- a/v2rayN/ServiceLib/Handler/CoreConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/CoreConfigHandler.cs
@@ -154,7 +154,8 @@ public static class CoreConfigHandler
             IsTunEnabled = config.TunModeItem.EnableTun,
             SimpleDnsItem = config.SimpleDNSItem,
             ProtectDomainList = [],
-            ProtectSocksPort = 0,
+            TunProtectSsPort = 0,
+            ProxyRelaySsPort = 0,
             RawDnsItem = await AppManager.Instance.GetDNSItem(coreType),
             RoutingItem = await ConfigHandler.GetDefaultRouting(config),
         };

--- a/v2rayN/ServiceLib/Manager/CoreManager.cs
+++ b/v2rayN/ServiceLib/Manager/CoreManager.cs
@@ -67,37 +67,13 @@ public class CoreManager
 
         var fileName = Utils.GetBinConfigPath(Global.CoreConfigFileName);
         var context = await CoreConfigHandler.BuildCoreConfigContext(_config, node);
-        CoreConfigContext? preContext = null;
-        if (context.IsTunEnabled)
+        var preContext = ConfigHandler.GetPreSocksCoreConfigContext(context);
+        if (preContext is not null)
         {
-            var coreType = AppManager.Instance.GetCoreType(node, node.ConfigType);
-            if (coreType == ECoreType.Xray && node.ConfigType != EConfigType.Custom)
+            context = context with
             {
-                var tunProtectSsPort = Utils.GetFreePort();
-                var proxyRelaySsPort = Utils.GetFreePort();
-                context = context with { TunProtectSsPort = tunProtectSsPort, ProxyRelaySsPort = proxyRelaySsPort, };
-                var preItem = new ProfileItem()
-                {
-                    CoreType = ECoreType.sing_box,
-                    ConfigType = EConfigType.Shadowsocks,
-                    Address = Global.Loopback,
-                    Port = proxyRelaySsPort,
-                    Password = Global.None,
-                };
-                preItem.SetProtocolExtra(preItem.GetProtocolExtra() with
-                {
-                    SsMethod = Global.None,
-                });
-                preContext = context with { Node = preItem, };
-            }
-            else
-            {
-                var preItem = ConfigHandler.GetPreSocksItem(_config, node, coreType);
-                if (preItem is not null)
-                {
-                    preContext = context with { Node = preItem, };
-                }
-            }
+                TunProtectSsPort = preContext.TunProtectSsPort, ProxyRelaySsPort = preContext.ProxyRelaySsPort,
+            };
         }
         var result = await CoreConfigHandler.GenerateClientConfig(context, fileName);
         if (result.Success != true)

--- a/v2rayN/ServiceLib/Models/ConfigItems.cs
+++ b/v2rayN/ServiceLib/Models/ConfigItems.cs
@@ -144,7 +144,6 @@ public class TunModeItem
     public bool StrictRoute { get; set; } = true;
     public string Stack { get; set; }
     public int Mtu { get; set; }
-    public bool EnableExInbound { get; set; }
     public bool EnableIPv6Address { get; set; }
 }
 

--- a/v2rayN/ServiceLib/Models/CoreConfigContext.cs
+++ b/v2rayN/ServiceLib/Models/CoreConfigContext.cs
@@ -13,5 +13,9 @@ public record CoreConfigContext
     // TUN Compatibility
     public bool IsTunEnabled { get; init; } = false;
     public HashSet<string> ProtectDomainList { get; init; } = new();
-    public int ProtectSocksPort { get; init; } = 0;
+    // -> tun inbound --(if routing proxy)--> relay outbound    
+    // -> proxy core (relay inbound --> proxy outbound --(dialerProxy)--> protect outbound)
+    // -> protect inbound -> direct proxy outbound data -> internet
+    public int TunProtectSsPort { get; init; } = 0;
+    public int ProxyRelaySsPort { get; init; } = 0;
 }

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -3772,15 +3772,6 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
-        ///   查找类似 Enable additional Inbound 的本地化字符串。
-        /// </summary>
-        public static string TbSettingsEnableExInbound {
-            get {
-                return ResourceManager.GetString("TbSettingsEnableExInbound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   查找类似 Enable fragment 的本地化字符串。
         /// </summary>
         public static string TbSettingsEnableFragment {

--- a/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fa-Ir.resx
@@ -1071,9 +1071,6 @@
   <data name="TbSettingsTunMtu" xml:space="preserve">
     <value>MTU</value>
   </data>
-  <data name="TbSettingsEnableExInbound" xml:space="preserve">
-    <value>فعال سازی additional Inbound</value>
-  </data>
   <data name="TbSettingsEnableIPv6Address" xml:space="preserve">
     <value>فعال سازی آدرس IPv6</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.fr.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fr.resx
@@ -1068,9 +1068,6 @@
   <data name="TbSettingsTunMtu" xml:space="preserve">
     <value>MTU</value>
   </data>
-  <data name="TbSettingsEnableExInbound" xml:space="preserve">
-    <value>Activer un port d’écoute supplémentaire</value>
-  </data>
   <data name="TbSettingsEnableIPv6Address" xml:space="preserve">
     <value>Activer IPv6</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.hu.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.hu.resx
@@ -1071,9 +1071,6 @@
   <data name="TbSettingsTunMtu" xml:space="preserve">
     <value>MTU</value>
   </data>
-  <data name="TbSettingsEnableExInbound" xml:space="preserve">
-    <value>További bejövő engedélyezése</value>
-  </data>
   <data name="TbSettingsEnableIPv6Address" xml:space="preserve">
     <value>IPv6 cím engedélyezése</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1071,9 +1071,6 @@
   <data name="TbSettingsTunMtu" xml:space="preserve">
     <value>MTU</value>
   </data>
-  <data name="TbSettingsEnableExInbound" xml:space="preserve">
-    <value>Enable additional Inbound</value>
-  </data>
   <data name="TbSettingsEnableIPv6Address" xml:space="preserve">
     <value>Enable IPv6 Address</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1071,9 +1071,6 @@
   <data name="TbSettingsTunMtu" xml:space="preserve">
     <value>MTU</value>
   </data>
-  <data name="TbSettingsEnableExInbound" xml:space="preserve">
-    <value>Включить дополнительный входящий канал</value>
-  </data>
   <data name="TbSettingsEnableIPv6Address" xml:space="preserve">
     <value>Включить IPv6 адреса</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1068,9 +1068,6 @@
   <data name="TbSettingsTunMtu" xml:space="preserve">
     <value>MTU</value>
   </data>
-  <data name="TbSettingsEnableExInbound" xml:space="preserve">
-    <value>启用额外监听端口</value>
-  </data>
   <data name="TbSettingsEnableIPv6Address" xml:space="preserve">
     <value>启用 IPv6</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -1068,9 +1068,6 @@
   <data name="TbSettingsTunMtu" xml:space="preserve">
     <value>MTU</value>
   </data>
-  <data name="TbSettingsEnableExInbound" xml:space="preserve">
-    <value>啟用額外偵聽連接埠</value>
-  </data>
   <data name="TbSettingsEnableIPv6Address" xml:space="preserve">
     <value>啟用 IPv6</value>
   </data>

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxInboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxInboundService.cs
@@ -7,10 +7,11 @@ public partial class CoreConfigSingboxService
         try
         {
             var listen = "0.0.0.0";
+            var listenPort = AppManager.Instance.GetLocalPort(EInboundProtocol.socks);
             _coreConfig.inbounds = [];
 
-            if (!_config.TunModeItem.EnableTun
-                || (_config.TunModeItem.EnableTun && _config.TunModeItem.EnableExInbound && AppManager.Instance.RunningCoreType == ECoreType.sing_box))
+            if (!context.IsTunEnabled
+                || (context.IsTunEnabled && _node.Port != listenPort))
             {
                 var inbound = new Inbound4Sbox()
                 {
@@ -20,7 +21,7 @@ public partial class CoreConfigSingboxService
                 };
                 _coreConfig.inbounds.Add(inbound);
 
-                inbound.listen_port = AppManager.Instance.GetLocalPort(EInboundProtocol.socks);
+                inbound.listen_port = listenPort;
 
                 if (_config.Inbound.First().SecondLocalPortEnabled)
                 {
@@ -49,7 +50,7 @@ public partial class CoreConfigSingboxService
                 }
             }
 
-            if (_config.TunModeItem.EnableTun)
+            if (context.IsTunEnabled)
             {
                 if (_config.TunModeItem.Mtu <= 0)
                 {

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
@@ -333,7 +333,7 @@ public partial class CoreConfigV2rayService(CoreConfigContext context)
                 {
                     inboundTag = new List<string> { "proxy-relay-ss" },
                     outboundTag = hasBalancer ? null : Global.ProxyTag,
-                    balancerTag = hasBalancer ? Global.ProxyTag : null,
+                    balancerTag = hasBalancer ? Global.ProxyTag + Global.BalancerTagSuffix: null,
                     type = "field"
                 }
             ];

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
@@ -304,7 +304,7 @@ public partial class CoreConfigV2rayService(CoreConfigContext context)
 
             var protectNode = new ProfileItem()
             {
-                CoreType = ECoreType.sing_box,
+                CoreType = ECoreType.Xray,
                 ConfigType = EConfigType.Shadowsocks,
                 Address = Global.Loopback,
                 Port = context.TunProtectSsPort,

--- a/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
@@ -95,7 +95,6 @@ public class OptionSettingViewModel : MyReactiveObject
     [Reactive] public bool TunStrictRoute { get; set; }
     [Reactive] public string TunStack { get; set; }
     [Reactive] public int TunMtu { get; set; }
-    [Reactive] public bool TunEnableExInbound { get; set; }
     [Reactive] public bool TunEnableIPv6Address { get; set; }
 
     #endregion Tun mode
@@ -220,7 +219,6 @@ public class OptionSettingViewModel : MyReactiveObject
         TunStrictRoute = _config.TunModeItem.StrictRoute;
         TunStack = _config.TunModeItem.Stack;
         TunMtu = _config.TunModeItem.Mtu;
-        TunEnableExInbound = _config.TunModeItem.EnableExInbound;
         TunEnableIPv6Address = _config.TunModeItem.EnableIPv6Address;
 
         #endregion Tun mode
@@ -380,7 +378,6 @@ public class OptionSettingViewModel : MyReactiveObject
         _config.TunModeItem.StrictRoute = TunStrictRoute;
         _config.TunModeItem.Stack = TunStack;
         _config.TunModeItem.Mtu = TunMtu;
-        _config.TunModeItem.EnableExInbound = TunEnableExInbound;
         _config.TunModeItem.EnableIPv6Address = TunEnableIPv6Address;
 
         //coreType

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
@@ -844,19 +844,6 @@
                         HorizontalAlignment="Left" />
 
                     <TextBlock
-                        Grid.Row="6"
-                        Grid.Column="0"
-                        Margin="{StaticResource Margin4}"
-                        VerticalAlignment="Center"
-                        Text="{x:Static resx:ResUI.TbSettingsEnableExInbound}" />
-                    <ToggleSwitch
-                        x:Name="togEnableExInbound"
-                        Grid.Row="6"
-                        Grid.Column="1"
-                        Margin="{StaticResource Margin4}"
-                        HorizontalAlignment="Left" />
-
-                    <TextBlock
                         Grid.Row="7"
                         Grid.Column="0"
                         Margin="{StaticResource Margin4}"

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
@@ -114,7 +114,6 @@ public partial class OptionSettingWindow : WindowBase<OptionSettingViewModel>
             this.Bind(ViewModel, vm => vm.TunStrictRoute, v => v.togStrictRoute.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.TunStack, v => v.cmbStack.SelectedValue).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.TunMtu, v => v.cmbMtu.SelectedValue).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.TunEnableExInbound, v => v.togEnableExInbound.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.TunEnableIPv6Address, v => v.togEnableIPv6Address.IsChecked).DisposeWith(disposables);
 
             this.Bind(ViewModel, vm => vm.CoreType1, v => v.cmbCoreType1.SelectedValue).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
@@ -1098,20 +1098,6 @@
                         Style="{StaticResource DefComboBox}" />
 
                     <TextBlock
-                        Grid.Row="6"
-                        Grid.Column="0"
-                        Margin="{StaticResource Margin8}"
-                        VerticalAlignment="Center"
-                        Style="{StaticResource ToolbarTextBlock}"
-                        Text="{x:Static resx:ResUI.TbSettingsEnableExInbound}" />
-                    <ToggleButton
-                        x:Name="togEnableExInbound"
-                        Grid.Row="6"
-                        Grid.Column="1"
-                        Margin="{StaticResource Margin8}"
-                        HorizontalAlignment="Left" />
-
-                    <TextBlock
                         Grid.Row="7"
                         Grid.Column="0"
                         Margin="{StaticResource Margin8}"

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
@@ -119,7 +119,6 @@ public partial class OptionSettingWindow
             this.Bind(ViewModel, vm => vm.TunStrictRoute, v => v.togStrictRoute.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.TunStack, v => v.cmbStack.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.TunMtu, v => v.cmbMtu.Text).DisposeWith(disposables);
-            this.Bind(ViewModel, vm => vm.TunEnableExInbound, v => v.togEnableExInbound.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.TunEnableIPv6Address, v => v.togEnableIPv6Address.IsChecked).DisposeWith(disposables);
 
             this.Bind(ViewModel, vm => vm.CoreType1, v => v.cmbCoreType1.Text).DisposeWith(disposables);


### PR DESCRIPTION
基于 #8768

彻底解决因双核心回环导致的 TUN 不可用问题

sing-box 开启一个直连出站的 protect 入站，xray 将其作为前置代理，解决因 DNS 以及进程嗅探失败等原因导致的 TUN 不可用