### PR TITLE
Tun ech protect

### DIFF
--- a/v2rayN/ServiceLib/Models/V2rayConfig.cs
+++ b/v2rayN/ServiceLib/Models/V2rayConfig.cs
@@ -360,6 +360,7 @@ public class TlsSettings4Ray
     public bool? disableSystemRoot { get; set; }
     public string? echConfigList { get; set; }
     public string? echForceQuery { get; set; }
+    public Sockopt4Ray? echSockopt { get; set; }
 }
 
 public class CertificateSettings4Ray

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
@@ -316,11 +316,19 @@ public partial class CoreConfigV2rayService(CoreConfigContext context)
                 SsMethod = Global.None,
             });
 
-            foreach (var outbound in _coreConfig.outbounds.Where(outbound => outbound.streamSettings?.sockopt?.dialerProxy?.IsNullOrEmpty() ?? true))
+            foreach (var outbound in _coreConfig.outbounds
+                .Where(o => o.streamSettings?.sockopt?.dialerProxy?.IsNullOrEmpty() ?? true))
             {
-                outbound.streamSettings ??= new StreamSettings4Ray();
-                outbound.streamSettings.sockopt ??= new Sockopt4Ray();
+                outbound.streamSettings ??= new();
+                outbound.streamSettings.sockopt ??= new();
                 outbound.streamSettings.sockopt.dialerProxy = "tun-project-ss";
+            }
+            // ech protected
+            foreach (var outbound in _coreConfig.outbounds
+                .Where(outbound => outbound.streamSettings?.tlsSettings?.echConfigList?.IsNullOrEmpty() == false))
+            {
+                outbound.streamSettings!.tlsSettings!.echSockopt ??= new();
+                outbound.streamSettings.tlsSettings.echSockopt.dialerProxy = "tun-project-ss";
             }
             _coreConfig.outbounds.Add(new CoreConfigV2rayService(context with
             {


### PR DESCRIPTION
Tun 模式下的 xray ech 保护

通过 echSockopt 将 ech dns 请求强制直连

至此，Tun 不可用只剩系统和规则集两种原因