### PR TITLE
Update dep

### DIFF
--- a/v2rayN/Directory.Packages.props
+++ b/v2rayN/Directory.Packages.props
@@ -9,18 +9,18 @@
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.3.12" />
     <PackageVersion Include="Avalonia.Desktop" Version="11.3.12" />
     <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.12" />
-    <PackageVersion Include="ReactiveUI.Avalonia" Version="11.3.8" />
+    <PackageVersion Include="ReactiveUI.Avalonia" Version="11.4.12" />
     <PackageVersion Include="CliWrap" Version="3.10.0" />
-    <PackageVersion Include="Downloader" Version="4.1.1" />
+    <PackageVersion Include="Downloader" Version="5.1.0" />
     <PackageVersion Include="H.NotifyIcon.Wpf" Version="2.4.1" />
     <PackageVersion Include="MaterialDesignThemes" Version="5.3.0" />
     <PackageVersion Include="MessageBox.Avalonia" Version="3.3.1.1" />
     <PackageVersion Include="QRCoder" Version="1.7.0" />
-    <PackageVersion Include="ReactiveUI" Version="22.3.1" />
+    <PackageVersion Include="ReactiveUI" Version="23.1.8" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />
-    <PackageVersion Include="ReactiveUI.WPF" Version="22.3.1" />
+    <PackageVersion Include="ReactiveUI.WPF" Version="23.1.8" />
     <PackageVersion Include="Semi.Avalonia" Version="11.3.7.3" />
-    <PackageVersion Include="Semi.Avalonia.AvaloniaEdit" Version="11.2.0.1" />
+    <PackageVersion Include="Semi.Avalonia.AvaloniaEdit" Version="11.2.0.2" />
     <PackageVersion Include="Semi.Avalonia.DataGrid" Version="11.3.7.3" />
     <PackageVersion Include="NLog" Version="6.1.1" />
     <PackageVersion Include="sqlite-net-pcl" Version="1.9.172" />

