### PR TITLE
Fix Linux Wayland title bar theming for main and dialog windows

### DIFF
--- a/v2rayN/ServiceLib/Common/Utils.cs
+++ b/v2rayN/ServiceLib/Common/Utils.cs
@@ -1101,6 +1101,13 @@ public class Utils
 
     public static bool IsLinux() => OperatingSystem.IsLinux();
 
+    public static bool IsWayland() =>
+        OperatingSystem.IsLinux()
+        && (
+            Environment.GetEnvironmentVariable("WAYLAND_DISPLAY").IsNotEmpty()
+            || string.Equals(Environment.GetEnvironmentVariable("XDG_SESSION_TYPE"), "wayland", StringComparison.OrdinalIgnoreCase)
+        );
+
     public static bool IsMacOS() => OperatingSystem.IsMacOS();
 
     public static bool IsNonWindows() => !OperatingSystem.IsWindows();

--- a/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
@@ -156,7 +156,7 @@ public class ProfilesViewModel : MyReactiveObject
         {
             await MoveServer(EMove.Bottom);
         }, canEditRemove);
-        MoveToGroupCmd = ReactiveCommand.CreateFromTask<SubItem>(async sub =>
+        MoveToGroupCmd = ReactiveCommand.Create<SubItem>(sub =>
         {
             SelectedMoveToGroup = sub;
         });

--- a/v2rayN/v2rayN.Desktop/App.axaml
+++ b/v2rayN/v2rayN.Desktop/App.axaml
@@ -22,6 +22,24 @@
         <StyleInclude Source="Assets/GlobalStyles.axaml" />
         <StyleInclude Source="avares://Semi.Avalonia.DataGrid/Index.axaml" />
         <dialogHost:DialogHostStyles />
+        <Style Selector="Border.windowTitleBar">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="{DynamicResource ButtonDefaultTertiaryForeground}" />
+            <Setter Property="BorderThickness" Value="0,0,0,1" />
+        </Style>
+        <Style Selector="Button.windowTitleBarButton">
+            <Setter Property="Width" Value="36" />
+            <Setter Property="Height" Value="32" />
+            <Setter Property="MinWidth" Value="36" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="Theme" Value="{DynamicResource BorderlessButton}" />
+        </Style>
+        <Style Selector="TextBlock.windowTitleBarGlyph">
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="Foreground" Value="{DynamicResource ButtonDefaultTertiaryForeground}" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
     </Application.Styles>
 
     <TrayIcon.Icons>

--- a/v2rayN/v2rayN.Desktop/Base/WindowBase.cs
+++ b/v2rayN/v2rayN.Desktop/Base/WindowBase.cs
@@ -2,8 +2,17 @@ namespace v2rayN.Desktop.Base;
 
 public class WindowBase<TViewModel> : ReactiveWindow<TViewModel> where TViewModel : class
 {
+    private Border? _linuxTitleBar;
+    private Control? _linuxTitleBarDragRegion;
+    private Button? _linuxTitleBarCloseButton;
+
     public WindowBase()
     {
+        if (Utils.IsLinux())
+        {
+            SystemDecorations = SystemDecorations.BorderOnly;
+        }
+
         Loaded += OnLoaded;
     }
 
@@ -34,15 +43,81 @@ public class WindowBase<TViewModel> : ReactiveWindow<TViewModel> where TViewMode
             Position = new PixelPoint((int)x, (int)y);
         }
         catch { }
+
+        ConfigureLinuxTitleBar();
     }
 
     protected override void OnClosed(EventArgs e)
     {
+        ReleaseLinuxTitleBar();
         base.OnClosed(e);
         try
         {
             ConfigHandler.SaveWindowSizeItem(AppManager.Instance.Config, GetType().Name, Width, Height);
         }
         catch { }
+    }
+
+    protected virtual void HandleLinuxTitleBarClose()
+    {
+        Close();
+    }
+
+    private void ConfigureLinuxTitleBar()
+    {
+        if (!Utils.IsLinux())
+        {
+            return;
+        }
+
+        _linuxTitleBar ??= this.FindControl<Border>("linuxTitleBar");
+        if (_linuxTitleBar == null)
+        {
+            return;
+        }
+
+        _linuxTitleBar.IsVisible = true;
+
+        _linuxTitleBarDragRegion ??= this.FindControl<Control>("linuxTitleBarDragRegion");
+        if (_linuxTitleBarDragRegion != null)
+        {
+            _linuxTitleBarDragRegion.PointerPressed -= LinuxTitleBar_PointerPressed;
+            _linuxTitleBarDragRegion.PointerPressed += LinuxTitleBar_PointerPressed;
+        }
+
+        _linuxTitleBarCloseButton ??= this.FindControl<Button>("btnLinuxClose");
+        if (_linuxTitleBarCloseButton != null)
+        {
+            _linuxTitleBarCloseButton.Click -= LinuxTitleBarClose_Click;
+            _linuxTitleBarCloseButton.Click += LinuxTitleBarClose_Click;
+        }
+    }
+
+    private void ReleaseLinuxTitleBar()
+    {
+        if (_linuxTitleBarDragRegion != null)
+        {
+            _linuxTitleBarDragRegion.PointerPressed -= LinuxTitleBar_PointerPressed;
+        }
+
+        if (_linuxTitleBarCloseButton != null)
+        {
+            _linuxTitleBarCloseButton.Click -= LinuxTitleBarClose_Click;
+        }
+    }
+
+    private void LinuxTitleBar_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed == false)
+        {
+            return;
+        }
+
+        BeginMoveDrag(e);
+    }
+
+    private void LinuxTitleBarClose_Click(object? sender, RoutedEventArgs e)
+    {
+        HandleLinuxTitleBarClose();
     }
 }

