### PR TITLE
Replace protect-ss with protect-socks

### DIFF
--- a/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
+++ b/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
@@ -25,14 +25,14 @@ public record CoreConfigContextBuilderAllResult(
         [.. MainResult.ValidatorResult.Warnings, .. PreSocksResult?.ValidatorResult.Warnings ?? []]);
 
     /// <summary>
-    /// The main context with TunProtectSsPort/ProxyRelaySsPort and ProtectDomainList merged in
+    /// The main context with TunProtectSocksPort/ProxyRelaySocksPort and ProtectDomainList merged in
     /// from the pre-socks result (if any). Pass this to the core runner.
     /// </summary>
     public CoreConfigContext ResolvedMainContext => PreSocksResult is not null
         ? MainResult.Context with
         {
-            TunProtectSsPort = PreSocksResult.Context.TunProtectSsPort,
-            ProxyRelaySsPort = PreSocksResult.Context.ProxyRelaySsPort,
+            TunProtectSocksPort = PreSocksResult.Context.TunProtectSocksPort,
+            ProxyRelaySocksPort = PreSocksResult.Context.ProxyRelaySocksPort,
             ProtectDomainList = [.. MainResult.Context.ProtectDomainList ?? [], .. PreSocksResult.Context.ProtectDomainList ?? []],
         }
         : MainResult.Context;
@@ -58,8 +58,8 @@ public class CoreConfigContextBuilder
             IsTunEnabled = config.TunModeItem.EnableTun,
             SimpleDnsItem = config.SimpleDNSItem,
             ProtectDomainList = [],
-            TunProtectSsPort = 0,
-            ProxyRelaySsPort = 0,
+            TunProtectSocksPort = 0,
+            ProxyRelaySocksPort = 0,
             RawDnsItem = await AppManager.Instance.GetDNSItem(coreType),
             RoutingItem = await ConfigHandler.GetDefaultRouting(config),
         };
@@ -155,28 +155,23 @@ public class CoreConfigContextBuilder
             return null;
         }
 
-        var tunProtectSsPort = Utils.GetFreePort();
-        var proxyRelaySsPort = Utils.GetFreePort();
+        var tunProtectSocksPort = Utils.GetFreePort();
+        var proxyRelaySocksPort = Utils.GetFreePort();
         var preItem = new ProfileItem()
         {
             CoreType = ECoreType.sing_box,
-            ConfigType = EConfigType.Shadowsocks,
+            ConfigType = EConfigType.SOCKS,
             Address = Global.Loopback,
-            Port = proxyRelaySsPort,
-            Password = Global.None,
+            Port = proxyRelaySocksPort,
         };
-        preItem.SetProtocolExtra(preItem.GetProtocolExtra() with
-        {
-            SsMethod = Global.None,
-        });
         var preResult2 = await Build(nodeContext.AppConfig, preItem);
         return preResult2 with
         {
             Context = preResult2.Context with
             {
                 ProtectDomainList = [.. nodeContext.ProtectDomainList ?? [], .. preResult2.Context.ProtectDomainList ?? []],
-                TunProtectSsPort = tunProtectSsPort,
-                ProxyRelaySsPort = proxyRelaySsPort,
+                TunProtectSocksPort = tunProtectSocksPort,
+                ProxyRelaySocksPort = proxyRelaySocksPort,
             }
         };
     }

--- a/v2rayN/ServiceLib/Models/CoreConfigContext.cs
+++ b/v2rayN/ServiceLib/Models/CoreConfigContext.cs
@@ -20,6 +20,6 @@ public record CoreConfigContext
     // -> tun inbound --(if routing proxy)--> relay outbound
     // -> proxy core (relay inbound --> proxy outbound --(dialerProxy)--> protect outbound)
     // -> protect inbound -> direct proxy outbound data -> internet
