### PR TITLE
Speedtest respect user-set core type

### DIFF
--- a/v2rayN/ServiceLib/Handler/CoreConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/CoreConfigHandler.cs
@@ -99,11 +99,9 @@ public static class CoreConfigHandler
         };
         var builderResult = await CoreConfigContextBuilder.Build(config, dummyNode);
         var context = builderResult.Context;
-        var ids = selecteds.Where(serverTestItem => !serverTestItem.IndexId.IsNullOrEmpty())
-            .Select(serverTestItem => serverTestItem.IndexId);
-        var nodes = await AppManager.Instance.GetProfileItemsByIndexIds(ids);
-        foreach (var node in nodes)
+        foreach (var testItem in selecteds)
         {
+            var node = testItem.Profile;
             var (actNode, _) = await CoreConfigContextBuilder.ResolveNodeAsync(context, node, true);
             if (node.IndexId == actNode.IndexId)
             {

--- a/v2rayN/ServiceLib/Manager/AppManager.cs
+++ b/v2rayN/ServiceLib/Manager/AppManager.cs
@@ -242,6 +242,12 @@ public sealed class AppManager
             .ToListAsync();
     }
 
+    public async Task<Dictionary<string, ProfileItem>> GetProfileItemsByIndexIdsAsMap(IEnumerable<string> indexIds)
+    {
+        var items = await GetProfileItemsByIndexIds(indexIds);
+        return items.ToDictionary(it => it.IndexId);
+    }
+
     public async Task<ProfileItem?> GetProfileItemViaRemarks(string? remarks)
     {
         if (remarks.IsNullOrEmpty())

--- a/v2rayN/ServiceLib/Manager/CoreManager.cs
+++ b/v2rayN/ServiceLib/Manager/CoreManager.cs
@@ -106,7 +106,7 @@ public class CoreManager
 
     public async Task<ProcessService?> LoadCoreConfigSpeedtest(List<ServerTestItem> selecteds)
     {
-        var coreType = selecteds.Any(t => Global.SingboxOnlyConfigType.Contains(t.ConfigType)) ? ECoreType.sing_box : ECoreType.Xray;
+        var coreType = selecteds.FirstOrDefault()?.CoreType == ECoreType.sing_box ? ECoreType.sing_box : ECoreType.Xray;
         var fileName = string.Format(Global.CoreSpeedtestConfigFileName, Utils.GetGuid(false));
         var configPath = Utils.GetBinConfigPath(fileName);
         var result = await CoreConfigHandler.GenerateClientSpeedtestConfig(_config, configPath, selecteds, coreType);

--- a/v2rayN/ServiceLib/Manager/GroupProfileManager.cs
+++ b/v2rayN/ServiceLib/Manager/GroupProfileManager.cs
@@ -103,16 +103,7 @@ public class GroupProfileManager
             return [];
         }
 
-        var childProfiles = await AppManager.Instance.GetProfileItemsByIndexIds(childProfileIds);
-        if (childProfiles == null || childProfiles.Count == 0)
-        {
-            return [];
-        }
-
-        var profileMap = childProfiles
-            .Where(p => p != null && !p.IndexId.IsNullOrEmpty())
-            .GroupBy(p => p!.IndexId!)
-            .ToDictionary(g => g.Key, g => g.First());
+        var profileMap = await AppManager.Instance.GetProfileItemsByIndexIdsAsMap(childProfileIds);
 
         var ordered = new List<ProfileItem>(childProfileIds.Count);
         foreach (var id in childProfileIds)

--- a/v2rayN/ServiceLib/Models/ServerTestItem.cs
+++ b/v2rayN/ServiceLib/Models/ServerTestItem.cs
@@ -9,4 +9,6 @@ public class ServerTestItem
     public EConfigType ConfigType { get; set; }
     public bool AllowTest { get; set; }
     public int QueueNum { get; set; }
+    public required ProfileItem Profile { get; set; }
+    public ECoreType CoreType { get; set; }
 }

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/CoreConfigSingboxService.cs
@@ -149,11 +149,11 @@ public partial class CoreConfigSingboxService(CoreConfigContext context)
 
             foreach (var it in selecteds)
             {
-                if (!Global.SingboxSupportConfigType.Contains(it.ConfigType))
+                if (!(Global.SingboxSupportConfigType.Contains(it.ConfigType) || it.ConfigType.IsGroupType()))
                 {
                     continue;
                 }
-                if (it.Port <= 0)
+                if (!it.ConfigType.IsComplexType() && it.Port <= 0)
                 {
                     continue;
                 }

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
@@ -112,11 +112,11 @@ public partial class CoreConfigV2rayService(CoreConfigContext context)
 
             foreach (var it in selecteds)
             {
-                if (!Global.XraySupportConfigType.Contains(it.ConfigType))
+                if (!(Global.XraySupportConfigType.Contains(it.ConfigType) || it.ConfigType.IsGroupType()))
                 {
                     continue;
                 }
-                if (it.Port <= 0)
+                if (!it.ConfigType.IsComplexType() && it.Port <= 0)
                 {
                     continue;
                 }
@@ -180,13 +180,13 @@ public partial class CoreConfigV2rayService(CoreConfigContext context)
                 //rule
                 RulesItem4Ray rule = new()
                 {
-                    inboundTag = new List<string> { inbound.tag },
+                    inboundTag = [inbound.tag],
                     outboundTag = tag,
                     type = "field"
                 };
                 if (isBalancer)
                 {
-                    rule.balancerTag = tag;
+                    rule.balancerTag = tag + Global.BalancerTagSuffix;
                     rule.outboundTag = null;
                 }
                 _coreConfig.routing.rules.Add(rule);

--- a/v2rayN/ServiceLib/Services/SpeedtestService.cs
+++ b/v2rayN/ServiceLib/Services/SpeedtestService.cs
@@ -61,21 +61,27 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
 
     private async Task<List<ServerTestItem>> GetClearItem(ESpeedActionType actionType, List<ProfileItem> selecteds)
     {
-        var lstSelected = new List<ServerTestItem>();
+        var lstSelected = new List<ServerTestItem>(selecteds.Count);
+        var ids = selecteds.Where(it => !it.IndexId.IsNullOrEmpty()
+            && it.ConfigType != EConfigType.Custom
+            && (it.ConfigType.IsComplexType() || it.Port > 0))
+            .Select(it => it.IndexId)
+            .ToList();
+        var profileMap = await AppManager.Instance.GetProfileItemsByIndexIdsAsMap(ids);
         for (var i = 0; i < selecteds.Count; i++)
         {
             var it = selecteds[i];
-            if (it.ConfigType.IsComplexType())
+            if (it.ConfigType == EConfigType.Custom)
             {
                 continue;
             }
 
-            if (it.Port <= 0)
+            if (!it.ConfigType.IsComplexType() && it.Port <= 0)
             {
                 continue;
             }
 
-            var profile = await AppManager.Instance.GetProfileItem(it.IndexId) ?? it;
+            var profile = profileMap.GetValueOrDefault(it.IndexId, it);
             lstSelected.Add(new ServerTestItem()
             {
                 IndexId = it.IndexId,
@@ -357,8 +363,8 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
     private List<List<ServerTestItem>> GetTestBatchItem(List<ServerTestItem> lstSelected, int pageSize)
     {
         List<List<ServerTestItem>> lstTest = new();
-        var lst1 = lstSelected.Where(t => Global.XraySupportConfigType.Contains(t.ConfigType) && t.CoreType == ECoreType.Xray).ToList();
-        var lst2 = lstSelected.Where(t => Global.SingboxSupportConfigType.Contains(t.ConfigType) && t.CoreType == ECoreType.sing_box).ToList();
+        var lst1 = lstSelected.Where(t => t.CoreType == ECoreType.Xray).ToList();
+        var lst2 = lstSelected.Where(t => t.CoreType == ECoreType.sing_box).ToList();
 
         for (var num = 0; num < (int)Math.Ceiling(lst1.Count * 1.0 / pageSize); num++)
         {

--- a/v2rayN/ServiceLib/Services/SpeedtestService.cs
+++ b/v2rayN/ServiceLib/Services/SpeedtestService.cs
@@ -62,8 +62,9 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
     private async Task<List<ServerTestItem>> GetClearItem(ESpeedActionType actionType, List<ProfileItem> selecteds)
     {
         var lstSelected = new List<ServerTestItem>();
-        foreach (var it in selecteds)
+        for (var i = 0; i < selecteds.Count; i++)
         {
+            var it = selecteds[i];
             if (it.ConfigType.IsComplexType())
             {
                 continue;
@@ -74,13 +75,16 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
                 continue;
             }
 
+            var profile = await AppManager.Instance.GetProfileItem(it.IndexId) ?? it;
             lstSelected.Add(new ServerTestItem()
             {
                 IndexId = it.IndexId,
                 Address = it.Address,
                 Port = it.Port,
                 ConfigType = it.ConfigType,
-                QueueNum = selecteds.IndexOf(it)
+                QueueNum = i,
+                Profile = profile,
+                CoreType = AppManager.Instance.GetCoreType(profile, it.ConfigType),
             });
         }
 
@@ -353,8 +357,8 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
     private List<List<ServerTestItem>> GetTestBatchItem(List<ServerTestItem> lstSelected, int pageSize)
     {
         List<List<ServerTestItem>> lstTest = new();
-        var lst1 = lstSelected.Where(t => Global.XraySupportConfigType.Contains(t.ConfigType)).ToList();
-        var lst2 = lstSelected.Where(t => Global.SingboxOnlyConfigType.Contains(t.ConfigType)).ToList();
+        var lst1 = lstSelected.Where(t => Global.XraySupportConfigType.Contains(t.ConfigType) && t.CoreType == ECoreType.Xray).ToList();
+        var lst2 = lstSelected.Where(t => Global.SingboxSupportConfigType.Contains(t.ConfigType) && t.CoreType == ECoreType.sing_box).ToList();
 
         for (var num = 0; num < (int)Math.Ceiling(lst1.Count * 1.0 / pageSize); num++)
         {


### PR DESCRIPTION
- 尊重用户设置的核心类型，将使用该核心测试节点真连接
- 允许测试链式代理连通性，顺带支持了策略组的测试