### PR TITLE
Limit MsgView log queue growth to reduce memory usage

### DIFF
--- a/v2rayN/ServiceLib/ViewModels/MsgViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MsgViewModel.cs
@@ -2,9 +2,15 @@ namespace ServiceLib.ViewModels;
 
 public class MsgViewModel : MyReactiveObject
 {
+    private const int MaxQueuedMessagesVisible = 2_000;
+    private const int MaxQueuedMessagesHidden = 500;
+    private const int MaxFlushMessages = 200;
+    private const int MaxFlushChars = 64 * 1024;
     private readonly ConcurrentQueue<string> _queueMsg = new();
     private volatile bool _lastMsgFilterNotAvailable;
+    private int _queuedMessageCount = 0;
     private int _showLock = 0; // 0 = unlocked, 1 = locked
+    private long _droppedMessageCount = 0;
     public int NumMaxMsg { get; } = 500;
 
     [Reactive]
@@ -31,19 +37,28 @@ public class MsgViewModel : MyReactiveObject
 
         AppEvents.SendMsgViewRequested
          .AsObservable()
-         //.ObserveOn(RxSchedulers.MainThreadScheduler)
+         //.ObserveOn(RxApp.MainThreadScheduler)
          .Subscribe(content => _ = AppendQueueMsg(content));
     }
 
-    private async Task AppendQueueMsg(string msg)
+    private Task AppendQueueMsg(string msg)
     {
         if (AutoRefresh == false)
         {
-            return;
+            return Task.CompletedTask;
         }
 
-        EnqueueQueueMsg(msg);
+        if (!EnqueueQueueMsg(msg))
+        {
+            return Task.CompletedTask;
+        }
 
+        TryScheduleDrain();
+        return Task.CompletedTask;
+    }
+
+    private void TryScheduleDrain()
+    {
         if (!AppManager.Instance.ShowInTaskbar)
         {
             return;
@@ -54,25 +69,59 @@ public class MsgViewModel : MyReactiveObject
             return;
         }
 
+        _ = DrainQueueMsgAsync();
+    }
+
+    private async Task DrainQueueMsgAsync()
+    {
         try
         {
             await Task.Delay(500).ConfigureAwait(false);
 
-            var sb = new StringBuilder();
-            while (_queueMsg.TryDequeue(out var line))
+            var batch = DequeueBatch();
+            if (_updateView != null && !string.IsNullOrEmpty(batch))
             {
-                sb.Append(line);
+                await _updateView(EViewAction.DispatcherShowMsg, batch);
             }
-
-            await _updateView?.Invoke(EViewAction.DispatcherShowMsg, sb.ToString());
         }
         finally
         {
             Interlocked.Exchange(ref _showLock, 0);
         }
+
+        if (AppManager.Instance.ShowInTaskbar && !_queueMsg.IsEmpty)
+        {
+            TryScheduleDrain();
+        }
     }
 