-    public int TunProtectSsPort { get; init; } = 0;
-    public int ProxyRelaySsPort { get; init; } = 0;
+    public int TunProtectSocksPort { get; init; } = 0;
+    public int ProxyRelaySocksPort { get; init; } = 0;
 }

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/CoreConfigSingboxService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/CoreConfigSingboxService.cs
@@ -62,16 +62,23 @@ public partial class CoreConfigSingboxService(CoreConfigContext context)
 
             ret.Data = ApplyFullConfigTemplate();
             if (!context.AppConfig.TunModeItem.EnableLegacyProtect
-                && context.TunProtectSsPort is > 0 and <= 65535)
+                && context.TunProtectSocksPort is > 0 and <= 65535)
             {
+                // Replace relay proxy outbound, avoid mux or other feature cause issue, and add a socks inbound for tun protect
+                var relayProxyIndex = _coreConfig.outbounds.FindIndex(o => o.tag == Global.ProxyTag);
+                _coreConfig.outbounds[relayProxyIndex] = new Outbound4Sbox()
+                {
+                    type = Global.ProtocolTypes[EConfigType.SOCKS],
+                    tag = Global.ProxyTag,
+                    server = Global.Loopback,
+                    server_port = context.ProxyRelaySocksPort,
+                };
                 var ssInbound = new
                 {
-                    type = "shadowsocks",
-                    tag = "tun-protect-ss",
+                    type = "socks",
+                    tag = "tun-protect-socks",
                     listen = Global.Loopback,
-                    listen_port = context.TunProtectSsPort,
-                    method = "none",
-                    password = "none",
+                    listen_port = context.TunProtectSocksPort,
                 };
                 var directRule = new Rule4Sbox()
                 {

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -345,14 +345,6 @@ public partial class CoreConfigSingboxService
     {
         try
         {
-            // The synthetic TUN relay outbound talks to the local Xray shadowsocks relay.
-            // Xray cannot terminate sing-box h2mux, so muxing here turns local relay traffic
-            // into sp.mux.sing-box.arpa pseudo-destinations and breaks DNS over TUN.
-            if (IsTunRelayProxyOutbound())
-            {
-                return;
-            }
-
             var muxEnabled = _node.MuxEnabled ?? _config.CoreBasicItem.MuxEnabled;
             if (muxEnabled && _config.Mux4SboxItem.Protocol.IsNotEmpty())
             {
@@ -370,21 +362,6 @@ public partial class CoreConfigSingboxService
         {
             Logging.SaveLog(_tag, ex);
         }
-    }
-
-    private bool IsTunRelayProxyOutbound()
-    {
-        if (!context.IsTunEnabled
-            || _node.ConfigType != EConfigType.Shadowsocks
-            || _node.Address != Global.Loopback
-            || _node.Port != context.ProxyRelaySsPort
-            || _node.Password != Global.None)
-        {
-            return false;
-        }
-
-        var protocolExtra = _node.GetProtocolExtra();
-        return protocolExtra.SsMethod == Global.None;
     }
 
     private void FillOutboundTls(Outbound4Sbox outbound)

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/CoreConfigV2rayService.cs
@@ -17,8 +17,8 @@ public partial class CoreConfigV2rayService(CoreConfigContext context)
         {
             if (!context.AppConfig.TunModeItem.EnableLegacyProtect
                 && context.IsTunEnabled
-                && context.TunProtectSsPort is > 0 and <= 65535
-                && context.ProxyRelaySsPort is > 0 and <= 65535)
+                && context.TunProtectSocksPort is > 0 and <= 65535
+                && context.ProxyRelaySocksPort is > 0 and <= 65535)
             {
                 return GenerateClientProxyRelayConfig();
             }
@@ -309,17 +309,16 @@ public partial class CoreConfigV2rayService(CoreConfigContext context)
             var protectNode = new ProfileItem()
             {
                 CoreType = ECoreType.Xray,
-                ConfigType = EConfigType.Shadowsocks,
+                ConfigType = EConfigType.SOCKS,
                 Address = Global.Loopback,
-                Port = context.TunProtectSsPort,
-                Password = Global.None,
+                Port = context.TunProtectSocksPort,
             };
             protectNode.SetProtocolExtra(protectNode.GetProtocolExtra() with
             {
                 SsMethod = Global.None,
             });
 
-            const string protectTag = "tun-protect-ss";
+            const string protectTag = "tun-protect-socks";
             foreach (var outbound in _coreConfig.outbounds
                 .Where(o => o.streamSettings?.sockopt?.dialerProxy?.IsNullOrEmpty() ?? true))
             {
@@ -368,7 +367,7 @@ public partial class CoreConfigV2rayService(CoreConfigContext context)
             var hasBalancer = _coreConfig.routing.balancers is { Count: > 0 };
             _coreConfig.routing.rules.Add(new()
             {
-                inboundTag = ["proxy-relay-ss"],
+                inboundTag = ["proxy-relay-socks"],
                 outboundTag = hasBalancer ? null : Global.ProxyTag,
                 balancerTag = hasBalancer ? Global.ProxyTag + Global.BalancerTagSuffix : null,
                 type = "field"
@@ -380,15 +379,14 @@ public partial class CoreConfigV2rayService(CoreConfigContext context)
             configNode["inbounds"]!.AsArray().Add(new
             {
                 listen = Global.Loopback,
-                port = context.ProxyRelaySsPort,
-                protocol = "shadowsocks",
+                port = context.ProxyRelaySocksPort,
+                protocol = "socks",
                 settings = new
                 {
-                    network = "tcp,udp",
-                    method = Global.None,
-                    password = Global.None,
+                    auth = "noauth",
+                    udp = true,
                 },
-                tag = "proxy-relay-ss",
+                tag = "proxy-relay-socks",
             });
 
             ret.Msg = string.Format(ResUI.SuccessfulConfiguration, "");


### PR DESCRIPTION
修复 ssh 不可用

---

似乎某个核心对 shadowsocks 的实现有问题，将其替换为 socks 就正常了

~~最初选择 shadowsocks 是主要是因为 udp。socks 有个 udp associate 可能有额外损耗，其他协议的 uot 两核心的实现可能不统一，一个是 sing-mux 一个是 xmux/mux.cool~~