### PR TITLE
Fix speedtest core type

### DIFF
--- a/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
+++ b/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
@@ -268,7 +268,7 @@ public class CoreConfigContextBuilder
         {
             IndexId = $"inner-{Utils.GetGuid(false)}",
             ConfigType = EConfigType.ProxyChain,
-            CoreType = node.CoreType ?? ECoreType.Xray,
+            CoreType = AppManager.Instance.GetCoreType(node, node.ConfigType),
         };
         List<string?> childItems = [prevNode?.IndexId, node.IndexId, nextNode?.IndexId];
         var chainExtraItem = chainNode.GetProtocolExtra() with

--- a/v2rayN/ServiceLib/Handler/CoreConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/CoreConfigHandler.cs
@@ -21,7 +21,7 @@ public static class CoreConfigHandler
                 _ => await GenerateClientCustomConfig(node, fileName)
             };
         }
-        else if (AppManager.Instance.GetCoreType(node, node.ConfigType) == ECoreType.sing_box)
+        else if (context.RunCoreType == ECoreType.sing_box)
         {
             result = new CoreConfigSingboxService(context).GenerateClientConfigContent();
         }
@@ -128,12 +128,11 @@ public static class CoreConfigHandler
     public static async Task<RetResult> GenerateClientSpeedtestConfig(Config config, CoreConfigContext context, ServerTestItem testItem, string fileName)
     {
         var result = new RetResult();
-        var node = context.Node;
         var initPort = AppManager.Instance.GetLocalPort(EInboundProtocol.speedtest);
         var port = Utils.GetFreePort(initPort + testItem.QueueNum);
         testItem.Port = port;
 
-        if (AppManager.Instance.GetCoreType(node, node.ConfigType) == ECoreType.sing_box)
+        if (context.RunCoreType == ECoreType.sing_box)
         {
             result = new CoreConfigSingboxService(context).GenerateClientSpeedtestConfig(port);
         }

--- a/v2rayN/ServiceLib/Manager/CoreManager.cs
+++ b/v2rayN/ServiceLib/Manager/CoreManager.cs
@@ -132,7 +132,7 @@ public class CoreManager
             return null;
         }
 
-        var coreType = AppManager.Instance.GetCoreType(node, node.ConfigType);
+        var coreType = context.RunCoreType;
         var coreInfo = CoreInfoManager.Instance.GetCoreInfo(coreType);
         return await RunProcess(coreInfo, fileName, true, false);
     }


### PR DESCRIPTION
修复全局核心类型设置为 sing-box 时，测速报错：

```
FATAL[0000] decode config at configTest5208329097969163090.json: log.loglevel: json: unknown field "loglevel"
运行 Core 失败，请查看提示信息
```