### PR TITLE
Add RiscV64 RPM build && Update

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -28,7 +28,7 @@ jobs:
       release_tag: ${{ inputs.release_tag }}
 
   deb:
-    name: build and release deb
+    name: build and release deb x64 & arm64
     if: |
       (github.event_name == 'workflow_dispatch' && inputs.release_tag != '') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
@@ -80,7 +80,7 @@ jobs:
         prerelease: true
 
   rpm:
-    name: build and release rpm
+    name: build and release rpm x64 & arm64
     if: |
       (github.event_name == 'workflow_dispatch' && inputs.release_tag != '') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
@@ -170,7 +170,7 @@ jobs:
         find "$GITHUB_WORKSPACE/dist/rpm" -name "v2rayN-*-1*.aarch64.rpm" -exec mv {} "$GITHUB_WORKSPACE/dist/rpm/v2rayN-linux-rhel-arm64.rpm" \; || true
         echo "==== Dist tree ===="
         ls -R "$GITHUB_WORKSPACE/dist/rpm" || true
-  
+
     - name: Upload RPMs to release
       uses: svenstaro/upload-release-action@v2
       with:
@@ -178,3 +178,76 @@ jobs:
         tag: ${{ env.RELEASE_TAG }}
         file_glob: true
         prerelease: true
