### PR TITLE
Fix

### DIFF
--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -723,8 +723,6 @@ public static class ConfigHandler
         profileItem.SetProtocolExtra(profileItem.GetProtocolExtra() with
         {
             SalamanderPass = profileItem.GetProtocolExtra().SalamanderPass?.TrimEx(),
-            UpMbps = profileItem.GetProtocolExtra().UpMbps is null or < 0 ? config.HysteriaItem.UpMbps : profileItem.GetProtocolExtra().UpMbps,
-            DownMbps = profileItem.GetProtocolExtra().DownMbps is null or < 0 ? config.HysteriaItem.DownMbps : profileItem.GetProtocolExtra().DownMbps,
             HopInterval = profileItem.GetProtocolExtra().HopInterval?.TrimEx(),
         });
 

--- a/v2rayN/ServiceLib/ViewModels/AddServerViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/AddServerViewModel.cs
@@ -113,8 +113,8 @@ public class AddServerViewModel : MyReactiveObject
         AlterId = int.TryParse(protocolExtra?.AlterId, out var result) ? result : 0;
         Flow = protocolExtra?.Flow ?? string.Empty;
         SalamanderPass = protocolExtra?.SalamanderPass ?? string.Empty;
-        UpMbps = protocolExtra?.UpMbps ?? _config.HysteriaItem.UpMbps;
-        DownMbps = protocolExtra?.DownMbps ?? _config.HysteriaItem.DownMbps;
+        UpMbps = protocolExtra?.UpMbps;
+        DownMbps = protocolExtra?.DownMbps;
         HopInterval = protocolExtra?.HopInterval.IsNullOrEmpty() ?? true ? Global.Hysteria2DefaultHopInt.ToString() : protocolExtra.HopInterval;
         VmessSecurity = protocolExtra?.VmessSecurity?.IsNullOrEmpty() == false ? protocolExtra.VmessSecurity : Global.DefaultSecurity;
         VlessEncryption = protocolExtra?.VlessEncryption.IsNullOrEmpty() == false ? protocolExtra.VlessEncryption : Global.None;
@@ -175,8 +175,8 @@ public class AddServerViewModel : MyReactiveObject
             AlterId = AlterId > 0 ? AlterId.ToString() : null,
             Flow = Flow.NullIfEmpty(),
             SalamanderPass = SalamanderPass.NullIfEmpty(),
-            UpMbps = UpMbps ?? 0,
-            DownMbps = DownMbps ?? 0,
+            UpMbps = UpMbps,
+            DownMbps = DownMbps,
             HopInterval = HopInterval.NullIfEmpty(),
             VmessSecurity = VmessSecurity.NullIfEmpty(),
             VlessEncryption = VlessEncryption.NullIfEmpty(),

--- a/v2rayN/ServiceLib/ViewModels/AddServerViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/AddServerViewModel.cs
@@ -27,10 +27,10 @@ public class AddServerViewModel : MyReactiveObject
     public string Ports { get; set; }
 
     [Reactive]
-    public int UpMbps { get; set; }
+    public int? UpMbps { get; set; }
 
     [Reactive]
-    public int DownMbps { get; set; }
+    public int? DownMbps { get; set; }
 
     [Reactive]
     public string HopInterval { get; set; }
@@ -175,8 +175,8 @@ public class AddServerViewModel : MyReactiveObject
             AlterId = AlterId > 0 ? AlterId.ToString() : null,
             Flow = Flow.NullIfEmpty(),
             SalamanderPass = SalamanderPass.NullIfEmpty(),
-            UpMbps = UpMbps >= 0 ? UpMbps : null,
-            DownMbps = DownMbps >= 0 ? DownMbps : null,
+            UpMbps = UpMbps ?? 0,
+            DownMbps = DownMbps ?? 0,
             HopInterval = HopInterval.NullIfEmpty(),
             VmessSecurity = VmessSecurity.NullIfEmpty(),
             VlessEncryption = VlessEncryption.NullIfEmpty(),

--- a/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
@@ -22,8 +22,8 @@ public class OptionSettingViewModel : MyReactiveObject
     [Reactive] public string defUserAgent { get; set; }
     [Reactive] public string mux4SboxProtocol { get; set; }
     [Reactive] public bool enableCacheFile4Sbox { get; set; }
-    [Reactive] public int hyUpMbps { get; set; }
-    [Reactive] public int hyDownMbps { get; set; }
+    [Reactive] public int? hyUpMbps { get; set; }
+    [Reactive] public int? hyDownMbps { get; set; }
     [Reactive] public bool enableFragment { get; set; }
 
     #endregion Core
@@ -336,8 +336,8 @@ public class OptionSettingViewModel : MyReactiveObject
         _config.CoreBasicItem.DefUserAgent = defUserAgent;
         _config.Mux4SboxItem.Protocol = mux4SboxProtocol;
         _config.CoreBasicItem.EnableCacheFile4Sbox = enableCacheFile4Sbox;
-        _config.HysteriaItem.UpMbps = hyUpMbps;
-        _config.HysteriaItem.DownMbps = hyDownMbps;
+        _config.HysteriaItem.UpMbps = hyUpMbps ?? 0;
+        _config.HysteriaItem.DownMbps = hyDownMbps ?? 0;
         _config.CoreBasicItem.EnableFragment = enableFragment;
 
         _config.GuiItem.AutoRun = AutoRun;


### PR DESCRIPTION
Fix #8911

修复清空行为应是设为 0 值，而非保留最后一次合法值

只针对这个 hy2 带宽，清空应是使用全局回退，显式设为 0 是使用 BBR