--- a/v2rayN/v2rayN.Desktop/Base/WindowBase.cs
+++ b/v2rayN/v2rayN.Desktop/Base/WindowBase.cs
@@ -8,7 +8,7 @@ public class WindowBase<TViewModel> : ReactiveWindow<TViewModel> where TViewMode
 
     public WindowBase()
     {
-        if (Utils.IsLinux())
+        if (Utils.IsWayland())
         {
             SystemDecorations = SystemDecorations.BorderOnly;
         }
@@ -65,7 +65,7 @@ public class WindowBase<TViewModel> : ReactiveWindow<TViewModel> where TViewMode
 
     private void ConfigureLinuxTitleBar()
     {
-        if (!Utils.IsLinux())
+        if (!Utils.IsWayland())
         {
             return;
         }

--- a/v2rayN/v2rayN.Desktop/Common/UI.cs
+++ b/v2rayN/v2rayN.Desktop/Common/UI.cs
@@ -18,7 +18,7 @@ internal class UI
             WindowStartupLocation = WindowStartupLocation.CenterOwner,
             CanResize = false,
             Topmost = false,
-            SystemDecorations = Utils.IsLinux() ? SystemDecorations.BorderOnly : SystemDecorations.Full
+            SystemDecorations = Utils.IsWayland() ? SystemDecorations.BorderOnly : SystemDecorations.Full
         };
         var box = MessageBoxManager.GetMessageBoxStandard(messageBoxParams);
         return await box.ShowWindowDialogAsync(owner);

--- a/v2rayN/v2rayN.Desktop/Common/UI.cs
+++ b/v2rayN/v2rayN.Desktop/Common/UI.cs
@@ -1,5 +1,6 @@
 using Avalonia.Platform.Storage;
 using MsBox.Avalonia;
+using MsBox.Avalonia.Dto;
 
 namespace v2rayN.Desktop.Common;
 
@@ -9,7 +10,17 @@ internal class UI
 
     public static async Task<ButtonResult> ShowYesNo(Window owner, string msg)
     {
-        var box = MessageBoxManager.GetMessageBoxStandard(caption, msg, ButtonEnum.YesNo);
+        var messageBoxParams = new MessageBoxStandardParams
+        {
+            ContentTitle = caption,
+            ContentMessage = msg,
+            ButtonDefinitions = ButtonEnum.YesNo,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            CanResize = false,
+            Topmost = false,
+            SystemDecorations = Utils.IsLinux() ? SystemDecorations.BorderOnly : SystemDecorations.Full
+        };
+        var box = MessageBoxManager.GetMessageBoxStandard(messageBoxParams);
         return await box.ShowWindowDialogAsync(owner);
     }
 

--- a/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml
@@ -13,8 +13,37 @@
     ShowInTaskbar="False"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-
-    <DockPanel Margin="{StaticResource Margin8}">
+    <Grid RowDefinitions="Auto,*">
+        <Border
+            x:Name="linuxTitleBar"
+            Classes="windowTitleBar"
+            IsVisible="False">
+            <Grid ColumnDefinitions="Auto,*,Auto" Height="36">
+                <Border
+                    x:Name="linuxTitleBarDragRegion"
+                    Grid.ColumnSpan="2"
+                    Background="Transparent" />
+                <StackPanel
+                    Grid.Column="0"
+                    Margin="12,0,0,0"
+                    Orientation="Horizontal"
+                    Spacing="8">
+                    <Image
+                        Width="16"
+                        Height="16"
+                        Source="/Assets/NotifyIcon1.ico" />
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Text="{Binding Title, RelativeSource={RelativeSource AncestorType=Window}}" />
+                </StackPanel>
+                <StackPanel Grid.Column="2" Orientation="Horizontal">
+                    <Button x:Name="btnLinuxClose" Classes="windowTitleBarButton">
+                        <TextBlock Classes="windowTitleBarGlyph" Text="×" />
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Border>
+        <DockPanel Grid.Row="1" Margin="{StaticResource Margin8}">
         <StackPanel
             Margin="{StaticResource Margin4}"
             HorizontalAlignment="Center"
@@ -252,5 +281,6 @@
                 </DataGrid>
             </TabItem>
         </TabControl>
-    </DockPanel>
+        </DockPanel>
+    </Grid>
 </Window>

--- a/v2rayN/v2rayN.Desktop/Views/AddServer2Window.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/AddServer2Window.axaml
@@ -13,7 +13,37 @@
     ShowInTaskbar="False"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-    <DockPanel Margin="{StaticResource Margin8}">
+    <Grid RowDefinitions="Auto,*">
+        <Border
+            x:Name="linuxTitleBar"
+            Classes="windowTitleBar"
+            IsVisible="False">
+            <Grid ColumnDefinitions="Auto,*,Auto" Height="36">
+                <Border
+                    x:Name="linuxTitleBarDragRegion"
+                    Grid.ColumnSpan="2"
+                    Background="Transparent" />
+                <StackPanel
+                    Grid.Column="0"
+                    Margin="12,0,0,0"
+                    Orientation="Horizontal"
+                    Spacing="8">
+                    <Image
+                        Width="16"
+                        Height="16"
+                        Source="/Assets/NotifyIcon1.ico" />
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Text="{Binding Title, RelativeSource={RelativeSource AncestorType=Window}}" />
+                </StackPanel>
+                <StackPanel Grid.Column="2" Orientation="Horizontal">
+                    <Button x:Name="btnLinuxClose" Classes="windowTitleBarButton">
+                        <TextBlock Classes="windowTitleBarGlyph" Text="×" />
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Border>
+        <DockPanel Grid.Row="1" Margin="{StaticResource Margin8}">
         <StackPanel
             Margin="{StaticResource Margin4}"
             HorizontalAlignment="Center"
@@ -154,5 +184,6 @@
                 </StackPanel>
             </Grid>
         </ScrollViewer>
-    </DockPanel>
+        </DockPanel>
+    </Grid>
 </Window>

--- a/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml
@@ -14,7 +14,37 @@
     ShowInTaskbar="False"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-    <DockPanel Margin="{StaticResource Margin8}">
+    <Grid RowDefinitions="Auto,*">
+        <Border
+            x:Name="linuxTitleBar"
+            Classes="windowTitleBar"
+            IsVisible="False">
+            <Grid ColumnDefinitions="Auto,*,Auto" Height="36">
+                <Border
+                    x:Name="linuxTitleBarDragRegion"
+                    Grid.ColumnSpan="2"
+                    Background="Transparent" />
+                <StackPanel
+                    Grid.Column="0"
+                    Margin="12,0,0,0"
+                    Orientation="Horizontal"
+                    Spacing="8">
+                    <Image
+                        Width="16"
+                        Height="16"
+                        Source="/Assets/NotifyIcon1.ico" />
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Text="{Binding Title, RelativeSource={RelativeSource AncestorType=Window}}" />
+                </StackPanel>
+                <StackPanel Grid.Column="2" Orientation="Horizontal">
+                    <Button x:Name="btnLinuxClose" Classes="windowTitleBarButton">
+                        <TextBlock Classes="windowTitleBarGlyph" Text="×" />
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Border>
+        <DockPanel Grid.Row="1" Margin="{StaticResource Margin8}">
         <StackPanel
             Margin="{StaticResource Margin4}"
             HorizontalAlignment="Center"
@@ -1131,5 +1161,6 @@
                 <Separator Grid.Row="9" Margin="{StaticResource MarginTb8}" />
             </Grid>
         </ScrollViewer>
-    </DockPanel>
+        </DockPanel>
+    </Grid>
 </Window>

--- a/v2rayN/v2rayN.Desktop/Views/DNSSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/DNSSettingWindow.axaml
@@ -14,7 +14,37 @@
     ShowInTaskbar="False"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-    <DockPanel Margin="{StaticResource Margin8}">
+    <Grid RowDefinitions="Auto,*">
+        <Border
+            x:Name="linuxTitleBar"
+            Classes="windowTitleBar"
+            IsVisible="False">
+            <Grid ColumnDefinitions="Auto,*,Auto" Height="36">
+                <Border
+                    x:Name="linuxTitleBarDragRegion"
+                    Grid.ColumnSpan="2"
+                    Background="Transparent" />
+                <StackPanel
+                    Grid.Column="0"
+                    Margin="12,0,0,0"
+                    Orientation="Horizontal"
+                    Spacing="8">
+                    <Image
+                        Width="16"
+                        Height="16"
+                        Source="/Assets/NotifyIcon1.ico" />
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Text="{Binding Title, RelativeSource={RelativeSource AncestorType=Window}}" />
+                </StackPanel>
+                <StackPanel Grid.Column="2" Orientation="Horizontal">
+                    <Button x:Name="btnLinuxClose" Classes="windowTitleBarButton">
+                        <TextBlock Classes="windowTitleBarGlyph" Text="×" />
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Border>
+        <DockPanel Grid.Row="1" Margin="{StaticResource Margin8}">
         <StackPanel
             Margin="{StaticResource Margin4}"
             HorizontalAlignment="Center"
@@ -486,5 +516,6 @@
                 </DockPanel>
             </TabItem>
         </TabControl>
-    </DockPanel>
+        </DockPanel>
+    </Grid>
 </Window>

--- a/v2rayN/v2rayN.Desktop/Views/FullConfigTemplateWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/FullConfigTemplateWindow.axaml
@@ -14,7 +14,37 @@
     ShowInTaskbar="False"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-    <DockPanel Margin="{StaticResource Margin8}">
+    <Grid RowDefinitions="Auto,*">
+        <Border
+            x:Name="linuxTitleBar"
+            Classes="windowTitleBar"
+            IsVisible="False">
+            <Grid ColumnDefinitions="Auto,*,Auto" Height="36">
+                <Border
+                    x:Name="linuxTitleBarDragRegion"
+                    Grid.ColumnSpan="2"
+                    Background="Transparent" />
+                <StackPanel
+                    Grid.Column="0"
+                    Margin="12,0,0,0"
+                    Orientation="Horizontal"
+                    Spacing="8">
+                    <Image
+                        Width="16"
+                        Height="16"
+                        Source="/Assets/NotifyIcon1.ico" />
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Text="{Binding Title, RelativeSource={RelativeSource AncestorType=Window}}" />
+                </StackPanel>
+                <StackPanel Grid.Column="2" Orientation="Horizontal">
+                    <Button x:Name="btnLinuxClose" Classes="windowTitleBarButton">
+                        <TextBlock Classes="windowTitleBarGlyph" Text="×" />
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Border>
+        <DockPanel Grid.Row="1" Margin="{StaticResource Margin8}">
         <StackPanel
             Margin="{StaticResource Margin4}"
             HorizontalAlignment="Center"
@@ -178,5 +208,6 @@
                 </DockPanel>
             </TabItem>
         </TabControl>
-    </DockPanel>
+        </DockPanel>
+    </Grid>
 </Window>

--- a/v2rayN/v2rayN.Desktop/Views/GlobalHotkeySettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/GlobalHotkeySettingWindow.axaml
@@ -13,7 +13,37 @@
     ShowInTaskbar="False"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-    <DockPanel Margin="{StaticResource Margin8}">
+    <Grid RowDefinitions="Auto,*">
+        <Border
+            x:Name="linuxTitleBar"
+            Classes="windowTitleBar"
+            IsVisible="False">
+            <Grid ColumnDefinitions="Auto,*,Auto" Height="36">
+                <Border
+                    x:Name="linuxTitleBarDragRegion"
+                    Grid.ColumnSpan="2"
+                    Background="Transparent" />
+                <StackPanel
+                    Grid.Column="0"
+                    Margin="12,0,0,0"
+                    Orientation="Horizontal"
+                    Spacing="8">
+                    <Image
+                        Width="16"
+                        Height="16"
+                        Source="/Assets/NotifyIcon1.ico" />
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Text="{Binding Title, RelativeSource={RelativeSource AncestorType=Window}}" />
+                </StackPanel>
+                <StackPanel Grid.Column="2" Orientation="Horizontal">
+                    <Button x:Name="btnLinuxClose" Classes="windowTitleBarButton">
+                        <TextBlock Classes="windowTitleBarGlyph" Text="×" />
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Border>
+        <DockPanel Grid.Row="1" Margin="{StaticResource Margin8}">
         <StackPanel
             Margin="{StaticResource Margin4}"
             HorizontalAlignment="Center"
@@ -127,5 +157,6 @@
                     Text="{x:Static resx:ResUI.TbGlobalHotkeySettingTip}" />
             </Grid>
         </ScrollViewer>
-    </DockPanel>
+        </DockPanel>
+    </Grid>
 </Window>

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml
@@ -18,26 +18,6 @@
     ShowInTaskbar="True"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-    <Window.Styles>
-        <Style Selector="Border.windowTitleBar">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="BorderBrush" Value="{DynamicResource ButtonDefaultTertiaryForeground}" />
-            <Setter Property="BorderThickness" Value="0,0,0,1" />
-        </Style>
-        <Style Selector="Button.windowTitleBarButton">
-            <Setter Property="Width" Value="36" />
-            <Setter Property="Height" Value="32" />
-            <Setter Property="MinWidth" Value="36" />
-            <Setter Property="Padding" Value="0" />
-            <Setter Property="Theme" Value="{DynamicResource BorderlessButton}" />
-        </Style>
-        <Style Selector="TextBlock.windowTitleBarGlyph">
-            <Setter Property="FontSize" Value="14" />
-            <Setter Property="Foreground" Value="{DynamicResource ButtonDefaultTertiaryForeground}" />
-            <Setter Property="HorizontalAlignment" Value="Center" />
-            <Setter Property="VerticalAlignment" Value="Center" />
-        </Style>
-    </Window.Styles>
     <dialogHost:DialogHost
         Background="Gray"
         CloseOnClickAway="True"
@@ -50,9 +30,9 @@
                 IsVisible="False">
                 <Grid ColumnDefinitions="Auto,*,Auto" Height="36">
                     <Border
+                        x:Name="linuxTitleBarDragRegion"
                         Grid.ColumnSpan="2"
-                        Background="Transparent"
-                        PointerPressed="LinuxTitleBar_PointerPressed" />
+                        Background="Transparent" />
                     <StackPanel
                         Grid.Column="0"
                         Margin="12,0,0,0"
@@ -72,8 +52,7 @@
                         Orientation="Horizontal">
                         <Button
                             x:Name="btnLinuxClose"
-                            Classes="windowTitleBarButton"
-                            Click="BtnLinuxClose_Click">
+                            Classes="windowTitleBarButton">
                             <TextBlock Classes="windowTitleBarGlyph" Text="×" />
                         </Button>
                     </StackPanel>

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml
@@ -8,6 +8,7 @@
     xmlns:resx="clr-namespace:ServiceLib.Resx;assembly=ServiceLib"
     xmlns:view="using:v2rayN.Desktop.Views"
     xmlns:vms="clr-namespace:ServiceLib.ViewModels;assembly=ServiceLib"
+    x:Name="mainWindow"
     Title="v2rayN"
     Width="1200"
     Height="800"
@@ -17,11 +18,84 @@
     ShowInTaskbar="True"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
+    <Window.Styles>
+        <Style Selector="Border.windowTitleBar">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="{DynamicResource ButtonDefaultTertiaryForeground}" />
+            <Setter Property="BorderThickness" Value="0,0,0,1" />
+        </Style>
+        <Style Selector="Button.windowTitleBarButton">
+            <Setter Property="Width" Value="36" />
+            <Setter Property="Height" Value="32" />
+            <Setter Property="MinWidth" Value="36" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="Theme" Value="{DynamicResource BorderlessButton}" />
+        </Style>
+        <Style Selector="TextBlock.windowTitleBarGlyph">
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="Foreground" Value="{DynamicResource ButtonDefaultTertiaryForeground}" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+    </Window.Styles>
     <dialogHost:DialogHost
         Background="Gray"
         CloseOnClickAway="True"
         DisableOpeningAnimation="True">
-        <DockPanel>
+        <DockPanel LastChildFill="True">
+            <Border
+                x:Name="linuxTitleBar"
+                Classes="windowTitleBar"
+                DockPanel.Dock="Top"
+                IsVisible="False">
+                <Grid ColumnDefinitions="Auto,*,Auto" Height="36">
+                    <Border
+                        Grid.ColumnSpan="2"
+                        Background="Transparent"
+                        DoubleTapped="LinuxTitleBar_DoubleTapped"
+                        PointerPressed="LinuxTitleBar_PointerPressed" />
+                    <StackPanel
+                        Grid.Column="0"
+                        Margin="12,0,0,0"
+                        Orientation="Horizontal"
+                        Spacing="8">
+                        <Image
+                            Width="16"
+                            Height="16"
+                            Source="/Assets/NotifyIcon1.ico" />
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Text="{Binding Title, ElementName=mainWindow}" />
+                    </StackPanel>
+
+                    <StackPanel
+                        Grid.Column="2"
+                        Orientation="Horizontal">
+                        <Button
+                            x:Name="btnLinuxMinimize"
+                            Classes="windowTitleBarButton"
+                            Click="BtnLinuxMinimize_Click">
+                            <TextBlock Classes="windowTitleBarGlyph" Text="-" />
+                        </Button>
+                        <Button
+                            x:Name="btnLinuxMaximizeRestore"
+                            Classes="windowTitleBarButton"
+                            Click="BtnLinuxMaximizeRestore_Click">
+                            <TextBlock
+                                x:Name="txtLinuxMaximizeRestore"
+                                Classes="windowTitleBarGlyph"
+                                Text="□" />
+                        </Button>
+                        <Button
+                            x:Name="btnLinuxClose"
+                            Classes="windowTitleBarButton"
+                            Click="BtnLinuxClose_Click">
+                            <TextBlock Classes="windowTitleBarGlyph" Text="×" />
+                        </Button>
+                    </StackPanel>
+                </Grid>
+            </Border>
+
             <DockPanel Margin="{StaticResource Margin8}" DockPanel.Dock="Top">
                 <ContentControl x:Name="conTheme" DockPanel.Dock="Right" />
                 <Menu Margin="{StaticResource Margin4}">

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml
@@ -52,7 +52,6 @@
                     <Border
                         Grid.ColumnSpan="2"
                         Background="Transparent"
-                        DoubleTapped="LinuxTitleBar_DoubleTapped"
                         PointerPressed="LinuxTitleBar_PointerPressed" />
                     <StackPanel
                         Grid.Column="0"
@@ -71,21 +70,6 @@
                     <StackPanel
                         Grid.Column="2"
                         Orientation="Horizontal">
-                        <Button
-                            x:Name="btnLinuxMinimize"
-                            Classes="windowTitleBarButton"
-                            Click="BtnLinuxMinimize_Click">
-                            <TextBlock Classes="windowTitleBarGlyph" Text="-" />
-                        </Button>
-                        <Button
-                            x:Name="btnLinuxMaximizeRestore"
-                            Classes="windowTitleBarButton"
-                            Click="BtnLinuxMaximizeRestore_Click">
-                            <TextBlock
-                                x:Name="txtLinuxMaximizeRestore"
-                                Classes="windowTitleBarGlyph"
-                                Text="□" />
-                        </Button>
                         <Button
                             x:Name="btnLinuxClose"
                             Classes="windowTitleBarButton"

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
@@ -10,6 +10,7 @@ public partial class MainWindow : WindowBase<MainWindowViewModel>
 {
     private static Config _config;
     private readonly WindowNotificationManager? _manager;
+    private IDisposable? _linuxWindowStateSubscription;
     private CheckUpdateView? _checkUpdateView;
     private BackupAndRestoreView? _backupAndRestoreView;
     private bool _blCloseByUser = false;
@@ -162,6 +163,7 @@ public partial class MainWindow : WindowBase<MainWindowViewModel>
         else
         {
             Title = $"{Utils.GetVersion()}";
+            ConfigureLinuxTitleBar();
         }
         menuAddServerViaScan.IsVisible = false;
 
@@ -388,6 +390,81 @@ public partial class MainWindow : WindowBase<MainWindowViewModel>
         await AppManager.Instance.AppExitAsync(true);
     }
 
+    private void ConfigureLinuxTitleBar()
+    {
+        if (!Utils.IsLinux())
+        {
+            return;
+        }
+
+        linuxTitleBar.IsVisible = true;
+        SystemDecorations = SystemDecorations.BorderOnly;
+        btnLinuxMaximizeRestore.IsVisible = CanResize;
+
+        _linuxWindowStateSubscription = this
+            .GetObservable(WindowStateProperty)
+            .Subscribe(_ => UpdateLinuxTitleBarWindowState());
+        UpdateLinuxTitleBarWindowState();
+    }
+
+    private void UpdateLinuxTitleBarWindowState()
+    {
+        txtLinuxMaximizeRestore.Text = WindowState == WindowState.Maximized ? "❐" : "□";
+    }
+
+    private void LinuxTitleBar_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!Utils.IsLinux() || e.GetCurrentPoint(this).Properties.IsLeftButtonPressed == false)
+        {
+            return;
+        }
+
+        BeginMoveDrag(e);
+    }
+
+    private void LinuxTitleBar_DoubleTapped(object? sender, TappedEventArgs e)
+    {
+        if (!Utils.IsLinux() || !CanResize)
+        {
+            return;
+        }
+
+        ToggleLinuxWindowState();
+    }
+
+    private void BtnLinuxMinimize_Click(object? sender, RoutedEventArgs e)
+    {
+        WindowState = WindowState.Minimized;
+    }
+
+    private void BtnLinuxMaximizeRestore_Click(object? sender, RoutedEventArgs e)
+    {
+        ToggleLinuxWindowState();
+    }
+
+    private void BtnLinuxClose_Click(object? sender, RoutedEventArgs e)
+    {
+        HideToTray();
+    }
+
+    private void ToggleLinuxWindowState()
+    {
+        WindowState = WindowState == WindowState.Maximized
+            ? WindowState.Normal
+            : WindowState.Maximized;
+    }
+
+    private void HideToTray()
+    {
+        foreach (var ownedWindow in OwnedWindows)
+        {
+            ownedWindow.Close();
+        }
+
+        Hide();
+        AppManager.Instance.ShowInTaskbar = false;
+    }
+
     private void Shutdown(bool obj)
     {
         if (obj is bool b && _blCloseByUser == false)
@@ -448,6 +525,12 @@ public partial class MainWindow : WindowBase<MainWindowViewModel>
             ShowHideWindow(false);
         }
         RestoreUI();
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        _linuxWindowStateSubscription?.Dispose();
+        base.OnClosed(e);
     }
 
     private void RestoreUI()

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
@@ -282,7 +282,14 @@ public partial class MainWindow : WindowBase<MainWindowViewModel>
         {
             case WindowCloseReason.OwnerWindowClosing or WindowCloseReason.WindowClosing:
                 e.Cancel = true;
-                ShowHideWindow(false);
+                if (Utils.IsLinux())
+                {
+                    HideToTray();
+                }
+                else
+                {
+                    ShowHideWindow(false);
+                }
                 break;
 
             case WindowCloseReason.ApplicationShutdown or WindowCloseReason.OSShutdown:

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
@@ -10,7 +10,6 @@ public partial class MainWindow : WindowBase<MainWindowViewModel>
 {
     private static Config _config;
     private readonly WindowNotificationManager? _manager;
-    private IDisposable? _linuxWindowStateSubscription;
     private CheckUpdateView? _checkUpdateView;
     private BackupAndRestoreView? _backupAndRestoreView;
     private bool _blCloseByUser = false;
@@ -406,17 +405,6 @@ public partial class MainWindow : WindowBase<MainWindowViewModel>
 
         linuxTitleBar.IsVisible = true;
         SystemDecorations = SystemDecorations.BorderOnly;
-        btnLinuxMaximizeRestore.IsVisible = CanResize;
-
-        _linuxWindowStateSubscription = this
-            .GetObservable(WindowStateProperty)
-            .Subscribe(_ => UpdateLinuxTitleBarWindowState());
-        UpdateLinuxTitleBarWindowState();
-    }
-
-    private void UpdateLinuxTitleBarWindowState()
-    {
-        txtLinuxMaximizeRestore.Text = WindowState == WindowState.Maximized ? "❐" : "□";
     }
 
     private void LinuxTitleBar_PointerPressed(object? sender, PointerPressedEventArgs e)
@@ -429,36 +417,9 @@ public partial class MainWindow : WindowBase<MainWindowViewModel>
         BeginMoveDrag(e);
     }
 
