### PR TITLE
Report node validator result

### DIFF
--- a/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
+++ b/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace ServiceLib.Handler.Builder;
 
 public record CoreConfigContextBuilderResult(CoreConfigContext Context, NodeValidatorResult ValidatorResult)
@@ -309,6 +311,11 @@ public class CoreConfigContextBuilder
         }
 
         var nodeValidatorResult = NodeValidator.Validate(node, context.RunCoreType);
+        var msgs = new List<string>([.. nodeValidatorResult.Errors, .. nodeValidatorResult.Warnings]);
+        if (msgs.Count > 0)
+        {
+            Logging.SaveLog($"{node.Remarks}: {string.Join("; ", msgs)}");
+        }
         if (!nodeValidatorResult.Success)
         {
             return nodeValidatorResult;


### PR DESCRIPTION
将节点检测输出到日志

---

close #9022

从日志可以看到 sing-box 正确嗅探出进程

```log
-0700 2026-03-30 16:58:42 INFO [116636559 0ms] inbound/mixed[socks]: inbound connection from 127.0.0.1:11066
-0700 2026-03-30 16:58:42 INFO [116636559 0ms] inbound/mixed[socks]: inbound connection to ipv6.ip.sb:443
-0700 2026-03-30 16:58:42 INFO [116636559 1ms] router: found process path: C:\Users\admin\AppData\Local\Perplexity\Comet\Application\comet.exe
-0700 2026-03-30 16:58:42 INFO [116636559 1ms] outbound/shadowsocks[proxy]: outbound connection to ipv6.ip.sb:443
```

所以要么是我们规则生成问题，要么节点 sing-box 不支持，回退至 仅 proxy

我更倾向于后者，因为我这边测试没问题

```bash
PS C:\Users\V\Desktop\curl\bin> ./curl ip.sb
140.238.***
PS C:\Users\V\Desktop\curl\bin> iwr ip.sb


StatusCode        : 200
StatusDescription : OK
Content           : 64.181.***
```

```log
+0800 2026-03-31 17:51:17 INFO router: found process path: C:\Users\V\Desktop\curl\bin\curl.exe
+0800 2026-03-31 17:51:17 INFO [4124758658 0ms] router: found process path: C:\Users\V\Desktop\curl\bin\curl.exe
+0800 2026-03-31 17:51:17 DEBUG [4124758658 0ms] router: match[7] process_name=curl.exe => route(5498334681881009421-proxy-🇬🇧英国伦敦)
```