### PR TITLE
fix: pin 7 unpinned action(s),extract 10 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -17,53 +17,65 @@ jobs:
         run: |
           curl -X POST \
             -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
             https://api.github.com/repos/${{ github.repository }}/actions/workflows/build-windows.yml/dispatches \
             -d "{
               \"ref\": \"master\",
               \"inputs\": {
-                \"release_tag\": \"${{ github.event.inputs.release_tag }}\"
+                \"release_tag\": \"${INPUT_RELEASE_TAG}\"
               }
             }"
 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag }}
       - name: Trigger build linux
         if: github.event.inputs.release_tag != ''
         run: |
           curl -X POST \
             -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
             https://api.github.com/repos/${{ github.repository }}/actions/workflows/build-linux.yml/dispatches \
             -d "{
               \"ref\": \"master\",
               \"inputs\": {
-                \"release_tag\": \"${{ github.event.inputs.release_tag }}\"
+                \"release_tag\": \"${INPUT_RELEASE_TAG}\"
               }
             }"
 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag }}
       - name: Trigger build osx
         if: github.event.inputs.release_tag != ''
         run: |
           curl -X POST \
             -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
             https://api.github.com/repos/${{ github.repository }}/actions/workflows/build-osx.yml/dispatches \
             -d "{
               \"ref\": \"master\",
               \"inputs\": {
-                \"release_tag\": \"${{ github.event.inputs.release_tag }}\"
+                \"release_tag\": \"${INPUT_RELEASE_TAG}\"
               }
             }"
 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag }}
       - name: Trigger build windows desktop
         if: github.event.inputs.release_tag != ''
         run: |
           curl -X POST \
             -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: token ${GITHUB_TOKEN}" \
             https://api.github.com/repos/${{ github.repository }}/actions/workflows/build-windows-desktop.yml/dispatches \
             -d "{
               \"ref\": \"master\",
               \"inputs\": {
-                \"release_tag\": \"${{ github.event.inputs.release_tag }}\"
+                \"release_tag\": \"${INPUT_RELEASE_TAG}\"
               }
             }"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag }}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -62,7 +62,7 @@ jobs:
         ./package-release-zip.sh "$OutputArchArm" "$OutputPathArm64"
     
     - name: Upload zip archive to release
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
       if: github.event.inputs.release_tag != ''
       with:
         file: ${{ github.workspace }}/v2rayN*.zip
@@ -122,7 +122,7 @@ jobs:
         path: dist/deb/**/*.deb
 
     - name: Upload DEBs to release
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
       with:
         file: dist/deb/**/*.deb
         tag: ${{ env.RELEASE_TAG }}
@@ -235,7 +235,7 @@ jobs:
         path: dist/rpm/**/*.rpm
 
     - name: Upload RPMs to release
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
       with:
         file: dist/rpm/**/*.rpm
         tag: ${{ env.RELEASE_TAG }}

--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -57,11 +57,13 @@ jobs:
       run: |
         brew install create-dmg
         chmod 755 package-osx.sh
-        ./package-osx.sh $OutputArch $OutputPath64 ${{ github.event.inputs.release_tag }}
-        ./package-osx.sh $OutputArchArm $OutputPathArm64 ${{ github.event.inputs.release_tag }}
+        ./package-osx.sh $OutputArch $OutputPath64 ${INPUT_RELEASE_TAG}
+        ./package-osx.sh $OutputArchArm $OutputPathArm64 ${INPUT_RELEASE_TAG}
     
+      env:
+        INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag }}
     - name: Upload dmg to release
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
       if: github.event.inputs.release_tag != ''
       with:
         file: ${{ github.workspace }}/v2rayN*.dmg
@@ -78,7 +80,7 @@ jobs:
         ./package-release-zip.sh $OutputArchArm $OutputPathArm64
     
     - name: Upload zip archive to release
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
       if: github.event.inputs.release_tag != ''
       with:
         file: ${{ github.workspace }}/v2rayN*.zip

--- a/.github/workflows/build-windows-desktop.yml
+++ b/.github/workflows/build-windows-desktop.yml
@@ -62,7 +62,7 @@ jobs:
         mv "v2rayN-${OutputArchArm}.zip" "v2rayN-${OutputArchArm}-desktop.zip"
 
     - name: Upload zip archive to release
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
       if: github.event.inputs.release_tag != ''
       with:
         file: ${{ github.workspace }}/v2rayN*.zip

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -57,7 +57,7 @@ jobs:
         ./package-release-zip.sh $OutputArchArm $OutputPathArm64
     
     - name: Upload zip archive to release
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
       if: github.event.inputs.release_tag != ''
       with:
         file: ${{ github.workspace }}/v2rayN*.zip

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
 
           $wingetPackage = "2dust.v2rayN"
-          $gitToken = "${{ secrets.PT_WINGET }}"
+          $gitToken = "${PT_WINGET}"
 
           $github = Invoke-RestMethod -uri "https://api.github.com/repos/2dust/v2rayN/releases" 
 
@@ -37,3 +37,6 @@ jobs:
           Write-Host "arm64 URL: $arm64InstallerUrl"
           
           .\wingetcreate.exe update $wingetPackage -s -v $ver -u "$x64InstallerUrl|x64" "$arm64InstallerUrl|arm64" -t $gitToken
+
+        env:
+          PT_WINGET: ${{ secrets.PT_WINGET }}


### PR DESCRIPTION
## Fix: CI/CD Security Vulnerabilities in GitHub Actions

Hi! [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), an open-source
CI/CD security scanner by [Vigilant Cyber Security](https://www.vigilantdefense.com),
identified security vulnerabilities in this repository's GitHub Actions workflows.

This PR applies automated fixes where possible and reports additional findings
for your review.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-002 | high | `.github/workflows/build-all.yml` | Extracted 8 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/build-linux.yml` | Pinned 3 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/build-osx.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/build-osx.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/build-windows-desktop.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/build-windows.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/winget-publish.yml` | Extracted 1 unsafe expression(s) to env vars |


### Advisory: additional findings (manual review recommended)

No additional findings beyond the fixes applied above.

### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.