### PR TITLE
修复 sing-box TUN 模式下 relay 出站的 mux 问题

### DIFF
--- a/v2rayN/ServiceLib/Common/ProcUtils.cs
+++ b/v2rayN/ServiceLib/Common/ProcUtils.cs
@@ -46,7 +46,7 @@ public static class ProcUtils
         return null;
     }
 
-    public static void RebootAsAdmin(bool blAdmin = true)
+    public static bool RebootAsAdmin(bool blAdmin = true)
     {
         try
         {
@@ -58,11 +58,12 @@ public static class ProcUtils
                 FileName = Utils.GetExePath().AppendQuotes(),
                 Verb = blAdmin ? "runas" : null,
             };
-            _ = Process.Start(startInfo);
+            return Process.Start(startInfo) != null;
         }
         catch (Exception ex)
         {
             Logging.SaveLog(_tag, ex);
+            return false;
         }
     }
 }

--- a/v2rayN/ServiceLib/Manager/AppManager.cs
+++ b/v2rayN/ServiceLib/Manager/AppManager.cs
@@ -144,16 +144,10 @@ public sealed class AppManager
         AppEvents.ShutdownRequested.Publish(byUser);
     }
 
-    public async Task<bool> RebootAsAdmin()
+    public async Task RebootAsAdmin()
     {
-        var started = ProcUtils.RebootAsAdmin();
-        if (!started)
-        {
-            return false;
-        }
-
+        ProcUtils.RebootAsAdmin();
         await AppManager.Instance.AppExitAsync(true);
-        return true;
     }
 
     #endregion App

--- a/v2rayN/ServiceLib/Manager/AppManager.cs
+++ b/v2rayN/ServiceLib/Manager/AppManager.cs
@@ -144,10 +144,16 @@ public sealed class AppManager
         AppEvents.ShutdownRequested.Publish(byUser);
     }
 
