### PR TITLE
Fix sing-box selector generation for dynamic group tags

### DIFF
--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -22,7 +22,7 @@ public partial class CoreConfigSingboxService
         }
         if (withSelector)
         {
-            var proxyTags = proxyOutboundList.Where(n => n.tag.StartsWith(Global.ProxyTag)).Select(n => n.tag).ToList();
+            var proxyTags = proxyOutboundList.Where(n => n.tag.StartsWith(baseTagName)).Select(n => n.tag).ToList();
             if (proxyTags.Count > 1)
             {
                 proxyOutboundList.InsertRange(0, BuildSelectorOutbounds(proxyTags, baseTagName));


### PR DESCRIPTION
## Summary
- fix sing-box group outbound selector generation when routing uses a dynamic base tag
- keep selector/urltest creation working for policy groups referenced by routing rules

## Root cause
BuildAllProxyOutbounds() filtered child outbound tags with StartsWith(Global.ProxyTag).
When routing builds a group-specific tag like <group-id>-proxy-<remarks>, the generated child tags also start with that dynamic prefix instead of the literal proxy, so selector/urltest outbounds were never created.

## Fix
- filter group child outbound tags with aseTagName instead of the fixed Global.ProxyTag

## Verification
- reproduced locally with a failing regression test against a dynamic group tag scenario
- after the fix, the regression test passes
- dotnet build v2rayN/v2rayN.sln -v minimal passes locally
- dotnet test v2rayN/v2rayN.sln -v minimal passes locally

## Notes
I kept the submitted change minimal. I used a local regression test during TDD, but did not include the temporary test project in this PR to avoid introducing broader solution/test-layout changes in the same fix.