+
+  rpm-riscv64:
+    name: build and release rpm riscv64
+    if: |
+      (github.event_name == 'workflow_dispatch' && inputs.release_tag != '') ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+    runs-on: ubuntu-24.04-riscv
+    container: rockylinux/rockylinux:10-ubi
+    env:
+      RELEASE_TAG: ${{ case(inputs.release_tag != '', inputs.release_tag, github.ref_name) }}
+
+    steps:
+    - name: Prepare tools (Red Hat)
+      shell: bash
+      run: |
+        set -euo pipefail
+        dnf -y makecache
+        dnf -y install \
+          sudo git rpm-build rpmdevtools dnf-plugins-core rsync findutils tar gzip unzip which curl jq wget file \
+          ca-certificates desktop-file-utils xdg-utils python3 gcc make glibc-devel kernel-headers libatomic libstdc++
+
+    - name: Checkout repo (for scripts)
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        rm -rf ./*
+        git init .
+        git config --global --add safe.directory "$PWD"
+        git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        git fetch --depth=1 origin "${GITHUB_SHA}"
+        git checkout FETCH_HEAD
+        git submodule update --init --recursive
+
+    - name: Ensure script permissions
+      run: chmod 755 package-rhel-riscv.sh
+
+    - name: Package RPM (RHEL-family)
+      run: ./package-rhel-riscv.sh "${RELEASE_TAG}"
+
+    - name: Collect RPMs into workspace
+      run: |
+        mkdir -p "$GITHUB_WORKSPACE/dist/rpm-riscv64"
+        rsync -av "$HOME/rpmbuild/RPMS/" "$GITHUB_WORKSPACE/dist/rpm-riscv64/" || true
+        find "$GITHUB_WORKSPACE/dist/rpm-riscv64" -name "*.riscv64.rpm" \
+          -exec mv {} "$GITHUB_WORKSPACE/dist/rpm-riscv64/v2rayN-linux-rhel-riscv64.rpm" \; || true
+        echo "==== Dist tree ===="
+        ls -R "$GITHUB_WORKSPACE/dist/rpm-riscv64" || true
+
+    - name: Upload RPMs to release
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        shopt -s globstar nullglob
+
+        files=(dist/rpm-riscv64/**/*.rpm)
+        (( ${#files[@]} )) || { echo "No RPMs found."; exit 1; }
+
+        api="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}"
+        upload_url="$(curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" "$api" | jq -r '.upload_url // empty' | sed 's/{?name,label}//')"
+        [[ "$upload_url" ]] || { echo "Release upload URL not found: ${RELEASE_TAG}"; exit 1; }
+
+        for f in "${files[@]}"; do
+          echo "Uploading ${f##*/}"
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Content-Type: application/x-rpm" \
+            --data-binary @"$f" \
+            "${upload_url}?name=${f##*/}"
+        done

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -185,7 +185,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && inputs.release_tag != '') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-24.04-riscv
-    container: rockylinux/rockylinux:10-ubi
+    container: ghcr.io/xujiegb/fedora-riscv:43-latest
     env:
       RELEASE_TAG: ${{ case(inputs.release_tag != '', inputs.release_tag, github.ref_name) }}
 

--- a/package-rhel-riscv.sh
+++ b/package-rhel-riscv.sh
@@ -1,0 +1,703 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Require Red Hat base branch
+. /etc/os-release
+
+case "${ID:-}" in
+  rhel|rocky|almalinux|fedora|centos)
+    echo "Detected supported system: ${NAME:-$ID} ${VERSION_ID:-}"
+    ;;
+  *)
+    echo "Unsupported system: ${NAME:-unknown} (${ID:-unknown})."
+    echo "This script only supports: RHEL / Rocky / AlmaLinux / Fedora / CentOS."
+    exit 1
+    ;;
+esac
+
+# Kernel version
+MIN_KERNEL="5.10"
+CURRENT_KERNEL="$(uname -r)"
+
+lowest="$(printf '%s\n%s\n' "$MIN_KERNEL" "$CURRENT_KERNEL" | sort -V | head -n1)"
+
+if [[ "$lowest" != "$MIN_KERNEL" ]]; then
+    echo "Kernel $CURRENT_KERNEL is below $MIN_KERNEL"
+    exit 1
+fi
+
+echo "[OK] Kernel $CURRENT_KERNEL verified."
+
+# Config & Parse arguments
+VERSION_ARG="${1:-}"     # Pass version number like 7.13.8, or leave empty
+WITH_CORE="both"         # Default: bundle both xray+sing-box
+FORCE_NETCORE=0          # --netcore => skip archive bundle, use separate downloads
+BUILD_FROM=""            # --buildfrom 1|2|3 to select channel non-interactively
+DOTNET_RISCV_VERSION="10.0.105"
+DOTNET_RISCV_BASE="https://github.com/filipnavara/dotnet-riscv/releases/download"
+DOTNET_RISCV_FILE="dotnet-sdk-${DOTNET_RISCV_VERSION}-linux-riscv64.tar.gz"
+DOTNET_SDK_URL="${DOTNET_RISCV_BASE}/${DOTNET_RISCV_VERSION}/${DOTNET_RISCV_FILE}"
+SKIA_VER="${SKIA_VER:-3.119.1}"
+HARFBUZZ_VER="${HARFBUZZ_VER:-8.3.1.1}"
+
+# If the first argument starts with --, do not treat it as a version number
+if [[ "${VERSION_ARG:-}" == --* ]]; then
+  VERSION_ARG=""
+fi
+# Take the first non --* argument as version, discard it
+if [[ -n "${VERSION_ARG:-}" ]]; then shift || true; fi
+
+# Parse remaining optional arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --with-core)     WITH_CORE="${2:-both}"; shift 2;;
+    --xray-ver)      XRAY_VER="${2:-}"; shift 2;;
+    --singbox-ver)   SING_VER="${2:-}"; shift 2;;
+    --netcore)       FORCE_NETCORE=1; shift;;
+    --buildfrom)     BUILD_FROM="${2:-}"; shift 2;;
+    *)
+      if [[ -z "${VERSION_ARG:-}" ]]; then VERSION_ARG="$1"; fi
+      shift;;
+  esac
+done
+
+# Conflict: version number AND --buildfrom cannot be used together
+if [[ -n "${VERSION_ARG:-}" && -n "${BUILD_FROM:-}" ]]; then
+  echo "You cannot specify both an explicit version and --buildfrom at the same time."
+  echo "        Provide either a version (e.g. 7.14.0) OR --buildfrom 1|2|3."
+  exit 1
+fi
+
+apply_riscv_patch() {
+  # Upgrade net8.0 -> net10.0
+  find . -type f \( -name "*.csproj" -o -name "*.props" -o -name "*.targets" \) \
+    -exec sed -i 's/net8\.0/net10.0/g' {} +
+
+  # Patch all Directory.Packages.props for SkiaSharp/HarfBuzzSharp
+  while IFS= read -r -d '' f; do
+    # replace existing versions if present
+    sed -i \
+      -e "s#<PackageVersion Include=\"SkiaSharp\" Version=\"[^\"]*\" */>#<PackageVersion Include=\"SkiaSharp\" Version=\"$SKIA_VER\" />#g" \
+      -e "s#<PackageVersion Include=\"SkiaSharp.NativeAssets.Linux\" Version=\"[^\"]*\" */>#<PackageVersion Include=\"SkiaSharp.NativeAssets.Linux\" Version=\"$SKIA_VER\" />#g" \
+      -e "s#<PackageVersion Include=\"HarfBuzzSharp\" Version=\"[^\"]*\" */>#<PackageVersion Include=\"HarfBuzzSharp\" Version=\"$HARFBUZZ_VER\" />#g" \
+      -e "s#<PackageVersion Include=\"HarfBuzzSharp.NativeAssets.Linux\" Version=\"[^\"]*\" */>#<PackageVersion Include=\"HarfBuzzSharp.NativeAssets.Linux\" Version=\"$HARFBUZZ_VER\" />#g" \
+      "$f"
+
+    grep -q 'PackageVersion Include="SkiaSharp"' "$f" || \
+      sed -i "/<\/ItemGroup>/i\    <PackageVersion Include=\"SkiaSharp\" Version=\"$SKIA_VER\" />" "$f"
+
+    grep -q 'PackageVersion Include="SkiaSharp.NativeAssets.Linux"' "$f" || \
+      sed -i "/<\/ItemGroup>/i\    <PackageVersion Include=\"SkiaSharp.NativeAssets.Linux\" Version=\"$SKIA_VER\" />" "$f"
+
+    grep -q 'PackageVersion Include="HarfBuzzSharp"' "$f" || \
+      sed -i "/<\/ItemGroup>/i\    <PackageVersion Include=\"HarfBuzzSharp\" Version=\"$HARFBUZZ_VER\" />" "$f"
+
+    grep -q 'PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux"' "$f" || \
+      sed -i "/<\/ItemGroup>/i\    <PackageVersion Include=\"HarfBuzzSharp.NativeAssets.Linux\" Version=\"$HARFBUZZ_VER\" />" "$f"
+  done < <(find . -type f -name 'Directory.Packages.props' -print0)
+
+  # Patch SDK bundled RIDs
+  f="$(find "$DOTNET_ROOT/sdk/$(dotnet --version)" -type f -name 'Microsoft.NETCoreSdk.BundledVersions.props' | head -n1 || true)"
+  [[ -f "$f" ]] && sed -i \
+    -e 's/linux-arm64/&;linux-riscv64/g' \
+    -e 's/linux-musl-arm64/&;linux-musl-riscv64/g' \
+    "$f"
+}
+
+build_sqlite_native_riscv64() {
+  local outdir="$1"
+  local workdir sqlite_year sqlite_ver sqlite_zip srcdir
+
+  mkdir -p "$outdir"
+  workdir="$(mktemp -d)"
+
+  # SQLite 3.49.1 amalgamation
+  sqlite_year="2025"
+  sqlite_ver="3490100"
+  sqlite_zip="sqlite-amalgamation-${sqlite_ver}.zip"
+
+  echo "[+] Download SQLite amalgamation: ${sqlite_zip}"
+  curl -fL "https://www.sqlite.org/${sqlite_year}/${sqlite_zip}" -o "${workdir}/${sqlite_zip}"
+
+  unzip -q "${workdir}/${sqlite_zip}" -d "$workdir"
+  srcdir="$(find "$workdir" -maxdepth 1 -type d -name 'sqlite-amalgamation-*' | head -n1 || true)"
+  [[ -n "$srcdir" ]] || { echo "[!] SQLite source unpack failed"; rm -rf "$workdir"; return 1; }
+
+  echo "[+] Build libe_sqlite3.so for riscv64"
+  gcc -shared -fPIC -O2 \
+    -DSQLITE_THREADSAFE=1 \
+    -DSQLITE_ENABLE_FTS5 \
+    -DSQLITE_ENABLE_RTREE \
+    -DSQLITE_ENABLE_JSON1 \
+    -o "${outdir}/libe_sqlite3.so" "${srcdir}/sqlite3.c" -ldl -lpthread
+
+  rm -rf "$workdir"
+}
+
+copy_skiasharp_native_riscv64() {
+  local outdir="$1"
+  local skia_so=""
+  local harfbuzz_so=""
+
+  mkdir -p "$outdir"
+
+  skia_so="$(find "$HOME/.nuget/packages" -path "*/skiasharp.nativeassets.linux/${SKIA_VER}/runtimes/linux-riscv64/native/libSkiaSharp.so" | head -n1 || true)"
+  if [[ -z "$skia_so" ]]; then
+    skia_so="$(find "$HOME/.nuget/packages" -path "*/runtimes/linux-riscv64/native/libSkiaSharp.so" | head -n1 || true)"
+  fi
+
+  harfbuzz_so="$(find "$HOME/.nuget/packages" -path "*/harfbuzzsharp.nativeassets.linux/${HARFBUZZ_VER}/runtimes/linux-riscv64/native/libHarfBuzzSharp.so" | head -n1 || true)"
+  if [[ -z "$harfbuzz_so" ]]; then
+    harfbuzz_so="$(find "$HOME/.nuget/packages" -path "*/runtimes/linux-riscv64/native/libHarfBuzzSharp.so" | head -n1 || true)"
+  fi
+
+  if [[ -n "$skia_so" && -f "$skia_so" ]]; then
+    echo "[+] Copy libSkiaSharp.so from NuGet cache"
+    install -m 755 "$skia_so" "$outdir/libSkiaSharp.so"
+  else
+    echo "[WARN] libSkiaSharp.so for linux-riscv64 not found in NuGet cache"
+  fi
+
+  if [[ -n "$harfbuzz_so" && -f "$harfbuzz_so" ]]; then
+    echo "[+] Copy libHarfBuzzSharp.so from NuGet cache"
+    install -m 755 "$harfbuzz_so" "$outdir/libHarfBuzzSharp.so"
+  else
+    echo "[WARN] libHarfBuzzSharp.so for linux-riscv64 not found in NuGet cache"
+  fi
+}
+
+# Check and install dependencies
+host_arch="$(uname -m)"
+[[ "$host_arch" == "riscv64" ]] || { echo "Only supports riscv64"; exit 1; }
+
+install_ok=0
+
+if command -v dnf >/dev/null 2>&1; then
+  sudo dnf -y install \
+    rpm-build rpmdevtools curl unzip tar jq rsync git python3 gcc make \
+    glibc-devel kernel-headers libatomic file ca-certificates libicu\
+    && install_ok=1
+
+  mkdir -p "$HOME/.dotnet"
+  tmp_dotnet="$(mktemp -d)"
+  curl -fL "$DOTNET_SDK_URL" -o "$tmp_dotnet/$DOTNET_RISCV_FILE"
+  tar -C "$HOME/.dotnet" -xzf "$tmp_dotnet/$DOTNET_RISCV_FILE"
+  rm -rf "$tmp_dotnet"
+
+  export PATH="$HOME/.dotnet:$PATH"
+  export DOTNET_ROOT="$HOME/.dotnet"
+
+  dotnet --info >/dev/null 2>&1 || install_ok=0
+fi
+
+if [[ "$install_ok" -ne 1 ]]; then
+  echo "Could not auto-install dependencies for '$ID'. Make sure these are available:"
+  echo "dotnet-riscv SDK, curl, unzip, tar, rsync, git, python3, gcc, rpm, rpmdevtools, rpm-build (on Red Hat branch)"
+  exit 1
+fi
+
+# Root directory
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Git submodules (best effort)
+if [[ -f .gitmodules ]]; then
+  git submodule sync --recursive || true
+  git submodule update --init --recursive || true
+fi
+
+# Locate project
+PROJECT="v2rayN.Desktop/v2rayN.Desktop.csproj"
+if [[ ! -f "$PROJECT" ]]; then
+  PROJECT="$(find . -maxdepth 3 -name 'v2rayN.Desktop.csproj' | head -n1 || true)"
+fi
+[[ -f "$PROJECT" ]] || { echo "v2rayN.Desktop.csproj not found"; exit 1; }
+
+choose_channel() {
+  # If --buildfrom provided, map it directly and skip interaction.
+  if [[ -n "${BUILD_FROM:-}" ]]; then
+    case "$BUILD_FROM" in
+      1) echo "latest"; return 0;;
+      2) echo "prerelease"; return 0;;
+      3) echo "keep"; return 0;;
+      *) echo "[ERROR] Invalid --buildfrom value: ${BUILD_FROM}. Use 1|2|3." >&2; exit 1;;
+    esac
+  fi
+
+  # Print menu to stderr and read from /dev/tty so stdout only carries the token.
+  local ch="latest" sel=""
+
+  if [[ -t 0 ]]; then
+    echo "[?] Choose v2rayN release channel:" >&2
+    echo "    1) Latest (stable)  [default]" >&2
+    echo "    2) Pre-release (preview)" >&2
+    echo "    3) Keep current (do nothing)" >&2
+    printf "Enter 1, 2 or 3 [default 1]: " >&2
+
+    if read -r sel </dev/tty; then
+      case "${sel:-}" in
+        2) ch="prerelease" ;;
+        3) ch="keep" ;;
+      esac
+    fi
+  fi
+
+  echo "$ch"
+}
+
+get_latest_tag_latest() {
+  curl -fsSL "https://api.github.com/repos/2dust/v2rayN/releases/latest" \
+    | jq -re '.tag_name' \
+    | sed 's/^v//'
+}
+
+get_latest_tag_prerelease() {
+  curl -fsSL "https://api.github.com/repos/2dust/v2rayN/releases?per_page=20" \
+    | jq -re 'first(.[] | select(.prerelease == true) | .tag_name)' \
+    | sed 's/^v//'
+}
+
+git_try_checkout() {
+  # Try a series of refs and checkout when found.
+  local want="$1" ref=""
+  if git rev-parse --git-dir >/dev/null 2>&1; then
+    git fetch --tags --force --prune --depth=1 || true
+    if git rev-parse "refs/tags/${want}" >/dev/null 2>&1; then
+      ref="${want}"
+    fi
+    if [[ -n "$ref" ]]; then
+      echo "[OK] Found ref '${ref}', checking out..."
+      git checkout -f "${ref}"
+      if [[ -f .gitmodules ]]; then
+        git submodule sync --recursive || true
+        git submodule update --init --recursive || true
+      fi
+      return 0
+    fi
+  fi
+  return 1
+}
+
+apply_channel_or_keep() {
+  local ch="$1" tag
+
+  if [[ "$ch" == "keep" ]]; then
+    echo "[*] Keep current repository state (no checkout)."
+    VERSION="$(git describe --tags --abbrev=0 2>/dev/null || echo '0.0.0+git')"
+    VERSION="${VERSION#v}"
+    return 0
+  fi
+
+  echo "[*] Resolving ${ch} tag from GitHub releases..."
+  if [[ "$ch" == "prerelease" ]]; then
+    tag="$(get_latest_tag_prerelease || true)"
+  else
+    tag="$(get_latest_tag_latest || true)"
+  fi
+
+  [[ -n "$tag" ]] || { echo "Failed to resolve latest tag for channel '${ch}'."; exit 1; }
+  echo "[*] Latest tag for '${ch}': ${tag}"
+  git_try_checkout "$tag" || { echo "Failed to checkout '${tag}'."; exit 1; }
+  VERSION="${tag#v}"
+}
+
+if git rev-parse --git-dir >/dev/null 2>&1; then
+  if [[ -n "${VERSION_ARG:-}" ]]; then
+    clean_ver="${VERSION_ARG#v}"
+    if git_try_checkout "$clean_ver"; then
+      VERSION="$clean_ver"
+    else
+      echo "[WARN] Tag '${VERSION_ARG}' not found."
+      ch="$(choose_channel)"
+      apply_channel_or_keep "$ch"
+    fi
+  else
+    ch="$(choose_channel)"
+    apply_channel_or_keep "$ch"
+  fi
+else
+  echo "Current directory is not a git repo; proceeding on current tree."
+  VERSION="${VERSION_ARG:-0.0.0}"
+fi
+
+VERSION="${VERSION#v}"
+echo "[*] GUI version resolved as: ${VERSION}"
+
+# riscv64 patch
+apply_riscv_patch
+
+# Helpers for core
+download_xray() {
+  # Download Xray core
+  local outdir="$1" rid="$2" ver="${XRAY_VER:-}" url="" tmp zipname="xray.zip"
+  mkdir -p "$outdir"
+  if [[ -z "$ver" ]]; then
+    ver="$(curl -fsSL https://api.github.com/repos/XTLS/Xray-core/releases/latest \
+        | grep -Eo '"tag_name":\s*"v[^"]+"' | sed -E 's/.*"v([^"]+)".*/\1/' | head -n1)" || true
+  fi
+  [[ -n "$ver" ]] || { echo "[xray] Failed to get version"; return 1; }
+  if [[ "$rid" == "linux-riscv64" ]]; then
+    url="https://github.com/XTLS/Xray-core/releases/download/v${ver}/Xray-linux-riscv64.zip"
+  fi
+  [[ -n "$url" ]] || { echo "[xray] Unsupported RID: $rid"; return 1; }
+  echo "[+] Download xray: $url"
+  tmp="$(mktemp -d)"
+  curl -fL "$url" -o "$tmp/$zipname"
+  unzip -q "$tmp/$zipname" -d "$tmp"
+  install -m 755 "$tmp/xray" "$outdir/xray"
+  rm -rf "$tmp"
+}
+
+download_singbox() {
+  # Download sing-box
+  local outdir="$1" rid="$2" ver="${SING_VER:-}" url="" tmp tarname="singbox.tar.gz" bin cronet
+  mkdir -p "$outdir"
+  if [[ -z "$ver" ]]; then
+    ver="$(curl -fsSL https://api.github.com/repos/SagerNet/sing-box/releases/latest \
+      | grep -Eo '"tag_name":\s*"v[^"]+"' \
+      | sed -E 's/.*"v([^"]+)".*/\1/' \
+      | head -n1)" || true
+  fi
+  [[ -n "$ver" ]] || { echo "[sing-box] Failed to get version"; return 1; }
+  if [[ "$rid" == "linux-riscv64" ]]; then
+    url="https://github.com/SagerNet/sing-box/releases/download/v${ver}/sing-box-${ver}-linux-riscv64.tar.gz"
+  fi
+  [[ -n "$url" ]] || { echo "[sing-box] Unsupported RID: $rid"; return 1; }
+  echo "[+] Download sing-box: $url"
+  tmp="$(mktemp -d)"
+  curl -fL "$url" -o "$tmp/$tarname"
+  tar -C "$tmp" -xzf "$tmp/$tarname"
+  bin="$(find "$tmp" -type f -name 'sing-box' | head -n1 || true)"
+  [[ -n "$bin" ]] || { echo "[!] sing-box unpack failed"; rm -rf "$tmp"; return 1; }
+  install -m 755 "$bin" "$outdir/sing-box"
+  cronet="$(find "$tmp" -type f -name 'libcronet*.so*' | head -n1 || true)"
+  [[ -n "$cronet" ]] && install -m 644 "$cronet" "$outdir/libcronet.so"
+  rm -rf "$tmp"
+}
+
+# Move geo files to outroot/bin
+unify_geo_layout() {
+  local outroot="$1"
+  mkdir -p "$outroot/bin"
+  local names=( \
+    "geosite.dat" \
+    "geoip.dat" \
+    "geoip-only-cn-private.dat" \
+    "Country.mmdb" \
+    "geoip.metadb" \
+  )
+  for n in "${names[@]}"; do
+    if [[ -f "$outroot/bin/xray/$n" ]]; then
+      mv -f "$outroot/bin/xray/$n" "$outroot/bin/$n"
+    fi
+  done
+}
+
+# Download geo/rule assets
+download_geo_assets() {
+  local outroot="$1"
+  local bin_dir="$outroot/bin"
+  local srss_dir="$bin_dir/srss"
+  mkdir -p "$bin_dir" "$srss_dir"
+
+  echo "[+] Download Xray Geo to ${bin_dir}"
+  curl -fsSL -o "$bin_dir/geosite.dat" \
+    "https://github.com/Loyalsoldier/V2ray-rules-dat/releases/latest/download/geosite.dat"
+  curl -fsSL -o "$bin_dir/geoip.dat" \
+    "https://github.com/Loyalsoldier/V2ray-rules-dat/releases/latest/download/geoip.dat"
+  curl -fsSL -o "$bin_dir/geoip-only-cn-private.dat" \
+    "https://raw.githubusercontent.com/Loyalsoldier/geoip/release/geoip-only-cn-private.dat"
+  curl -fsSL -o "$bin_dir/Country.mmdb" \
+    "https://raw.githubusercontent.com/Loyalsoldier/geoip/release/Country.mmdb"
+
+  echo "[+] Download sing-box rule DB & rule-sets"
+  curl -fsSL -o "$bin_dir/geoip.metadb" \
+    "https://github.com/MetaCubeX/meta-rules-dat/releases/latest/download/geoip.metadb" || true
+
+  for f in \
+    geoip-private.srs geoip-cn.srs geoip-facebook.srs geoip-fastly.srs \
+    geoip-google.srs geoip-netflix.srs geoip-telegram.srs geoip-twitter.srs; do
+    curl -fsSL -o "$srss_dir/$f" \
+      "https://raw.githubusercontent.com/2dust/sing-box-rules/rule-set-geoip/$f" || true
+  done
+  for f in \
+    geosite-cn.srs geosite-gfw.srs geosite-google.srs geosite-greatfire.srs \
+    geosite-geolocation-cn.srs geosite-category-ads-all.srs geosite-private.srs; do
+    curl -fsSL -o "$srss_dir/$f" \
+      "https://raw.githubusercontent.com/2dust/sing-box-rules/rule-set-geosite/$f" || true
+  done
+
+  # Unify to bin
+  unify_geo_layout "$outroot"
+}
+
+# Prefer the prebuilt v2rayN core bundle; then unify geo layout
+download_v2rayn_bundle() {
+  local outroot="$1" rid="$2"
+  local url=""
+  if [[ "$rid" == "linux-riscv64" ]]; then
+    url="https://raw.githubusercontent.com/2dust/v2rayN-core-bin/refs/heads/master/v2rayN-linux-riscv64.zip"
+  fi
+  [[ -n "$url" ]] || { echo "[!] Bundle unsupported RID: $rid"; return 1; }
+  echo "[+] Try v2rayN bundle archive: $url"
+  local tmp zipname
+  tmp="$(mktemp -d)"; zipname="$tmp/v2rayn.zip"
+  curl -fL "$url" -o "$zipname" || { echo "[!] Bundle download failed"; return 1; }
+  unzip -q "$zipname" -d "$tmp" || { echo "[!] Bundle unzip failed"; return 1; }
+
+  if [[ -d "$tmp/bin" ]]; then
+    mkdir -p "$outroot/bin"
+    rsync -a "$tmp/bin/" "$outroot/bin/"
+  else
+    rsync -a "$tmp/" "$outroot/"
+  fi
+
+  rm -f "$outroot/v2rayn.zip" 2>/dev/null || true
+  find "$outroot" -type d -name "mihomo" -prune -exec rm -rf {} + 2>/dev/null || true
+
+  local nested_dir
+  nested_dir="$(find "$outroot" -maxdepth 1 -type d -name 'v2rayN-linux-*' | head -n1 || true)"
+  if [[ -n "$nested_dir" && -d "$nested_dir/bin" ]]; then
+    mkdir -p "$outroot/bin"
+    rsync -a "$nested_dir/bin/" "$outroot/bin/"
+    rm -rf "$nested_dir"
+  fi
+
+  # Unify to bin/
+  unify_geo_layout "$outroot"
+
+  echo "[+] Bundle extracted to $outroot"
+}
+
+# ===== Build results collection ========================================================
+BUILT_RPMS=()
+
+# ===== Build (single-arch) function ====================================================
+build_for_arch() {
+  # $1: target short arch: riscv64
+  local short="$1"
+  local rid rpm_target archdir
+  case "$short" in
+    riscv64) rid="linux-riscv64"; rpm_target="riscv64"; archdir="riscv64" ;;
+    *) echo "Unknown arch '$short' (use riscv64)"; return 1;;
+  esac
+
+  echo "[*] Building for target: $short  (RID=$rid, RPM --target $rpm_target)"
+
+  # .NET publish (self-contained) for this RID
+  dotnet clean "$PROJECT" -c Release -p:TargetFramework=net10.0
+  rm -rf "$(dirname "$PROJECT")/bin/Release/net10.0" || true
+
+  dotnet restore "$PROJECT" -r "$rid" -p:TargetFramework=net10.0
+  dotnet publish "$PROJECT" \
+    -c Release -r "$rid" \
+    -p:TargetFramework=net10.0 \
+    -p:PublishSingleFile=false \
+    -p:SelfContained=true
+
+  # Per-arch variables (scoped)
+  local RID_DIR="$rid"
+  local PUBDIR
+  PUBDIR="$(dirname "$PROJECT")/bin/Release/net10.0/${RID_DIR}/publish"
+  [[ -d "$PUBDIR" ]] || { echo "Publish directory not found: $PUBDIR"; return 1; }
+
+  # Per-arch working area
+  local PKGROOT="v2rayN-publish"
+  local WORKDIR
+  WORKDIR="$(mktemp -d)"
+  trap '[[ -n "${WORKDIR:-}" ]] && rm -rf "$WORKDIR"' RETURN
+
+  # rpmbuild topdir selection
+  local TOPDIR SPECDIR SOURCEDIR PROJECT_DIR
+  rpmdev-setuptree
+  TOPDIR="${HOME}/rpmbuild"
+  SPECDIR="${TOPDIR}/SPECS"
+  SOURCEDIR="${TOPDIR}/SOURCES"
+
+  # Stage publish content
+  mkdir -p "$WORKDIR/$PKGROOT"
+  cp -a "$PUBDIR/." "$WORKDIR/$PKGROOT/"
+
+  copy_skiasharp_native_riscv64 "$WORKDIR/$PKGROOT" || echo "[!] SkiaSharp native copy failed (skipped)"
+  build_sqlite_native_riscv64 "$WORKDIR/$PKGROOT" || echo "[!] sqlite native build failed (skipped)"
+
+  # Required icon
+  local ICON_CANDIDATE
+  PROJECT_DIR="$(cd "$(dirname "$PROJECT")" && pwd)"
+  ICON_CANDIDATE="$PROJECT_DIR/v2rayN.png"
+  [[ -f "$ICON_CANDIDATE" ]] || { echo "Required icon not found: $ICON_CANDIDATE"; return 1; }
+  cp "$ICON_CANDIDATE" "$WORKDIR/$PKGROOT/v2rayn.png"
+
+  # Prepare bin structure
+  mkdir -p "$WORKDIR/$PKGROOT/bin/xray" "$WORKDIR/$PKGROOT/bin/sing_box"
+
+  # Bundle / cores per-arch
+  fetch_separate_cores_and_rules() {
+    local outroot="$1"
+
+    if [[ "$WITH_CORE" == "xray" || "$WITH_CORE" == "both" ]]; then
+      download_xray "$outroot/bin/xray" "$RID_DIR" || echo "[!] xray download failed (skipped)"
+    fi
+    if [[ "$WITH_CORE" == "sing-box" || "$WITH_CORE" == "both" ]]; then
+      download_singbox "$outroot/bin/sing_box" "$RID_DIR" || echo "[!] sing-box download failed (skipped)"
+    fi
+    download_geo_assets "$outroot" || echo "[!] Geo rules download failed (skipped)"
+  }
+
+  if [[ "$FORCE_NETCORE" -eq 0 ]]; then
+    if download_v2rayn_bundle "$WORKDIR/$PKGROOT" "$RID_DIR"; then
+      echo "[*] Using v2rayN bundle archive."
+    else
+      echo "[*] Bundle failed, fallback to separate core + rules."
+      fetch_separate_cores_and_rules "$WORKDIR/$PKGROOT"
+    fi
+  else
+    echo "[*] --netcore specified: use separate core + rules."
+    fetch_separate_cores_and_rules "$WORKDIR/$PKGROOT"
+  fi
+
+  # Tarball
+  mkdir -p "$SOURCEDIR"
+  tar -C "$WORKDIR" -czf "$SOURCEDIR/$PKGROOT.tar.gz" "$PKGROOT"
+
+  # SPEC
+  local SPECFILE="$SPECDIR/v2rayN.spec"
+  mkdir -p "$SPECDIR"
+  cat > "$SPECFILE" <<'SPEC'
+%global debug_package %{nil}
+%undefine _debuginfo_subpackages
+%undefine _debugsource_packages
+# Ignore outdated LTTng dependencies incorrectly reported by the .NET runtime (to avoid installation failures)
+%global __requires_exclude ^liblttng-ust\.so\..*$
+
+Name:           v2rayN
+Version:        __VERSION__
+Release:        1%{?dist}
+Summary:        v2rayN (Avalonia) GUI client for Linux (riscv64)
+License:        GPL-3.0-only
+URL:            https://github.com/2dust/v2rayN
+BugURL:         https://github.com/2dust/v2rayN/issues
+ExclusiveArch:  riscv64
+Source0:        __PKGROOT__.tar.gz
+
+# Runtime dependencies (Avalonia / X11 / Fonts / GL)
+Requires:       cairo, pango, openssl, mesa-libEGL, mesa-libGL
+Requires:       glibc >= 2.34
+Requires:       fontconfig >= 2.13.1
+Requires:       desktop-file-utils >= 0.26
+Requires:       xdg-utils >= 1.1.3
+Requires:       coreutils >= 8.32
+Requires:       bash >= 5.1
+Requires:       freetype >= 2.10
+
+%description
+v2rayN Linux for Red Hat Enterprise Linux
+Support vless / vmess / Trojan / http / socks / Anytls / Hysteria2 / Shadowsocks / tuic / WireGuard
+Support Red Hat Enterprise Linux / Fedora Linux / Rocky Linux / AlmaLinux / CentOS
+For more information, Please visit our website
+https://github.com/2dust/v2rayN
+
+%prep
+%setup -q -n __PKGROOT__
+
+%build
+# no build
+
+%install
+install -dm0755 %{buildroot}/opt/v2rayN
+cp -a * %{buildroot}/opt/v2rayN/
+
+# Normalize permissions
+find %{buildroot}/opt/v2rayN -type d -exec chmod 0755 {} +
+find %{buildroot}/opt/v2rayN -type f -exec chmod 0644 {} +
+[ -f %{buildroot}/opt/v2rayN/v2rayN ] && chmod 0755 %{buildroot}/opt/v2rayN/v2rayN || :
+[ -f %{buildroot}/opt/v2rayN/libSkiaSharp.so ] && chmod 0755 %{buildroot}/opt/v2rayN/libSkiaSharp.so || :
+[ -f %{buildroot}/opt/v2rayN/libHarfBuzzSharp.so ] && chmod 0755 %{buildroot}/opt/v2rayN/libHarfBuzzSharp.so || :
+[ -f %{buildroot}/opt/v2rayN/libe_sqlite3.so ] && chmod 0755 %{buildroot}/opt/v2rayN/libe_sqlite3.so || :
+
+# Launcher (prefer native ELF first, then DLL fallback)
+install -dm0755 %{buildroot}%{_bindir}
+install -m0755 /dev/stdin %{buildroot}%{_bindir}/v2rayn << 'EOF'
+#!/usr/bin/bash
+set -euo pipefail
+DIR="/opt/v2rayN"
+export LD_LIBRARY_PATH="$DIR:${LD_LIBRARY_PATH:-}"
+
+# Prefer native apphost
+if [[ -x "$DIR/v2rayN" ]]; then exec "$DIR/v2rayN" "$@"; fi
+
+# DLL fallback
+for dll in v2rayN.Desktop.dll v2rayN.dll; do
+  if [[ -f "$DIR/$dll" ]]; then exec /usr/bin/dotnet "$DIR/$dll" "$@"; fi
+done
+
+echo "v2rayN launcher: no executable found in $DIR" >&2
+ls -l "$DIR" >&2 || true
+exit 1
+EOF
+
+# Desktop file
+install -dm0755 %{buildroot}%{_datadir}/applications
+install -m0644 /dev/stdin %{buildroot}%{_datadir}/applications/v2rayn.desktop << 'EOF'
+[Desktop Entry]
+Type=Application
+Name=v2rayN
+Comment=v2rayN for Red Hat Enterprise Linux
+Exec=v2rayn
+Icon=v2rayn
+Terminal=false
+Categories=Network;
+EOF
+
+# Icon
+install -dm0755 %{buildroot}%{_datadir}/icons/hicolor/256x256/apps
+install -m0644 %{_builddir}/__PKGROOT__/v2rayn.png %{buildroot}%{_datadir}/icons/hicolor/256x256/apps/v2rayn.png
+
+%post
+/usr/bin/update-desktop-database %{_datadir}/applications >/dev/null 2>&1 || true
+/usr/bin/gtk-update-icon-cache -f %{_datadir}/icons/hicolor >/dev/null 2>&1 || true
+
+%postun
+/usr/bin/update-desktop-database %{_datadir}/applications >/dev/null 2>&1 || true
+/usr/bin/gtk-update-icon-cache -f %{_datadir}/icons/hicolor >/dev/null 2>&1 || true
+
+%files
+%{_bindir}/v2rayn
+/opt/v2rayN
+%{_datadir}/applications/v2rayn.desktop
+%{_datadir}/icons/hicolor/256x256/apps/v2rayn.png
+SPEC
+
+  # Replace placeholders
+  sed -i "s/__VERSION__/${VERSION}/g" "$SPECFILE"
+  sed -i "s/__PKGROOT__/${PKGROOT}/g" "$SPECFILE"
+
+  # Build RPM for this arch
+  rpmbuild -ba "$SPECFILE" --target "$rpm_target"
+
+  echo "Build done for $short. RPM at:"
+  local f
+  for f in "${TOPDIR}/RPMS/${archdir}/v2rayN-${VERSION}-1"*.rpm; do
+    [[ -e "$f" ]] || continue
+    echo "  $f"
+    BUILT_RPMS+=("$f")
+  done
+}
+
+# ===== Arch selection and build orchestration =========================================
+targets=(riscv64)
+
+for arch in "${targets[@]}"; do
+  build_for_arch "$arch"
+done
+
+echo ""
+echo "================ Build Summary ================"
+if [[ "${#BUILT_RPMS[@]}" -gt 0 ]]; then
+  for rp in "${BUILT_RPMS[@]}"; do
+    echo "$rp"
+  done
+else
+  echo "No RPMs detected in summary (check build logs above)."
+fi
+echo "=============================================="

