### PR TITLE
Adjust DNS priority order

### DIFF
--- a/v2rayN/ServiceLib/Global.cs
+++ b/v2rayN/ServiceLib/Global.cs
@@ -424,11 +424,12 @@ public class Global
 
     public static readonly List<string> DomainDirectDNSAddress =
     [
-        "https://dns.alidns.com/dns-query",
-        "https://doh.pub/dns-query",
-        "https://dns.alidns.com/dns-query,https://doh.pub/dns-query",
-        "223.5.5.5",
         "119.29.29.29",
+        "223.5.5.5",
+        "119.29.29.29,223.5.5.5,https://doh.pub/dns-query",
+        "https://doh.pub/dns-query",
+        "https://dns.alidns.com/dns-query",
+        "https://doh.pub/dns-query,https://dns.alidns.com/dns-query",
         "localhost"
     ];
 
@@ -450,8 +451,8 @@ public class Global
 
     public static readonly List<string> DomainPureIPDNSAddress =
     [
-        "223.5.5.5",
         "119.29.29.29",
+        "223.5.5.5",
         "localhost"
     ];
 


### PR DESCRIPTION
调整直连 DNS 次序，保证最大可用性

听说部分墙高的地区 DoH 有问题，所以默认使用 腾讯 普通 UDP DNS

远程 DNS 仍保持 DoH；
UDP 远程 DNS 可能涉及到 节点 uot，udp 连通性等；
而 DoH 可以视为普通网站请求