### PR TITLE
Optimize

### DIFF
--- a/v2rayN/ServiceLib/Manager/AppManager.cs
+++ b/v2rayN/ServiceLib/Manager/AppManager.cs
@@ -248,6 +248,24 @@ public sealed class AppManager
         return items.ToDictionary(it => it.IndexId);
     }
 
+    public async Task<List<ProfileItem>> GetProfileItemsOrderedByIndexIds(IEnumerable<string> indexIds)
+    {
+        var idList = indexIds.Where(id => !id.IsNullOrEmpty()).Distinct().ToList();
+        if (idList.Count == 0)
+        {
+            return [];
+        }
+
+        var items = await SQLiteHelper.Instance.TableAsync<ProfileItem>()
+            .Where(it => idList.Contains(it.IndexId))
+            .ToListAsync();
+        var itemMap = items.ToDictionary(it => it.IndexId);
+
+        return idList.Select(id => itemMap.GetValueOrDefault(id))
+            .Where(item => item != null)
+            .ToList();
+    }
+
     public async Task<ProfileItem?> GetProfileItemViaRemarks(string? remarks)
     {
         if (remarks.IsNullOrEmpty())

--- a/v2rayN/ServiceLib/Manager/GroupProfileManager.cs
+++ b/v2rayN/ServiceLib/Manager/GroupProfileManager.cs
@@ -52,10 +52,10 @@ public class GroupProfileManager
                 return false;
             }
 
-            foreach (var child in childIds)
+            var childItems = await AppManager.Instance.GetProfileItemsByIndexIds(childIds);
+            foreach (var childItem in childItems)
             {
-                var childItem = await AppManager.Instance.GetProfileItem(child);
-                if (await HasCycle(child, childItem?.GetProtocolExtra(), visited, stack))
+                if (await HasCycle(childItem.IndexId, childItem?.GetProtocolExtra(), visited, stack))
                 {
                     return true;
                 }
@@ -103,17 +103,7 @@ public class GroupProfileManager
             return [];
         }
 
-        var profileMap = await AppManager.Instance.GetProfileItemsByIndexIdsAsMap(childProfileIds);
-
-        var ordered = new List<ProfileItem>(childProfileIds.Count);
-        foreach (var id in childProfileIds)
-        {
-            if (id != null && profileMap.TryGetValue(id, out var item) && item != null)
-            {
-                ordered.Add(item);
-            }
-        }
-
+        var ordered = await AppManager.Instance.GetProfileItemsOrderedByIndexIds(childProfileIds);
         return ordered;
     }
 

--- a/v2rayN/ServiceLib/ViewModels/AddGroupServerViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/AddGroupServerViewModel.cs
@@ -99,15 +99,8 @@ public class AddGroupServerViewModel : MyReactiveObject
         Filter = protocolExtra?.Filter;
 
         var childIndexIds = Utils.String2List(protocolExtra?.ChildItems) ?? [];
-        foreach (var item in childIndexIds)
-        {
-            var child = await AppManager.Instance.GetProfileItem(item);
-            if (child == null)
-            {
-                continue;
-            }
-            ChildItemsObs.Add(child);
-        }
+        var childItemList = await AppManager.Instance.GetProfileItemsOrderedByIndexIds(childIndexIds);
+        ChildItemsObs.AddRange(childItemList);
     }
 
     public async Task ChildRemoveAsync()

--- a/v2rayN/ServiceLib/ViewModels/ProfilesSelectViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ProfilesSelectViewModel.cs
@@ -255,19 +255,7 @@ public class ProfilesSelectViewModel : MyReactiveObject
         {
             return null;
         }