--- a/v2rayN/ServiceLib/Manager/CoreInfoManager.cs
+++ b/v2rayN/ServiceLib/Manager/CoreInfoManager.cs
@@ -68,6 +68,7 @@ public sealed class CoreInfoManager
                     DownloadUrlWinArm64 = urlN + "/download/{0}/v2rayN-windows-arm64.zip",
                     DownloadUrlLinux64 = urlN + "/download/{0}/v2rayN-linux-64.zip",
                     DownloadUrlLinuxArm64 = urlN + "/download/{0}/v2rayN-linux-arm64.zip",
+                    DownloadUrlLinuxRiscV64 = urlN + "/download/{0}/v2rayN-linux-riscv64.zip",
                     DownloadUrlOSX64 = urlN + "/download/{0}/v2rayN-macos-64.zip",
                     DownloadUrlOSXArm64 = urlN + "/download/{0}/v2rayN-macos-arm64.zip",
                 },
@@ -111,6 +112,7 @@ public sealed class CoreInfoManager
                     DownloadUrlWinArm64 = urlXray + "/download/{0}/Xray-windows-arm64-v8a.zip",
                     DownloadUrlLinux64 = urlXray + "/download/{0}/Xray-linux-64.zip",
                     DownloadUrlLinuxArm64 = urlXray + "/download/{0}/Xray-linux-arm64-v8a.zip",
