### PR TITLE
fix: persist selected subscription group across restarts

### DIFF
--- a/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
@@ -333,6 +333,7 @@ public class ProfilesViewModel : MyReactiveObject
             return;
         }
         _config.SubIndexId = SelectedSub?.Id;
+        await ConfigHandler.SaveConfig(_config);
 
         await RefreshServers();
 
@@ -393,7 +394,7 @@ public class ProfilesViewModel : MyReactiveObject
         }
         SelectedSub = (_config.SubIndexId.IsNotEmpty()
                         ? SubItems.FirstOrDefault(t => t.Id == _config.SubIndexId)
-                        : null) ?? SubItems.LastOrDefault();
+                        : null) ?? SubItems.FirstOrDefault();
     }
 
     private async Task<List<ProfileItemModel>?> GetProfileItemsEx(string subid, string filter)


### PR DESCRIPTION
切换订阅分组时，SubIndexId 仅在内存中更新，并没有保存到配置文件。因此在重启时，回退（fallback）逻辑使用了 LastOrDefault()，导致默认选中了最后一个订阅，而不是之前选中的分组。

修改内容：

切换分组时添加了 SaveConfig 调用以保存配置

将回退逻辑修改为了 FirstOrDefault，以便正确恢复“全部 (All)”分组

---

### Before
https://github.com/user-attachments/assets/6e2ca267-bccc-44fa-8b48-7e9e31287726

### After
https://github.com/user-attachments/assets/d5c32473-9431-4efc-894f-999660769b73