--- a/v2rayN/ServiceLib/ViewModels/CheckUpdateViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/CheckUpdateViewModel.cs
@@ -204,7 +204,7 @@ public class CheckUpdateViewModel : MyReactiveObject
 
     private async Task UpdateFinishedSub(bool blReload)
     {
-        RxApp.MainThreadScheduler.Schedule(blReload, (scheduler, blReload) =>
+        RxSchedulers.MainThreadScheduler.Schedule(blReload, (scheduler, blReload) =>
         {
             _ = UpdateFinishedResult(blReload);
             return Disposable.Empty;
@@ -317,7 +317,7 @@ public class CheckUpdateViewModel : MyReactiveObject
             Remarks = msg,
         };
 
-        RxApp.MainThreadScheduler.Schedule(item, (scheduler, model) =>
+        RxSchedulers.MainThreadScheduler.Schedule(item, (scheduler, model) =>
         {
             _ = UpdateViewResult(model);
             return Disposable.Empty;

--- a/v2rayN/ServiceLib/ViewModels/ClashConnectionsViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ClashConnectionsViewModel.cs
@@ -56,7 +56,7 @@ public class ClashConnectionsViewModel : MyReactiveObject
             return;
         }
 
-        RxApp.MainThreadScheduler.Schedule(ret?.connections, (scheduler, model) =>
+        RxSchedulers.MainThreadScheduler.Schedule(ret?.connections, (scheduler, model) =>
         {
             _ = RefreshConnections(model);
             return Disposable.Empty;

--- a/v2rayN/ServiceLib/ViewModels/ClashProxiesViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ClashProxiesViewModel.cs
@@ -90,7 +90,7 @@ public class ClashProxiesViewModel : MyReactiveObject
 
         AppEvents.ProxiesReloadRequested
             .AsObservable()
-            .ObserveOn(RxApp.MainThreadScheduler)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(async _ => await ProxiesReload());
 
         #endregion AppEvents
@@ -173,7 +173,7 @@ public class ClashProxiesViewModel : MyReactiveObject
 
         if (refreshUI)
         {
-            RxApp.MainThreadScheduler.Schedule(() => _ = RefreshProxyGroups());
+            RxSchedulers.MainThreadScheduler.Schedule(() => _ = RefreshProxyGroups());
         }
     }
 
@@ -387,7 +387,7 @@ public class ClashProxiesViewModel : MyReactiveObject
             }
 
             var model = new SpeedTestResult() { IndexId = item.Name, Delay = result };
-            RxApp.MainThreadScheduler.Schedule(model, (scheduler, model) =>
+            RxSchedulers.MainThreadScheduler.Schedule(model, (scheduler, model) =>
             {
                 _ = ProxiesDelayTestResult(model);
                 return Disposable.Empty;

--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -228,22 +228,22 @@ public class MainWindowViewModel : MyReactiveObject
 
         AppEvents.ReloadRequested
             .AsObservable()
-            .ObserveOn(RxApp.MainThreadScheduler)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(async _ => await Reload());
 
         AppEvents.AddServerViaScanRequested
             .AsObservable()
-            .ObserveOn(RxApp.MainThreadScheduler)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(async _ => await AddServerViaScanAsync());
 
         AppEvents.AddServerViaClipboardRequested
             .AsObservable()
-            .ObserveOn(RxApp.MainThreadScheduler)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(async _ => await AddServerViaClipboardAsync(null));
 
         AppEvents.SubscriptionsUpdateRequested
             .AsObservable()
-            .ObserveOn(RxApp.MainThreadScheduler)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(async blProxy => await UpdateSubscriptionProcess("", blProxy));
 
         #endregion AppEvents
@@ -583,7 +583,7 @@ public class MainWindowViewModel : MyReactiveObject
 
     private void ReloadResult(bool showClashUI)
     {
-        RxApp.MainThreadScheduler.Schedule(() =>
+        RxSchedulers.MainThreadScheduler.Schedule(() =>
         {
             ShowClashUI = showClashUI;
             TabMainSelectedIndex = showClashUI ? TabMainSelectedIndex : 0;
@@ -592,7 +592,7 @@ public class MainWindowViewModel : MyReactiveObject
 
     private void SetReloadEnabled(bool enabled)
     {
-        RxApp.MainThreadScheduler.Schedule(() => BlReloadEnabled = enabled);
+        RxSchedulers.MainThreadScheduler.Schedule(() => BlReloadEnabled = enabled);
     }
 
     private async Task LoadCore(CoreConfigContext? mainContext, CoreConfigContext? preContext)

--- a/v2rayN/ServiceLib/ViewModels/MsgViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MsgViewModel.cs
@@ -31,7 +31,7 @@ public class MsgViewModel : MyReactiveObject
 
         AppEvents.SendMsgViewRequested
          .AsObservable()
-         //.ObserveOn(RxApp.MainThreadScheduler)
+         //.ObserveOn(RxSchedulers.MainThreadScheduler)
          .Subscribe(content => _ = AppendQueueMsg(content));
     }
 

--- a/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
@@ -228,22 +228,22 @@ public class ProfilesViewModel : MyReactiveObject
 
         AppEvents.ProfilesRefreshRequested
             .AsObservable()
-            .ObserveOn(RxApp.MainThreadScheduler)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(async _ => await RefreshServersBiz());
 
         AppEvents.SubscriptionsRefreshRequested
             .AsObservable()
-            .ObserveOn(RxApp.MainThreadScheduler)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(async _ => await RefreshSubscriptions());
 
         AppEvents.DispatcherStatisticsRequested
             .AsObservable()
-            .ObserveOn(RxApp.MainThreadScheduler)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(async result => await UpdateStatistics(result));
 
         AppEvents.SetDefaultServerRequested
             .AsObservable()
-            .ObserveOn(RxApp.MainThreadScheduler)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(async indexId => await SetDefaultServer(indexId));
 
         #endregion AppEvents
@@ -732,7 +732,7 @@ public class ProfilesViewModel : MyReactiveObject
 
         _speedtestService ??= new SpeedtestService(_config, async (SpeedTestResult result) =>
         {
-            RxApp.MainThreadScheduler.Schedule(result, (scheduler, result) =>
+            RxSchedulers.MainThreadScheduler.Schedule(result, (scheduler, result) =>
             {
                 _ = SetSpeedTestResult(result);
                 return Disposable.Empty;

--- a/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
@@ -200,27 +200,27 @@ public class StatusBarViewModel : MyReactiveObject
 
         AppEvents.DispatcherStatisticsRequested
             .AsObservable()
-            .ObserveOn(RxApp.MainThreadScheduler)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(async result => await UpdateStatistics(result));
 
         AppEvents.RoutingsMenuRefreshRequested
             .AsObservable()
-            .ObserveOn(RxApp.MainThreadScheduler)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(async _ => await RefreshRoutingsMenu());
 
         AppEvents.TestServerRequested
             .AsObservable()
-            .ObserveOn(RxApp.MainThreadScheduler)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(async _ => await TestServerAvailability());
 
         AppEvents.InboundDisplayRequested
             .AsObservable()
-            .ObserveOn(RxApp.MainThreadScheduler)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(async _ => await InboundDisplayStatus());
 
         AppEvents.SysProxyChangeRequested
             .AsObservable()
-            .ObserveOn(RxApp.MainThreadScheduler)
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(async result => await SetListenerType(result));
 
         #endregion AppEvents
@@ -243,7 +243,7 @@ public class StatusBarViewModel : MyReactiveObject
         {
             AppEvents.ProfilesRefreshRequested
               .AsObservable()
-              .ObserveOn(RxApp.MainThreadScheduler)
+              .ObserveOn(RxSchedulers.MainThreadScheduler)
               .Subscribe(async _ => await RefreshServersBiz()); //.DisposeWith(_disposables);
         }
     }
@@ -362,7 +362,7 @@ public class StatusBarViewModel : MyReactiveObject
 
     private async Task TestServerAvailabilitySub(string msg)
     {
-        RxApp.MainThreadScheduler.Schedule(msg, (scheduler, msg) =>
+        RxSchedulers.MainThreadScheduler.Schedule(msg, (scheduler, msg) =>
         {
             _ = TestServerAvailabilityResult(msg);
             return Disposable.Empty;

--- a/v2rayN/v2rayN.Desktop/Program.cs
+++ b/v2rayN/v2rayN.Desktop/Program.cs
@@ -59,7 +59,7 @@ internal class Program
            //.WithInterFont()
            .WithFontByDefault()
            .LogToTrace()
-           .UseReactiveUI();
+           .UseReactiveUI(_ => { });
 
         if (OperatingSystem.IsMacOS())
         {

--- a/v2rayN/v2rayN.Desktop/Views/ClashConnectionsView.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/ClashConnectionsView.axaml.cs
@@ -28,7 +28,7 @@ public partial class ClashConnectionsView : ReactiveUserControl<ClashConnections
 
             AppEvents.AppExitRequested
               .AsObservable()
-              .ObserveOn(RxApp.MainThreadScheduler)
+              .ObserveOn(RxSchedulers.MainThreadScheduler)
               .Subscribe(_ => StorageUI())
               .DisposeWith(disposables);
         });

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
@@ -128,25 +128,25 @@ public partial class MainWindow : WindowBase<MainWindowViewModel>
 
             AppEvents.SendSnackMsgRequested
               .AsObservable()
-              .ObserveOn(RxApp.MainThreadScheduler)
+              .ObserveOn(RxSchedulers.MainThreadScheduler)
               .Subscribe(async content => await DelegateSnackMsg(content))
               .DisposeWith(disposables);
 
             AppEvents.AppExitRequested
               .AsObservable()
-              .ObserveOn(RxApp.MainThreadScheduler)
+              .ObserveOn(RxSchedulers.MainThreadScheduler)
               .Subscribe(_ => StorageUI())
               .DisposeWith(disposables);
 
             AppEvents.ShutdownRequested
               .AsObservable()
-              .ObserveOn(RxApp.MainThreadScheduler)
+              .ObserveOn(RxSchedulers.MainThreadScheduler)
               .Subscribe(content => Shutdown(content))
               .DisposeWith(disposables);
 
             AppEvents.ShowHideWindowRequested
              .AsObservable()
-             .ObserveOn(RxApp.MainThreadScheduler)
+             .ObserveOn(RxSchedulers.MainThreadScheduler)
              .Subscribe(blShow => ShowHideWindow(blShow))
              .DisposeWith(disposables);
         });

--- a/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml.cs
@@ -90,13 +90,13 @@ public partial class ProfilesView : ReactiveUserControl<ProfilesViewModel>
 
             AppEvents.AppExitRequested
               .AsObservable()
-              .ObserveOn(RxApp.MainThreadScheduler)
+              .ObserveOn(RxSchedulers.MainThreadScheduler)
               .Subscribe(_ => StorageUI())
               .DisposeWith(disposables);
 
             AppEvents.AdjustMainLvColWidthRequested
                 .AsObservable()
-                .ObserveOn(RxApp.MainThreadScheduler)
+                .ObserveOn(RxSchedulers.MainThreadScheduler)
                 .Subscribe(_ => AutofitColumnWidth())
                 .DisposeWith(disposables);
         });

--- a/v2rayN/v2rayN/App.xaml.cs
+++ b/v2rayN/v2rayN/App.xaml.cs
@@ -39,6 +39,11 @@ public partial class App : Application
         }
 
         AppManager.Instance.InitComponents();
+
+        RxAppBuilder.CreateReactiveUIBuilder()
+            .WithWpf()
+            .BuildApp();
+
         base.OnStartup(e);
     }
 

--- a/v2rayN/v2rayN/GlobalUsings.cs
+++ b/v2rayN/v2rayN/GlobalUsings.cs
@@ -20,6 +20,7 @@ global using System.Windows.Threading;
 global using DynamicData;
 global using DynamicData.Binding;
 global using ReactiveUI;
+global using ReactiveUI.Builder;
 global using ReactiveUI.Fody.Helpers;
 global using ServiceLib;
 global using ServiceLib.Base;

--- a/v2rayN/v2rayN/Views/ClashConnectionsView.xaml.cs
+++ b/v2rayN/v2rayN/Views/ClashConnectionsView.xaml.cs
@@ -33,7 +33,7 @@ public partial class ClashConnectionsView
 
             AppEvents.AppExitRequested
                 .AsObservable()
-                .ObserveOn(RxApp.MainThreadScheduler)
+                .ObserveOn(RxSchedulers.MainThreadScheduler)
                 .Subscribe(_ => StorageUI())
                 .DisposeWith(disposables);
         });

--- a/v2rayN/v2rayN/Views/MainWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml.cs
@@ -127,25 +127,25 @@ public partial class MainWindow
 
             AppEvents.SendSnackMsgRequested
               .AsObservable()
-              .ObserveOn(RxApp.MainThreadScheduler)
+              .ObserveOn(RxSchedulers.MainThreadScheduler)
               .Subscribe(async content => await DelegateSnackMsg(content))
               .DisposeWith(disposables);
 
             AppEvents.AppExitRequested
               .AsObservable()
-              .ObserveOn(RxApp.MainThreadScheduler)
+              .ObserveOn(RxSchedulers.MainThreadScheduler)
               .Subscribe(_ => StorageUI())
               .DisposeWith(disposables);
 
             AppEvents.ShutdownRequested
              .AsObservable()
-             .ObserveOn(RxApp.MainThreadScheduler)
+             .ObserveOn(RxSchedulers.MainThreadScheduler)
              .Subscribe(content => Shutdown(content))
              .DisposeWith(disposables);
 
             AppEvents.ShowHideWindowRequested
              .AsObservable()
-             .ObserveOn(RxApp.MainThreadScheduler)
+             .ObserveOn(RxSchedulers.MainThreadScheduler)
              .Subscribe(blShow => ShowHideWindow(blShow))
              .DisposeWith(disposables);
         });

--- a/v2rayN/v2rayN/Views/ProfilesView.xaml.cs
+++ b/v2rayN/v2rayN/Views/ProfilesView.xaml.cs
@@ -84,13 +84,13 @@ public partial class ProfilesView
 
             AppEvents.AppExitRequested
               .AsObservable()
-              .ObserveOn(RxApp.MainThreadScheduler)
+              .ObserveOn(RxSchedulers.MainThreadScheduler)
               .Subscribe(_ => StorageUI())
               .DisposeWith(disposables);
 
             AppEvents.AdjustMainLvColWidthRequested
                 .AsObservable()
-                .ObserveOn(RxApp.MainThreadScheduler)
+                .ObserveOn(RxSchedulers.MainThreadScheduler)
                 .Subscribe(_ => AutofitColumnWidth())
                 .DisposeWith(disposables);
         });

--- a/v2rayN/v2rayN/v2rayN.csproj
+++ b/v2rayN/v2rayN/v2rayN.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows10.0.17763</TargetFramework>
+		<TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
 		<GenerateSatelliteAssembliesForCore>true</GenerateSatelliteAssembliesForCore>
 		<UseWPF>true</UseWPF>
 		<ApplicationIcon>Resources\v2rayN.ico</ApplicationIcon>


### PR DESCRIPTION
更新 ReactiveUI 相关库，顺带更新了 Downloader 和 Semi.Avalonia.AvaloniaEdit

将 RxApp 迁移更改为 RxSchedulers，还有就是 wpf 和 avalonia 两个入口点初始化的迁移

TargetFramework 更改为 net8.0-windows10.0.19041.0 https://github.com/reactiveui/ReactiveUI/blob/fe354a4238d2d69c693a8ba40ef4b52bc90ec7c1/src/Directory.Build.props#L57