+                    DownloadUrlLinuxRiscV64 = urlXray + "/download/{0}/Xray-linux-riscv64.zip",
                     DownloadUrlOSX64 = urlXray + "/download/{0}/Xray-macos-64.zip",
                     DownloadUrlOSXArm64 = urlXray + "/download/{0}/Xray-macos-arm64-v8a.zip",
                     Match = "Xray",
@@ -133,6 +135,7 @@ public sealed class CoreInfoManager
                     DownloadUrlWinArm64 = urlMihomo + "/download/{0}/mihomo-windows-arm64-{0}.zip",
                     DownloadUrlLinux64 = urlMihomo + "/download/{0}/mihomo-linux-amd64-v1-{0}.gz",
                     DownloadUrlLinuxArm64 = urlMihomo + "/download/{0}/mihomo-linux-arm64-{0}.gz",
+                    DownloadUrlLinuxRiscV64 = urlMihomo + "/download/{0}/mihomo-linux-riscv64-{0}.gz",
                     DownloadUrlOSX64 = urlMihomo + "/download/{0}/mihomo-darwin-amd64-v1-{0}.gz",
                     DownloadUrlOSXArm64 = urlMihomo + "/download/{0}/mihomo-darwin-arm64-{0}.gz",
                     Match = "Mihomo",
