### PR TITLE
Prepend subscription group name in status bar if possible

### DIFF
--- a/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
@@ -291,8 +291,17 @@ public class StatusBarViewModel : MyReactiveObject
         var running = await ConfigHandler.GetDefaultServer(_config);
         if (running != null)
         {
+            var summary = running.GetSummary();
+            if (running.Subid.IsNotEmpty())
+            {
+                var subItem = await AppManager.Instance.GetSubItem(running.Subid);
+                if (subItem != null)
+                {
+                    summary = $"{subItem.Remarks}: {summary}";
+                }
+            }
             RunningServerDisplay =
-                RunningServerToolTipText = running.GetSummary();
+                RunningServerToolTipText = summary;
         }
         else
         {


### PR DESCRIPTION
format: "`<group>: <original text>`"

Screenshot:

<img width="750" alt="screenshot of the comparison about the newly added subscription group name" src="https://github.com/user-attachments/assets/6d4e4674-7575-4d61-94cd-db9e7d1eef69" />

Hope this makes the status bar more informative.

Tested on Windows 10 22H2.