-    private void EnqueueQueueMsg(string msg)
+    private string DequeueBatch()
+    {
+        var sb = new StringBuilder();
+        var droppedCount = Interlocked.Exchange(ref _droppedMessageCount, 0);
+        if (droppedCount > 0)
+        {
+            sb.Append($"----- Message queue trimmed: dropped {droppedCount} messages -----{Environment.NewLine}");
+        }
+
+        var dequeuedCount = 0;
+        while (dequeuedCount < MaxFlushMessages
+               && _queueMsg.TryDequeue(out var line))
+        {
+            Interlocked.Decrement(ref _queuedMessageCount);
+            sb.Append(line);
+            dequeuedCount++;
+
+            if (sb.Length >= MaxFlushChars)
+            {
+                break;
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private bool EnqueueQueueMsg(string msg)
     {
         //filter msg
         if (MsgFilter.IsNotEmpty() && !_lastMsgFilterNotAvailable)
@@ -81,21 +130,39 @@ public class MsgViewModel : MyReactiveObject
             {
                 if (!Regex.IsMatch(msg, MsgFilter))
                 {
-                    return;
+                    return false;
                 }
             }
             catch (Exception ex)
             {
-                _queueMsg.Enqueue(ex.Message);
+                msg = ex.Message;
                 _lastMsgFilterNotAvailable = true;
             }
         }
 
-        _queueMsg.Enqueue(msg);
-        if (!msg.EndsWith(Environment.NewLine))
+        _queueMsg.Enqueue(NormalizeMessage(msg));
+        Interlocked.Increment(ref _queuedMessageCount);
+        TrimQueuedMessages();
+        return true;
+    }
+
+    private void TrimQueuedMessages()
+    {
+        var maxQueuedMessages = AppManager.Instance.ShowInTaskbar
+            ? MaxQueuedMessagesVisible
+            : MaxQueuedMessagesHidden;
+
+        while (Volatile.Read(ref _queuedMessageCount) > maxQueuedMessages
+               && _queueMsg.TryDequeue(out _))
         {
-            _queueMsg.Enqueue(Environment.NewLine);
+            Interlocked.Decrement(ref _queuedMessageCount);
+            Interlocked.Increment(ref _droppedMessageCount);
         }
+    }
+
+    private static string NormalizeMessage(string msg)
+    {
+        return msg.EndsWith(Environment.NewLine) ? msg : msg + Environment.NewLine;
     }
 
     //public void ClearMsg()

--- a/v2rayN/v2rayN.Desktop/Views/MsgView.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MsgView.axaml.cs
@@ -43,22 +43,30 @@ public partial class MsgView : ReactiveUserControl<MsgViewModel>
 
     private void ShowMsg(object msg)
     {
-        //var lineCount = txtMsg.LineCount;
-        //if (lineCount > ViewModel?.NumMaxMsg)
-        //{
-        //    var cutLine = txtMsg.Document.GetLineByNumber(lineCount - KeepLines);
-        //    txtMsg.Document.Remove(0, cutLine.Offset);
-        //}
-        if (txtMsg.LineCount > ViewModel?.NumMaxMsg)
-        {
-            ClearMsg();
-        }
-
         txtMsg.AppendText(msg.ToString());
+        TrimMsg();
         if (togScrollToEnd.IsChecked ?? true)
         {
             txtMsg.ScrollToEnd();
         }
+    }
+
+    private void TrimMsg()
+    {
+        var maxLines = ViewModel?.NumMaxMsg ?? 500;
+        if (txtMsg.LineCount <= maxLines || txtMsg.Document == null)
+        {
+            return;
+        }
+
+        var firstKeepLine = txtMsg.LineCount - maxLines + 1;
+        var cutLine = txtMsg.Document.GetLineByNumber(firstKeepLine);
+        if (cutLine.Offset <= 0)
+        {
+            return;
+        }
+
+        txtMsg.Document.Remove(0, cutLine.Offset);
     }
 
     public void ClearMsg()

--- a/v2rayN/v2rayN/Views/MsgView.xaml.cs
+++ b/v2rayN/v2rayN/Views/MsgView.xaml.cs
@@ -45,16 +45,30 @@ public partial class MsgView
 
     private void ShowMsg(object msg)
     {
-        if (txtMsg.LineCount > ViewModel?.NumMaxMsg)
-        {
-            ClearMsg();
-        }
-
         txtMsg.AppendText(msg.ToString());
+        TrimMsg();
         if (togScrollToEnd.IsChecked ?? true)
         {
             txtMsg.ScrollToEnd();
         }
+    }
+
+    private void TrimMsg()
+    {
+        var maxLines = ViewModel?.NumMaxMsg ?? 500;
+        if (txtMsg.LineCount <= maxLines)
+        {
+            return;
+        }
+
+        var keepFromCharIndex = txtMsg.GetCharacterIndexFromLineIndex(txtMsg.LineCount - maxLines);
+        if (keepFromCharIndex <= 0)
+        {
+            return;
+        }
+
+        txtMsg.Select(0, keepFromCharIndex);
+        txtMsg.SelectedText = string.Empty;
     }
 
     public void ClearMsg()


### PR DESCRIPTION
Fix: 限制 `MsgViewModel` 日志队列容量，并改为增量刷新，避免后台运行时内存持续增长

closes #8906

## 复现
### 复现时的操作系统和版本
Windows 10 22H2 - V2rayN 7.18.0
### 预期情况
v2rayN进程在后台运行时占用内存不应持续增长
### 实际情况
v2rayN进程提交大小持续升高，长时间隐藏到托盘后，重新打开主界面时内存会进一步明显上涨
<img width="1711" height="61" alt="1" src="https://github.com/user-attachments/assets/2518ba82-92e7-4c1d-97b9-b49013a6f2db" />
<img width="2718" height="201" alt="2" src="https://github.com/user-attachments/assets/fe2e0701-7777-435f-a861-1193e493e2b4" />


### 复现方法

1. 启动v2rayN.exe，使用ProcDump或查看任务管理器

2. 建议使用更容易产生大量xray core日志的配置以加快复现，例如

   - TUN

   - Hysteria2 (原issue使用Hysteria2，复现时用的是VMESS)

   - 调整日志等级至debug
     - 设置--参数设置--日志等级

3. 将v2rayN主窗口隐藏到托盘

4. 持续跑流量，正常使用数个小时至数十个小时，期间保持v2rayN主窗口隐藏于托盘

5. 观察到v2rayN进程占用内存持续升高

6. 重新打开主界面，内存进一步明显上涨

### 成因

1. MsgViewModel 使用 `private readonly ConcurrentQueue<string> _queueMsg = new();`缓存xray core日志，但原实现没有对队列长度设置上限；同时在 `AppManager.Instance.ShowInTaskbar` 为 false 时不会继续触发界面刷新，导致后台期间队列更容易持续积压
2. 随时间推移，xray core日志持续添加进`_queueMsg`
3. 后续打开v2rayN主窗口，触发刷新消息视图时，积压队列中的大量字符串会再被拼接进 UI 文本框，从而同时保留队列中的日志字符串和 TextBox 当前显示的大文本，进一步放大内存占用

### 证明

对内存转储文件做托管堆分析，主要内存占用来自消息字符串和 `ConcurrentQueue<string>` 段数组占据，根链指向 `MsgViewModel._queueMsg`。

核心输出：

  ```text
  GC Allocated Heap Size: 353,374,776 bytes

  Statistics:
  System.String                                                   938,974  294,446,640
  System.Collections.Concurrent.ConcurrentQueueSegment<String>+Slot[]  11   16,745,736
  ```

```text
  Name: ServiceLib.ViewModels.MsgViewModel
  _queueMsg = 000001bfde5d5cb8
  <NumMaxMsg>k__BackingField = 500
```

```text
  Name: ConcurrentQueueSegment<String>
  _slotsMask = 524287
```

`_slotsMask = 524287` 表示当前 segment 容量为 524,288 个槽位，原实现中的 `NumMaxMsg=500` 仅限制消息视图显示行数，不限制 `_queueMsg` 的积压规模。

gcroot 也确认该队列由消息视图链路保活：

```text
  v2rayN.Views.MsgView
   -> ServiceLib.ViewModels.MsgViewModel
   -> _queueMsg
   -> ConcurrentQueue<string>
```

此外，dump 中还存在一个大 UI 字符串：

```text
  System.String Size: 1,183,208
  _stringLength: 591,593
```

其根链 MsgView -> TextBox，说明刷新界面时还会把大量日志拼成巨型文本并保留在 UI 中。

结论：问题根因是 MsgViewModel 日志队列在后台运行时无界积压，叠加消息视图的大字符串，导致内存持续增长。


## 修复

### 修改内容

  - 为 MsgViewModel 的日志队列增加容量上限，避免后台运行时无界积压
  - 按批次刷新队列内容到消息视图，降低单次刷新的内存和界面压力
  - 将消息视图的超限处理改为裁剪旧内容而不是整块清空，保留最近日志并避免大文本持续膨胀

### 预期效果

  - 内存占用不再随时间持续累计