-    private void LinuxTitleBar_DoubleTapped(object? sender, TappedEventArgs e)
-    {
-        if (!Utils.IsLinux() || !CanResize)
-        {
-            return;
-        }
-
-        ToggleLinuxWindowState();
-    }
-
-    private void BtnLinuxMinimize_Click(object? sender, RoutedEventArgs e)
-    {
-        HideToTray();
-    }
-
-    private void BtnLinuxMaximizeRestore_Click(object? sender, RoutedEventArgs e)
-    {
-        ToggleLinuxWindowState();
-    }
-
     private void BtnLinuxClose_Click(object? sender, RoutedEventArgs e)
     {
         HideToTray();
-    }
-
-    private void ToggleLinuxWindowState()
-    {
-        WindowState = WindowState == WindowState.Maximized
-            ? WindowState.Normal
-            : WindowState.Maximized;
     }
 
     private void HideToTray()
@@ -532,12 +493,6 @@ public partial class MainWindow : WindowBase<MainWindowViewModel>
             ShowHideWindow(false);
         }
         RestoreUI();
-    }
-
-    protected override void OnClosed(EventArgs e)
-    {
-        _linuxWindowStateSubscription?.Dispose();
-        base.OnClosed(e);
     }
 
     private void RestoreUI()

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
@@ -162,7 +162,6 @@ public partial class MainWindow : WindowBase<MainWindowViewModel>
         else
         {
             Title = $"{Utils.GetVersion()}";
-            ConfigureLinuxTitleBar();
         }
         menuAddServerViaScan.IsVisible = false;
 
