### PR TITLE
Replace 100MB Cloudflare speedtest URL with 99MB

### DIFF
--- a/v2rayN/ServiceLib/Global.cs
+++ b/v2rayN/ServiceLib/Global.cs
@@ -143,7 +143,7 @@ public class Global
         @"https://cachefly.cachefly.net/50mb.test",
         @"https://speed.cloudflare.com/__down?bytes=10000000",
         @"https://speed.cloudflare.com/__down?bytes=50000000",
-        @"https://speed.cloudflare.com/__down?bytes=100000000",
+        @"https://speed.cloudflare.com/__down?bytes=99999999",
     ];
 
     public static readonly List<string> SpeedPingTestUrls =


### PR DESCRIPTION
fix #9071
找了半天别的测速源，最后发现改成 99999999 就行……
```bash
curl -I "https://speed.cloudflare.com/__down?bytes=99999999"
# HTTP/1.1 200 OK
```