-        var lst = new List<ProfileItem>();
-        foreach (var sp in SelectedProfiles)
-        {
-            if (string.IsNullOrEmpty(sp?.IndexId))
-            {
-                continue;
-            }
-            var item = await AppManager.Instance.GetProfileItem(sp.IndexId);
-            if (item != null)
-            {
-                lst.Add(item);
-            }
-        }
+        var lst = await AppManager.Instance.GetProfileItemsOrderedByIndexIds(SelectedProfiles.Select(sp => sp?.IndexId));
         if (lst.Count == 0)
         {
             NoticeManager.Instance.Enqueue(ResUI.PleaseSelectServer);

--- a/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
@@ -456,14 +456,7 @@ public class ProfilesViewModel : MyReactiveObject
         var orderProfiles = SelectedProfiles?.OrderBy(t => t.Sort);
         if (latest)
         {
-            foreach (var profile in orderProfiles)
-            {
-                var item = await AppManager.Instance.GetProfileItem(profile.IndexId);
-                if (item is not null)
-                {
-                    lstSelected.Add(item);
-                }
-            }
+            lstSelected.AddRange(await AppManager.Instance.GetProfileItemsOrderedByIndexIds(orderProfiles.Select(sp => sp?.IndexId)));
         }
         else
         {

--- a/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml.cs
@@ -148,14 +148,7 @@ public partial class AddGroupServerWindow : WindowBase<AddGroupServerViewModel>
     private async void MenuAddChild_Click(object? sender, RoutedEventArgs e)
     {
         var selectWindow = new ProfilesSelectWindow();
-        if (ViewModel?.SelectedSource?.ConfigType == EConfigType.PolicyGroup)
-        {
-            selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom }, exclude: true);
-        }
-        else
-        {
-            selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
-        }
+        selectWindow.SetConfigTypeFilter([EConfigType.Custom], exclude: true);
         selectWindow.AllowMultiSelect(true);
         var result = await selectWindow.ShowDialog<bool?>(this);
         if (result == true)

--- a/v2rayN/v2rayN.Desktop/Views/SubEditWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/SubEditWindow.axaml.cs
@@ -59,7 +59,7 @@ public partial class SubEditWindow : WindowBase<SubEditViewModel>
     private async void BtnSelectPrevProfile_Click(object? sender, RoutedEventArgs e)
     {
         var selectWindow = new ProfilesSelectWindow();
-        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
+        selectWindow.SetConfigTypeFilter([EConfigType.Custom], exclude: true);
         var result = await selectWindow.ShowDialog<bool?>(this);
         if (result == true)
         {
@@ -74,7 +74,7 @@ public partial class SubEditWindow : WindowBase<SubEditViewModel>
     private async void BtnSelectNextProfile_Click(object? sender, RoutedEventArgs e)
     {
         var selectWindow = new ProfilesSelectWindow();
-        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
+        selectWindow.SetConfigTypeFilter([EConfigType.Custom], exclude: true);
         var result = await selectWindow.ShowDialog<bool?>(this);
         if (result == true)
         {

--- a/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml.cs
@@ -128,14 +128,7 @@ public partial class AddGroupServerWindow
     private async void MenuAddChild_Click(object sender, RoutedEventArgs e)
     {
         var selectWindow = new ProfilesSelectWindow();
-        if (ViewModel?.SelectedSource?.ConfigType == EConfigType.PolicyGroup)
-        {
-            selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom }, exclude: true);
-        }
-        else
-        {
-            selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
-        }
+        selectWindow.SetConfigTypeFilter([EConfigType.Custom], exclude: true);
         selectWindow.AllowMultiSelect(true);
         if (selectWindow.ShowDialog() == true)
         {

--- a/v2rayN/v2rayN/Views/SubEditWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/SubEditWindow.xaml.cs
@@ -53,7 +53,7 @@ public partial class SubEditWindow
     private async void BtnSelectPrevProfile_Click(object sender, RoutedEventArgs e)
     {
         var selectWindow = new ProfilesSelectWindow();
-        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
+        selectWindow.SetConfigTypeFilter([EConfigType.Custom], exclude: true);
         if (selectWindow.ShowDialog() == true)
         {
             var profile = await selectWindow.ProfileItem;
@@ -67,7 +67,7 @@ public partial class SubEditWindow
     private async void BtnSelectNextProfile_Click(object sender, RoutedEventArgs e)
     {
         var selectWindow = new ProfilesSelectWindow();
-        selectWindow.SetConfigTypeFilter(new[] { EConfigType.Custom, EConfigType.PolicyGroup, EConfigType.ProxyChain }, exclude: true);
+        selectWindow.SetConfigTypeFilter([EConfigType.Custom], exclude: true);
         if (selectWindow.ShowDialog() == true)
         {
             var profile = await selectWindow.ProfileItem;


### PR DESCRIPTION
- 放宽组类型限制，允许作为前置/落地/路由规则节点
- 从 List indexId 中读取 List<ProfileItem> 时使用 GetProfileItemsOrderedByIndexIds，大幅度减小读取数据库次数。上次测的 2000 个节点读取耗时约减小了 85%。400 ms -> 50 ms