@@ -175,6 +178,7 @@ public sealed class CoreInfoManager
                     DownloadUrlWinArm64 = urlSingbox + "/download/{0}/sing-box-{1}-windows-arm64.zip",
                     DownloadUrlLinux64 = urlSingbox + "/download/{0}/sing-box-{1}-linux-amd64.tar.gz",
                     DownloadUrlLinuxArm64 = urlSingbox + "/download/{0}/sing-box-{1}-linux-arm64.tar.gz",
+                    DownloadUrlLinuxRiscV64 = urlSingbox + "/download/{0}/sing-box-{1}-linux-riscv64.tar.gz",
                     DownloadUrlOSX64 = urlSingbox + "/download/{0}/sing-box-{1}-darwin-amd64.tar.gz",
                     DownloadUrlOSXArm64 = urlSingbox + "/download/{0}/sing-box-{1}-darwin-arm64.tar.gz",
                     Match = "sing-box",
@@ -265,6 +269,7 @@ public sealed class CoreInfoManager
             names.Add("mihomo-linux-amd64-v1");
             names.Add("mihomo-linux-amd64");
             names.Add("mihomo-linux-arm64");
+            names.Add("mihomo-linux-riscv64");
         }
         else if (Utils.IsMacOS())
         {

--- a/v2rayN/ServiceLib/Models/CoreInfo.cs
+++ b/v2rayN/ServiceLib/Models/CoreInfo.cs
@@ -12,6 +12,7 @@ public class CoreInfo
     public string? DownloadUrlWinArm64 { get; set; }
     public string? DownloadUrlLinux64 { get; set; }
     public string? DownloadUrlLinuxArm64 { get; set; }
+    public string? DownloadUrlLinuxRiscV64 { get; set; }
     public string? DownloadUrlOSX64 { get; set; }
     public string? DownloadUrlOSXArm64 { get; set; }
     public string? Match { get; set; }

--- a/v2rayN/ServiceLib/Resx/ResUI.fr.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fr.resx
@@ -1316,6 +1316,15 @@
   </data>
   <data name="TbSettingsLinuxSudoPasswordTip" xml:space="preserve">
     <value>Le mot de passe sera vérifié en ligne de commande. En cas d’échec ou de dysfonctionnement, redémarrez l’application. Il n’est pas stocké et doit être saisi à chaque redémarrage.</value>
+    </data>
+  <data name="TbSettingsSendThrough" xml:space="preserve">
+    <value>Adresse sortante locale (SendThrough)</value>
+  </data>
+  <data name="TbSettingsSendThroughTip" xml:space="preserve">
+    <value>Pour environnement multi-interfaces, veuillez saisir l’adresse IPv4 de la machine locale.</value>
+  </data>
+  <data name="FillCorrectSendThroughIPv4" xml:space="preserve">
+    <value>Veuillez saisir l’adresse IPv4 correcte de SendThrough.</value>
   </data>
   <data name="TransportHeaderTypeTip5" xml:space="preserve">
     <value>*Mode XHTTP</value>
@@ -1621,28 +1630,28 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
     <value>Finalmask</value>
   </data>
   <data name="MsgRoutingRuleOutboundNodeWarning" xml:space="preserve">
-    <value>Routing rule {0} outbound node {1} warning: {2}</value>
+    <value>Règle de routage {0} nœud sortant {1} avertissement: {2}</value>
   </data>
   <data name="MsgRoutingRuleOutboundNodeError" xml:space="preserve">
-    <value>Routing rule {0} outbound node {1} error: {2}. Fallback to proxy node only.</value>
+    <value>Règle {0} nœud VPN sortant {1} erreur : {2}. Repli nœud proxy uniquement.</value>
   </data>
   <data name="MsgGroupCycleDependency" xml:space="preserve">
-    <value>Group {0} has a cycle dependency on child node {1}. Skipping this node.</value>
+    <value>Le groupe {0} a une dépendance cyclique avec le nœud enfant {1}. Nœud ignoré.</value>
   </data>
   <data name="MsgGroupChildNodeWarning" xml:space="preserve">
-    <value>Group {0} child node {1} warning: {2}</value>
+    <value>Groupe {0} nœud enfant {1} avertissement : {2}</value>
   </data>
   <data name="MsgGroupChildNodeError" xml:space="preserve">
-    <value>Group {0} child node {1} error: {2}. Skipping this node.</value>
+    <value>Groupe {0} nœud enfant {1} erreur : {2}. Nœud ignoré.</value>
   </data>
   <data name="MsgGroupChildGroupNodeWarning" xml:space="preserve">
-    <value>Group {0} child group node {1} warning: {2}</value>
+    <value>Groupe {0} nœud enfant groupe {1} avertissement: {2}</value>
   </data>
   <data name="MsgGroupChildGroupNodeError" xml:space="preserve">
-    <value>Group {0} child group node {1} error: {2}. Skipping this node.</value>
+    <value>Groupe {0} nœud groupe enfant {1} erreur: {2}. Nœud ignoré.</value>
   </data>
   <data name="MsgGroupNoValidChildNode" xml:space="preserve">
-    <value>Group {0} has no valid child node.</value>
+    <value>Groupe {0} n’a aucun nœud enfant valide.</value>
   </data>
   <data name="MsgRoutingRuleEmptyOutboundTag" xml:space="preserve">
     <value>Routing rule {0} has an empty outbound tag. Fallback to proxy node only.</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.fr.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fr.resx
@@ -1654,10 +1654,10 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
     <value>Groupe {0} n’a aucun nœud enfant valide.</value>
   </data>
   <data name="MsgRoutingRuleEmptyOutboundTag" xml:space="preserve">
-    <value>Routing rule {0} has an empty outbound tag. Fallback to proxy node only.</value>
+    <value>Règle de routage {0} tag sortant vide. Replié sur le nœud proxy uniquement.</value>
   </data>
   <data name="MsgRoutingRuleOutboundNodeNotFound" xml:space="preserve">
-    <value>Routing rule {0} outbound node {1} not found. Fallback to proxy node only.</value>
+    <value>Règle de routage {0} nœud sortant {1} introuvable. Repli sur le seul nœud proxy.</value>
   </data>
   <data name="MsgSubscriptionPrevProfileNotFound" xml:space="preserve">
     <value>Subscription previous proxy {0} not found. Skipping.</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.fr.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fr.resx
@@ -1660,19 +1660,19 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
     <value>Règle de routage {0} nœud sortant {1} introuvable. Repli sur le seul nœud proxy.</value>
   </data>
   <data name="MsgSubscriptionPrevProfileNotFound" xml:space="preserve">
-    <value>Subscription previous proxy {0} not found. Skipping.</value>
+    <value>Nœud proxy précédent de l’abonnement {0} introuvable. Ignoré.</value>
   </data>
   <data name="MsgSubscriptionNextProfileNotFound" xml:space="preserve">
-    <value>Subscription next proxy {0} not found. Skipping.</value>
+    <value>Nœud proxy suivant de l’abonnement {0} introuvable. Ignoré.</value>
   </data>
   <data name="menuGenGroupServer" xml:space="preserve">
-    <value>Generate Policy Group</value>
+    <value>Générer groupe de stratégie</value>
   </data>
   <data name="menuAllServers" xml:space="preserve">
-    <value>All configurations</value>
+    <value>Toutes configurations</value>
   </data>
   <data name="menuGenRegionGroup" xml:space="preserve">
-    <value>Group by Region</value>
+    <value>Grouper par région</value>
   </data>
   <data name="menuEditCopy" xml:space="preserve">
     <value>Copier</value>
@@ -1681,7 +1681,7 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
     <value>Tout sélect</value>
   </data>
   <data name="menuEditPaste" xml:space="preserve">
-    <value>Paste</value>
+    <value>Coller</value>
   </data>
   <data name="menuEditFormat" xml:space="preserve">
     <value>Format</value>
@@ -1696,15 +1696,15 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
     <value>Insecure Concurrency</value>
   </data>
   <data name="TbUsername" xml:space="preserve">
-    <value>Username</value>
+    <value>Nom d’utilisateur</value>
   </data>
   <data name="TbIcmpRoutingPolicy" xml:space="preserve">
-    <value>ICMP routing policy</value>
+    <value>Politique de routage ICMP</value>
   </data>
   <data name="TbLegacyProtect" xml:space="preserve">
-    <value>Legacy TUN Protect</value>
+    <value>Protection TUN héritée</value>
   </data>
   <data name="TbSettingsSendThroughTip" xml:space="preserve">
-    <value>For multi-interface environments, enter the local machine's IPv4 address</value>
+    <value>Pour environnements multi-interfaces, entrez l’adresse IPv4 de la machine locale.</value>
   </data>
 </root>

--- a/v2rayN/ServiceLib/Sample/proxy_set_linux_sh
+++ b/v2rayN/ServiceLib/Sample/proxy_set_linux_sh
@@ -1,5 +1,24 @@
 #!/bin/bash
 
+trim() {
+    local -n ref=$1
+    ref="${ref#"${ref%%[![:space:]]*}"}"
+    ref="${ref%"${ref##*[![:space:]]}"}"
+}
+
+build_gsettings_array() {
+    [[ -z "$1" ]] && echo "[]" && return
+    local host joined hosts=()
+    IFS=',' read -ra parts <<< "$1"
+    for host in "${parts[@]}"; do
+        trim host
+        [[ -n "$host" ]] && hosts+=("$host")
+    done
+    [[ ${#hosts[@]} -eq 0 ]] && echo "[]" && return
+    printf -v joined "'%s'," "${hosts[@]}"
+    echo "[${joined%,}]"
+}
+
 # Function to set proxy for GNOME
 set_gnome_proxy() {
     local MODE=$1
@@ -21,7 +40,7 @@ set_gnome_proxy() {
         done
 
         # Set ignored hosts
-        gsettings set org.gnome.system.proxy ignore-hosts "['$IGNORE_HOSTS']"
+        gsettings set org.gnome.system.proxy ignore-hosts "$(build_gsettings_array "$IGNORE_HOSTS")"
 
         echo "GNOME: Manual proxy settings applied."
         echo "Proxy IP: $PROXY_IP"

--- a/v2rayN/ServiceLib/Services/UpdateService.cs
+++ b/v2rayN/ServiceLib/Services/UpdateService.cs
@@ -299,15 +299,22 @@ public class UpdateService(Config config, Func<bool, string, Task> updateFunc)
 
             return url;
         }
+
         else if (Utils.IsLinux())
         {
-            return RuntimeInformation.ProcessArchitecture switch
+            var arch = RuntimeInformation.ProcessArchitecture;
+            if (arch.ToString().Equals("RiscV64", StringComparison.OrdinalIgnoreCase))
+            {
+                return coreInfo?.DownloadUrlLinuxRiscV64;
+            }
+            return arch switch
             {
                 Architecture.Arm64 => coreInfo?.DownloadUrlLinuxArm64,
                 Architecture.X64 => coreInfo?.DownloadUrlLinux64,
                 _ => null,
             };
         }
+        
         else if (Utils.IsMacOS())
         {
             return RuntimeInformation.ProcessArchitecture switch


### PR DESCRIPTION
此PR旨在添加 RiscV64 RPM 软件包，修复bug

## 添加 RiscV64 RPM 软件包

### 合并前注意

由于 RiscV64 Runner 依赖 rise-risc-v 项目，需要在 GitHub 账号中安装这个应用并给对应仓库授权
### RISE RISC-V Runners (Personal)
GitHub App 
RISE（RISC-V Software Ecosystem）Linux Foundation
[点击安装 RISE RISC-V Runners (Personal)](https://github.com/apps/rise-risc-v-runners-personal)

相关信息
https://riseproject.dev/2026/03/24/announcing-the-rise-risc-v-runners-free-native-risc-v-ci-on-github/

目前 rpm 已在 Fedora Linux 43 和 Rocky Linux 10 验证

## 修复Bug

修复设置代理脚本在Gnome上的格式问题

相关信息
https://github.com/2dust/v2rayN/issues/9105