@@ -396,28 +395,7 @@ public partial class MainWindow : WindowBase<MainWindowViewModel>
         await AppManager.Instance.AppExitAsync(true);
     }
 
-    private void ConfigureLinuxTitleBar()
-    {
-        if (!Utils.IsLinux())
-        {
-            return;
-        }
-
-        linuxTitleBar.IsVisible = true;
-        SystemDecorations = SystemDecorations.BorderOnly;
-    }
-
-    private void LinuxTitleBar_PointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        if (!Utils.IsLinux() || e.GetCurrentPoint(this).Properties.IsLeftButtonPressed == false)
-        {
-            return;
-        }
-
-        BeginMoveDrag(e);
-    }
-
-    private void BtnLinuxClose_Click(object? sender, RoutedEventArgs e)
+    protected override void HandleLinuxTitleBarClose()
     {
         HideToTray();
     }

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
@@ -441,7 +441,7 @@ public partial class MainWindow : WindowBase<MainWindowViewModel>
 
     private void BtnLinuxMinimize_Click(object? sender, RoutedEventArgs e)
     {
-        WindowState = WindowState.Minimized;
+        HideToTray();
     }
 
     private void BtnLinuxMaximizeRestore_Click(object? sender, RoutedEventArgs e)
@@ -510,7 +510,7 @@ public partial class MainWindow : WindowBase<MainWindowViewModel>
         {
             if (Utils.IsLinux() && _config.UiItem.Hide2TrayWhenClose == false)
             {
-                WindowState = WindowState.Minimized;
+                HideToTray();
                 return;
             }
 

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
@@ -13,7 +13,37 @@
     ShowInTaskbar="False"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-    <DockPanel Margin="{StaticResource Margin8}">
+    <Grid RowDefinitions="Auto,*">
+        <Border
+            x:Name="linuxTitleBar"
+            Classes="windowTitleBar"
+            IsVisible="False">
+            <Grid ColumnDefinitions="Auto,*,Auto" Height="36">
+                <Border
+                    x:Name="linuxTitleBarDragRegion"
+                    Grid.ColumnSpan="2"
+                    Background="Transparent" />
+                <StackPanel
+                    Grid.Column="0"
+                    Margin="12,0,0,0"
+                    Orientation="Horizontal"
+                    Spacing="8">
+                    <Image
+                        Width="16"
+                        Height="16"
+                        Source="/Assets/NotifyIcon1.ico" />
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Text="{Binding Title, RelativeSource={RelativeSource AncestorType=Window}}" />
+                </StackPanel>
+                <StackPanel Grid.Column="2" Orientation="Horizontal">
+                    <Button x:Name="btnLinuxClose" Classes="windowTitleBarButton">
+                        <TextBlock Classes="windowTitleBarGlyph" Text="×" />
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Border>
+        <DockPanel Grid.Row="1" Margin="{StaticResource Margin8}">
         <StackPanel
             Margin="{StaticResource Margin4}"
             HorizontalAlignment="Center"
@@ -965,5 +995,6 @@
                 </Grid>
             </TabItem>
         </TabControl>
-    </DockPanel>
+        </DockPanel>
+    </Grid>
 </Window>

--- a/v2rayN/v2rayN.Desktop/Views/ProfilesSelectWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/ProfilesSelectWindow.axaml
@@ -12,8 +12,37 @@
     x:DataType="vms:ProfilesSelectViewModel"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-
-    <DockPanel Margin="8">
+    <Grid RowDefinitions="Auto,*">
+        <Border
+            x:Name="linuxTitleBar"
+            Classes="windowTitleBar"
+            IsVisible="False">
+            <Grid ColumnDefinitions="Auto,*,Auto" Height="36">
+                <Border
+                    x:Name="linuxTitleBarDragRegion"
+                    Grid.ColumnSpan="2"
+                    Background="Transparent" />
+                <StackPanel
+                    Grid.Column="0"
+                    Margin="12,0,0,0"
+                    Orientation="Horizontal"
+                    Spacing="8">
+                    <Image
+                        Width="16"
+                        Height="16"
+                        Source="/Assets/NotifyIcon1.ico" />
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Text="{Binding Title, RelativeSource={RelativeSource AncestorType=Window}}" />
+                </StackPanel>
+                <StackPanel Grid.Column="2" Orientation="Horizontal">
+                    <Button x:Name="btnLinuxClose" Classes="windowTitleBarButton">
+                        <TextBlock Classes="windowTitleBarGlyph" Text="×" />
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Border>
+        <DockPanel Grid.Row="1" Margin="8">
         <!--  Bottom buttons  -->
         <StackPanel
             Margin="4"
@@ -123,5 +152,6 @@
                 </DataGrid>
             </DockPanel>
         </Grid>
-    </DockPanel>
+        </DockPanel>
+    </Grid>
 </Window>

--- a/v2rayN/v2rayN.Desktop/Views/RoutingRuleDetailsWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/RoutingRuleDetailsWindow.axaml
@@ -13,7 +13,37 @@
     ShowInTaskbar="False"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-    <DockPanel>
+    <Grid RowDefinitions="Auto,*">
+        <Border
+            x:Name="linuxTitleBar"
+            Classes="windowTitleBar"
+            IsVisible="False">
+            <Grid ColumnDefinitions="Auto,*,Auto" Height="36">
+                <Border
+                    x:Name="linuxTitleBarDragRegion"
+                    Grid.ColumnSpan="2"
+                    Background="Transparent" />
+                <StackPanel
+                    Grid.Column="0"
+                    Margin="12,0,0,0"
+                    Orientation="Horizontal"
+                    Spacing="8">
+                    <Image
+                        Width="16"
+                        Height="16"
+                        Source="/Assets/NotifyIcon1.ico" />
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Text="{Binding Title, RelativeSource={RelativeSource AncestorType=Window}}" />
+                </StackPanel>
+                <StackPanel Grid.Column="2" Orientation="Horizontal">
+                    <Button x:Name="btnLinuxClose" Classes="windowTitleBarButton">
+                        <TextBlock Classes="windowTitleBarGlyph" Text="×" />
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Border>
+        <DockPanel Grid.Row="1">
         <Grid
             Margin="{StaticResource Margin4}"
             ColumnDefinitions="Auto,Auto,Auto"
@@ -250,5 +280,6 @@
                     TextWrapping="Wrap" />
             </HeaderedContentControl>
         </Grid>
-    </DockPanel>
+        </DockPanel>
+    </Grid>
 </Window>

--- a/v2rayN/v2rayN.Desktop/Views/RoutingRuleSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/RoutingRuleSettingWindow.axaml
@@ -13,7 +13,37 @@
     ShowInTaskbar="False"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-    <DockPanel>
+    <Grid RowDefinitions="Auto,*">
+        <Border
+            x:Name="linuxTitleBar"
+            Classes="windowTitleBar"
+            IsVisible="False">
+            <Grid ColumnDefinitions="Auto,*,Auto" Height="36">
+                <Border
+                    x:Name="linuxTitleBarDragRegion"
+                    Grid.ColumnSpan="2"
+                    Background="Transparent" />
+                <StackPanel
+                    Grid.Column="0"
+                    Margin="12,0,0,0"
+                    Orientation="Horizontal"
+                    Spacing="8">
+                    <Image
+                        Width="16"
+                        Height="16"
+                        Source="/Assets/NotifyIcon1.ico" />
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Text="{Binding Title, RelativeSource={RelativeSource AncestorType=Window}}" />
+                </StackPanel>
+                <StackPanel Grid.Column="2" Orientation="Horizontal">
+                    <Button x:Name="btnLinuxClose" Classes="windowTitleBarButton">
+                        <TextBlock Classes="windowTitleBarGlyph" Text="×" />
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Border>
+        <DockPanel Grid.Row="1">
         <Menu Margin="{StaticResource Margin4}" DockPanel.Dock="Top">
             <MenuItem x:Name="menuRuleAdd" Header="{x:Static resx:ResUI.menuRuleAdd}" />
             <MenuItem x:Name="menuImportRulesFromFile" Header="{x:Static resx:ResUI.menuImportRulesFromFile}" />
@@ -253,5 +283,6 @@
                 </DataGrid>
             </TabItem>
         </TabControl>
-    </DockPanel>
+        </DockPanel>
+    </Grid>
 </Window>

--- a/v2rayN/v2rayN.Desktop/Views/RoutingSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/RoutingSettingWindow.axaml
@@ -13,8 +13,37 @@
     ShowInTaskbar="False"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-
-    <DockPanel>
+    <Grid RowDefinitions="Auto,*">
+        <Border
+            x:Name="linuxTitleBar"
+            Classes="windowTitleBar"
+            IsVisible="False">
+            <Grid ColumnDefinitions="Auto,*,Auto" Height="36">
+                <Border
+                    x:Name="linuxTitleBarDragRegion"
+                    Grid.ColumnSpan="2"
+                    Background="Transparent" />
+                <StackPanel
+                    Grid.Column="0"
+                    Margin="12,0,0,0"
+                    Orientation="Horizontal"
+                    Spacing="8">
+                    <Image
+                        Width="16"
+                        Height="16"
+                        Source="/Assets/NotifyIcon1.ico" />
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Text="{Binding Title, RelativeSource={RelativeSource AncestorType=Window}}" />
+                </StackPanel>
+                <StackPanel Grid.Column="2" Orientation="Horizontal">
+                    <Button x:Name="btnLinuxClose" Classes="windowTitleBarButton">
+                        <TextBlock Classes="windowTitleBarGlyph" Text="×" />
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Border>
+        <DockPanel Grid.Row="1">
         <Menu Margin="{StaticResource Margin4}" DockPanel.Dock="Top">
             <MenuItem x:Name="menuRoutingAdvancedAdd2" Header="{x:Static resx:ResUI.menuRoutingAdvancedAdd}" />
             <MenuItem x:Name="menuRoutingAdvancedImportRules2" Header="{x:Static resx:ResUI.menuRoutingAdvancedImportRules}" />
@@ -138,5 +167,6 @@
                 </DataGrid>
             </TabItem>
         </TabControl>
-    </DockPanel>
+        </DockPanel>
+    </Grid>
 </Window>

--- a/v2rayN/v2rayN.Desktop/Views/SubEditWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/SubEditWindow.axaml
@@ -12,7 +12,37 @@
     ShowInTaskbar="False"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-    <DockPanel Margin="{StaticResource Margin8}">
+    <Grid RowDefinitions="Auto,*">
+        <Border
+            x:Name="linuxTitleBar"
+            Classes="windowTitleBar"
+            IsVisible="False">
+            <Grid ColumnDefinitions="Auto,*,Auto" Height="36">
+                <Border
+                    x:Name="linuxTitleBarDragRegion"
+                    Grid.ColumnSpan="2"
+                    Background="Transparent" />
+                <StackPanel
+                    Grid.Column="0"
+                    Margin="12,0,0,0"
+                    Orientation="Horizontal"
+                    Spacing="8">
+                    <Image
+                        Width="16"
+                        Height="16"
+                        Source="/Assets/NotifyIcon1.ico" />
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Text="{Binding Title, RelativeSource={RelativeSource AncestorType=Window}}" />
+                </StackPanel>
+                <StackPanel Grid.Column="2" Orientation="Horizontal">
+                    <Button x:Name="btnLinuxClose" Classes="windowTitleBarButton">
+                        <TextBlock Classes="windowTitleBarGlyph" Text="×" />
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Border>
+        <DockPanel Grid.Row="1" Margin="{StaticResource Margin8}">
         <StackPanel
             Margin="{StaticResource Margin4}"
             HorizontalAlignment="Center"
@@ -266,5 +296,6 @@
 
             </Grid>
         </ScrollViewer>
-    </DockPanel>
+        </DockPanel>
+    </Grid>
 </Window>

--- a/v2rayN/v2rayN.Desktop/Views/SubSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/SubSettingWindow.axaml
@@ -14,12 +14,43 @@
     ShowInTaskbar="False"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-    <dialogHost:DialogHost
-        Background="Gray"
-        CloseOnClickAway="True"
-        DisableOpeningAnimation="True"
-        Identifier="dialogHostSub">
-        <DockPanel Margin="{StaticResource Margin8}">
+    <Grid RowDefinitions="Auto,*">
+        <Border
+            x:Name="linuxTitleBar"
+            Classes="windowTitleBar"
+            IsVisible="False">
+            <Grid ColumnDefinitions="Auto,*,Auto" Height="36">
+                <Border
+                    x:Name="linuxTitleBarDragRegion"
+                    Grid.ColumnSpan="2"
+                    Background="Transparent" />
+                <StackPanel
+                    Grid.Column="0"
+                    Margin="12,0,0,0"
+                    Orientation="Horizontal"
+                    Spacing="8">
+                    <Image
+                        Width="16"
+                        Height="16"
+                        Source="/Assets/NotifyIcon1.ico" />
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Text="{Binding Title, RelativeSource={RelativeSource AncestorType=Window}}" />
+                </StackPanel>
+                <StackPanel Grid.Column="2" Orientation="Horizontal">
+                    <Button x:Name="btnLinuxClose" Classes="windowTitleBarButton">
+                        <TextBlock Classes="windowTitleBarGlyph" Text="×" />
+                    </Button>
+                </StackPanel>
+            </Grid>
+        </Border>
+        <dialogHost:DialogHost
+            Grid.Row="1"
+            Background="Gray"
+            CloseOnClickAway="True"
+            DisableOpeningAnimation="True"
+            Identifier="dialogHostSub">
+            <DockPanel Margin="{StaticResource Margin8}">
             <Menu Margin="{StaticResource Margin4}" DockPanel.Dock="Top">
                 <MenuItem x:Name="menuSubAdd" Header="{x:Static resx:ResUI.menuSubAdd}" />
                 <MenuItem x:Name="menuSubDelete" Header="{x:Static resx:ResUI.menuSubDelete}" />
@@ -75,6 +106,7 @@
                         Header="{x:Static resx:ResUI.LvSort}" />
                 </DataGrid.Columns>
             </DataGrid>
-        </DockPanel>
-    </dialogHost:DialogHost>
+            </DockPanel>
+        </dialogHost:DialogHost>
+    </Grid>
 </Window>


### PR DESCRIPTION
## Summary

This PR adds Linux-specific custom title bar handling for the Avalonia desktop frontend so the title bar follows the app theme under Wayland instead of keeping a light/native-looking decoration.

Related to #8947.

## Background

On Linux Wayland, `v2rayN.Desktop` already switched the content area theme correctly when using `Dark` or `FollowSystem`, but the window title bar remained light because Linux-specific window chrome handling was missing.

The original issue was reported for the main window, but the same visual inconsistency also affected dialog windows and confirmation dialogs once Linux custom chrome was introduced.

## What Changed

### 1. Shared Linux title bar styles
- Added reusable title bar styles in `v2rayN.Desktop/App.axaml`.
- This keeps the Linux title bar appearance consistent across the main window and dialog windows.

### 2. Shared Linux window chrome behavior
- Extended `v2rayN.Desktop/Base/WindowBase.cs` to handle Linux-only title bar behavior centrally.
- For Linux windows derived from `WindowBase`:
  - switch to Linux custom window chrome behavior
  - show the in-app title bar only on Linux
  - support dragging from the custom title bar
  - provide a shared close-button handler
- Non-Linux platforms keep their normal native window decorations.

### 3. Main window integration
- Updated `v2rayN.Desktop/Views/MainWindow.axaml` and `MainWindow.axaml.cs` to reuse the shared Linux title bar mechanism.
- The main window still keeps its existing Linux-specific close behavior:
  - the custom close button hides the window to tray/background instead of exiting the app

### 4. Dialog window integration
- Applied the same Linux title bar container to desktop dialog windows, including:
  - server edit/add windows
  - DNS / routing / option / template windows
  - subscription-related windows
  - profile selection window
  - routing rule detail windows
- For these dialog windows, the custom close button closes only the current dialog.

### 5. Confirmation dialog decoration
- Updated `v2rayN.Desktop/Common/UI.cs` so the `MessageBox.Avalonia` Yes/No confirmation dialog also uses Linux-specific window decoration settings.
- This avoids leaving one remaining native/light title bar on Linux for exit confirmation and similar prompts.

## Scope

This PR only changes Linux desktop window chrome / title bar behavior in the Avalonia frontend.

It does **not** change:
- core proxy logic
- routing/subscription business logic
- configuration models or persistence format
- Windows-specific dark border handling
- macOS window behavior

## Validation

Tested/verified locally with:
- Linux Wayland session
- custom title bar shown for the main window and desktop dialog windows
- dialog close button closes only the dialog
- main window close button still hides to tray/background
- build check: 0 warnings, 0 errors

## Screenshots

- Main window in Linux dark theme
<img width="905" height="1040" alt="image" src="https://github.com/user-attachments/assets/6b47ec7b-bd1e-4a9a-93b6-5f1b05f75a7d" />

- One desktop dialog window with the new Linux title bar
<img width="1000" height="570" alt="image" src="https://github.com/user-attachments/assets/0970cc8e-3070-4baf-9e99-f856f3ba6f2b" />


- Exit confirmation dialog on Linux
<img width="210" height="101" alt="image" src="https://github.com/user-attachments/assets/77223c7c-6ba9-48fb-a319-230ed693ec90" />


- Light theme comparison
<img width="936" height="1050" alt="image" src="https://github.com/user-attachments/assets/464fcaa7-f9a9-4b15-890e-2cc7ce27a8cf" />


