### PR TITLE
Fix

### DIFF
--- a/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
+++ b/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
@@ -269,6 +269,7 @@ public class CoreConfigContextBuilder
             IndexId = $"inner-{Utils.GetGuid(false)}",
             ConfigType = EConfigType.ProxyChain,
             CoreType = AppManager.Instance.GetCoreType(node, node.ConfigType),
+            Remarks = node.Remarks,
         };
         List<string?> childItems = [prevNode?.IndexId, node.IndexId, nextNode?.IndexId];
         var chainExtraItem = chainNode.GetProtocolExtra() with


### PR DESCRIPTION
修复配置订阅分组链式代理后，弹出框节点名为空

比如 [ProxyChain] [sing_box]