-    public async Task RebootAsAdmin()
+    public async Task<bool> RebootAsAdmin()
     {
-        ProcUtils.RebootAsAdmin();
+        var started = ProcUtils.RebootAsAdmin();
+        if (!started)
+        {
+            return false;
+        }
+
         await AppManager.Instance.AppExitAsync(true);
+        return true;
     }
 
     #endregion App

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -22,7 +22,7 @@ public partial class CoreConfigSingboxService
         }
         if (withSelector)
         {
-            var proxyTags = proxyOutboundList.Where(n => n.tag.StartsWith(Global.ProxyTag)).Select(n => n.tag).ToList();
+            var proxyTags = proxyOutboundList.Where(n => n.tag.StartsWith(baseTagName)).Select(n => n.tag).ToList();
             if (proxyTags.Count > 1)
             {
                 proxyOutboundList.InsertRange(0, BuildSelectorOutbounds(proxyTags, baseTagName));

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -345,6 +345,14 @@ public partial class CoreConfigSingboxService
     {
         try
         {
+            // The synthetic TUN relay outbound talks to the local Xray shadowsocks relay.
+            // Xray cannot terminate sing-box h2mux, so muxing here turns local relay traffic
+            // into sp.mux.sing-box.arpa pseudo-destinations and breaks DNS over TUN.
+            if (IsTunRelayProxyOutbound())
+            {
+                return;
+            }
+
             var muxEnabled = _node.MuxEnabled ?? _config.CoreBasicItem.MuxEnabled;
             if (muxEnabled && _config.Mux4SboxItem.Protocol.IsNotEmpty())
             {
@@ -362,6 +370,21 @@ public partial class CoreConfigSingboxService
         {
             Logging.SaveLog(_tag, ex);
         }
+    }
+
+    private bool IsTunRelayProxyOutbound()
+    {
+        if (!context.IsTunEnabled
+            || _node.ConfigType != EConfigType.Shadowsocks
+            || _node.Address != Global.Loopback
+            || _node.Port != context.ProxyRelaySsPort
+            || _node.Password != Global.None)
+        {
+            return false;
+        }
+
+        var protocolExtra = _node.GetProtocolExtra();
+        return protocolExtra.SsMethod == Global.None;
     }
 
     private void FillOutboundTls(Outbound4Sbox outbound)

--- a/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
@@ -469,38 +469,30 @@ public class StatusBarViewModel : MyReactiveObject
             return;
         }
 
-        var allowEnableTun = AllowEnableTun();
-        if (PrepareTunConfigForPrivilegeEscalation(_config, EnableTun, allowEnableTun, Utils.IsWindows()))
-        {
-            await ConfigHandler.SaveConfig(_config);
-            if (!await AppManager.Instance.RebootAsAdmin())
-            {
-                _config.TunModeItem.EnableTun = false;
-                EnableTun = false;
-                await ConfigHandler.SaveConfig(_config);
-                NoticeManager.Instance.SendMessageEx(ResUI.OperationFailed);
-            }
-            return;
-        }
+        _config.TunModeItem.EnableTun = EnableTun;
 
-        if (EnableTun && !allowEnableTun)
+        if (EnableTun && AllowEnableTun() == false)
         {
-            bool? passwordResult = await _updateView?.Invoke(EViewAction.PasswordInput, null);
-            if (passwordResult == false)
+            // When running as a non-administrator, reboot to administrator mode
+            if (Utils.IsWindows())
             {
                 _config.TunModeItem.EnableTun = false;
+                await AppManager.Instance.RebootAsAdmin();
                 return;
+            }
+            else
+            {
+                bool? passwordResult = await _updateView?.Invoke(EViewAction.PasswordInput, null);
+                if (passwordResult == false)
+                {
+                    _config.TunModeItem.EnableTun = false;
+                    return;
+                }
             }
         }
 
         await ConfigHandler.SaveConfig(_config);
         AppEvents.ReloadRequested.Publish();
-    }
-
-    private static bool PrepareTunConfigForPrivilegeEscalation(Config config, bool enableTun, bool allowEnableTun, bool isWindows)
-    {
-        config.TunModeItem.EnableTun = enableTun;
-        return enableTun && !allowEnableTun && isWindows;
     }
 
     private bool AllowEnableTun()

--- a/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
@@ -469,29 +469,38 @@ public class StatusBarViewModel : MyReactiveObject
             return;
         }
 
-        _config.TunModeItem.EnableTun = EnableTun;
-
-        if (EnableTun && AllowEnableTun() == false)
+        var allowEnableTun = AllowEnableTun();
+        if (PrepareTunConfigForPrivilegeEscalation(_config, EnableTun, allowEnableTun, Utils.IsWindows()))
         {
-            // When running as a non-administrator, reboot to administrator mode
-            if (Utils.IsWindows())
+            await ConfigHandler.SaveConfig(_config);
+            if (!await AppManager.Instance.RebootAsAdmin())
             {
                 _config.TunModeItem.EnableTun = false;
-                await AppManager.Instance.RebootAsAdmin();
+                EnableTun = false;
+                await ConfigHandler.SaveConfig(_config);
+                NoticeManager.Instance.SendMessageEx(ResUI.OperationFailed);
+            }
+            return;
+        }
+
+        if (EnableTun && !allowEnableTun)
+        {
+            bool? passwordResult = await _updateView?.Invoke(EViewAction.PasswordInput, null);
+            if (passwordResult == false)
+            {
+                _config.TunModeItem.EnableTun = false;
                 return;
             }
-            else
-            {
-                bool? passwordResult = await _updateView?.Invoke(EViewAction.PasswordInput, null);
-                if (passwordResult == false)
-                {
-                    _config.TunModeItem.EnableTun = false;
-                    return;
-                }
-            }
         }
+
         await ConfigHandler.SaveConfig(_config);
         AppEvents.ReloadRequested.Publish();
+    }
+
+    private static bool PrepareTunConfigForPrivilegeEscalation(Config config, bool enableTun, bool allowEnableTun, bool isWindows)
+    {
+        config.TunModeItem.EnableTun = enableTun;
+        return enableTun && !allowEnableTun && isWindows;
     }
 
     private bool AllowEnableTun()


### PR DESCRIPTION
## 问题说明

这次修复包含两个彼此相关的 TUN 问题：

1. 在 TUN 预服务链路中，本地 relay 到 Xray 的 shadowsocks 出站会错误启用 sing-box 的 h2mux。
   这会把本地 relay 流量包装成 `sp.mux.sing-box.arpa` 伪目标，导致 TUN 下 DoH/DNS 请求失败。

2. 在 Windows 下，非管理员状态开启 TUN 时，提权重启前会把 `EnableTun` 状态写回 `false`。
   结果是提权后的新进程不会真正启用 TUN，表现为用户已经开启 TUN，但 TUN 栈没有被拉起。

## 修复内容

- 对 TUN 本地 relay shadowsocks 出站禁用 mux，避免本地 relay 流量被错误包装
- 调整 Windows 下开启 TUN 的提权流程，在提权重启前保留并保存 `EnableTun=true`
- 在 UAC 取消时回滚 `EnableTun`，避免配置状态与实际运行状态不一致

## 验证情况

本地已完成以下验证：

- GUI 模式下开启 TUN 后，`v2rayN` 可正确提权重启
- 提权后 `EnableTun` 状态可保留
- `singbox_tun` 适配器可正常拉起
- `google.com`、`nytimes.com`、`scoop.sh`、`xys.org` 在 TUN 下恢复可访问
- `dotnet build v2rayN/v2rayN/v2rayN.csproj -c Release` 通过
- `dotnet test v2rayN/ServiceLib.Tests/ServiceLib.Tests.csproj --no-restore --verbosity minimal` 通过（本地回归用）

说明：
本地还补充了回归测试并验证通过，但考虑仓库当前没有现成测试基础设施，这次 PR 先只提交最小代码修复，测试工程暂未一并提交。