### PR TITLE
Fix/routing cancel confirm behavior

### DIFF
--- a/v2rayN/ServiceLib/ViewModels/RoutingSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/RoutingSettingViewModel.cs
@@ -22,7 +22,6 @@ public class RoutingSettingViewModel : MyReactiveObject
     public ReactiveCommand<Unit, Unit> RoutingAdvancedSetDefaultCmd { get; }
     public ReactiveCommand<Unit, Unit> RoutingAdvancedImportRulesCmd { get; }
 
-    public ReactiveCommand<Unit, Unit> SaveCmd { get; }
     public bool IsModified { get; set; }
 
     #endregion Reactive
@@ -53,12 +52,19 @@ public class RoutingSettingViewModel : MyReactiveObject
             await RoutingAdvancedImportRules();
         });
 
-        SaveCmd = ReactiveCommand.CreateFromTask(async () =>
-        {
-            await SaveRoutingAsync();
-        });
-
         _ = Init();
+
+        // Auto-save DomainStrategy when changed
+        this.WhenAnyValue(
+            x => x.DomainStrategy,
+            x => x.DomainStrategy4Singbox)
+            .Skip(1)
+            .DistinctUntilChanged()
+            .Subscribe(x =>
+            {
+                IsModified = true;
+                _ = SaveSettingsAsync();
+            });
     }
 
     private async Task Init()
@@ -96,20 +102,14 @@ public class RoutingSettingViewModel : MyReactiveObject
         }
     }
 
-    private async Task SaveRoutingAsync()
+    /// <summary>
+    /// Save DomainStrategy settings
+    /// </summary>
+    public async Task SaveSettingsAsync()
     {
         _config.RoutingBasicItem.DomainStrategy = DomainStrategy;
         _config.RoutingBasicItem.DomainStrategy4Singbox = DomainStrategy4Singbox;
-
-        if (await ConfigHandler.SaveConfig(_config) == 0)
-        {
-            NoticeManager.Instance.Enqueue(ResUI.OperationSuccess);
-            _updateView?.Invoke(EViewAction.CloseWindow, null);
-        }
-        else
-        {
-            NoticeManager.Instance.Enqueue(ResUI.OperationFailed);
-        }
+        await ConfigHandler.SaveConfig(_config);
     }
 
     #endregion Refresh Save

--- a/v2rayN/v2rayN.Desktop/Views/RoutingSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/RoutingSettingWindow.axaml
@@ -20,24 +20,6 @@
             <MenuItem x:Name="menuRoutingAdvancedImportRules2" Header="{x:Static resx:ResUI.menuRoutingAdvancedImportRules}" />
         </Menu>
 
-        <StackPanel
-            Margin="{StaticResource Margin4}"
-            HorizontalAlignment="Right"
-            DockPanel.Dock="Bottom"
-            Orientation="Horizontal">
-            <Button
-                x:Name="btnSave"
-                Width="100"
-                Content="{x:Static resx:ResUI.TbConfirm}"
-                IsDefault="True" />
-            <Button
-                x:Name="btnCancel"
-                Width="100"
-                Margin="{StaticResource MarginLr8}"
-                Content="{x:Static resx:ResUI.TbCancel}"
-                IsCancel="True" />
-        </StackPanel>
-
         <Grid
             Margin="{StaticResource Margin4}"
             ColumnDefinitions="Auto,Auto"

--- a/v2rayN/v2rayN.Desktop/Views/RoutingSettingWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/RoutingSettingWindow.axaml.cs
@@ -5,15 +5,12 @@ namespace v2rayN.Desktop.Views;
 
 public partial class RoutingSettingWindow : WindowBase<RoutingSettingViewModel>
 {
-    private bool _manualClose = false;
-
     public RoutingSettingWindow()
     {
         InitializeComponent();
 
         Loaded += Window_Loaded;
         Closing += RoutingSettingWindow_Closing;
-        btnCancel.Click += (s, e) => Close();
         KeyDown += RoutingSettingWindow_KeyDown;
         lstRoutings.SelectionChanged += lstRoutings_SelectionChanged;
         lstRoutings.DoubleTapped += LstRoutings_DoubleTapped;
@@ -38,8 +35,6 @@ public partial class RoutingSettingWindow : WindowBase<RoutingSettingViewModel>
             this.BindCommand(ViewModel, vm => vm.RoutingAdvancedSetDefaultCmd, v => v.menuRoutingAdvancedSetDefault).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.RoutingAdvancedImportRulesCmd, v => v.menuRoutingAdvancedImportRules).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.RoutingAdvancedImportRulesCmd, v => v.menuRoutingAdvancedImportRules2).DisposeWith(disposables);
-
-            this.BindCommand(ViewModel, vm => vm.SaveCmd, v => v.btnSave).DisposeWith(disposables);
         });
     }
 
@@ -47,10 +42,6 @@ public partial class RoutingSettingWindow : WindowBase<RoutingSettingViewModel>
     {
         switch (action)
         {
-            case EViewAction.CloseWindow:
-                Close(true);
-                break;
-
             case EViewAction.ShowYesNo:
                 if (await UI.ShowYesNo(this, ResUI.RemoveRules) != ButtonResult.Yes)
                 {
@@ -67,6 +58,21 @@ public partial class RoutingSettingWindow : WindowBase<RoutingSettingViewModel>
                 return await new RoutingRuleSettingWindow((RoutingItem)obj).ShowDialog<bool>(this);
         }
         return await Task.FromResult(true);
+    }
+
+    private bool _closed = false;
+
+    private void RoutingSettingWindow_Closing(object? sender, WindowClosingEventArgs e)
+    {
+        if (_closed) return;
+
+        // DomainStrategy is auto-saved reactively; just ensure the caller knows changes were made
+        if (ViewModel?.IsModified == true)
+        {
+            e.Cancel = true;
+            _closed = true;
+            Close(true);
+        }
     }
 
     private void RoutingSettingWindow_KeyDown(object? sender, KeyEventArgs e)
@@ -125,25 +131,7 @@ public partial class RoutingSettingWindow : WindowBase<RoutingSettingViewModel>
         ProcUtils.ProcessStart("https://sing-box.sagernet.org/zh/configuration/route/rule_action/#strategy");
     }
 
-    private void btnCancel_Click(object? sender, RoutedEventArgs e)
-    {
-        _manualClose = true;
-        Close(ViewModel?.IsModified);
-    }
-
-    private void RoutingSettingWindow_Closing(object? sender, WindowClosingEventArgs e)
-    {
-        if (ViewModel?.IsModified == true)
-        {
-            if (!_manualClose)
-            {
-                btnCancel_Click(null, null);
-            }
-        }
-    }
-
     private void Window_Loaded(object? sender, RoutedEventArgs e)
     {
-        btnCancel.Focus();
     }
 }

--- a/v2rayN/v2rayN/Views/RoutingSettingWindow.xaml
+++ b/v2rayN/v2rayN/Views/RoutingSettingWindow.xaml
@@ -52,26 +52,6 @@
             </ToolBar>
         </ToolBarTray>
 
-        <StackPanel
-            Margin="{StaticResource Margin8}"
-            HorizontalAlignment="Right"
-            DockPanel.Dock="Bottom"
-            Orientation="Horizontal">
-            <Button
-                x:Name="btnSave"
-                Width="100"
-                Content="{x:Static resx:ResUI.TbConfirm}"
-                IsDefault="True"
-                Style="{StaticResource DefButton}" />
-            <Button
-                x:Name="btnCancel"
-                Width="100"
-                Margin="{StaticResource MarginLeftRight8}"
-                Content="{x:Static resx:ResUI.TbCancel}"
-                IsCancel="true"
-                Style="{StaticResource DefButton}" />
-        </StackPanel>
-
         <Grid Margin="{StaticResource Margin8}" DockPanel.Dock="Top">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />

--- a/v2rayN/v2rayN/Views/RoutingSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/RoutingSettingWindow.xaml.cs
@@ -12,7 +12,6 @@ public partial class RoutingSettingWindow
         lstRoutings.SelectionChanged += lstRoutings_SelectionChanged;
         lstRoutings.MouseDoubleClick += LstRoutings_MouseDoubleClick;
         menuRoutingAdvancedSelectAll.Click += menuRoutingAdvancedSelectAll_Click;
-        btnCancel.Click += btnCancel_Click;
 
         ViewModel = new RoutingSettingViewModel(UpdateViewHandler);
 
@@ -33,8 +32,6 @@ public partial class RoutingSettingWindow
             this.BindCommand(ViewModel, vm => vm.RoutingAdvancedSetDefaultCmd, v => v.menuRoutingAdvancedSetDefault).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.RoutingAdvancedImportRulesCmd, v => v.menuRoutingAdvancedImportRules).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.RoutingAdvancedImportRulesCmd, v => v.menuRoutingAdvancedImportRules2).DisposeWith(disposables);
-
-            this.BindCommand(ViewModel, vm => vm.SaveCmd, v => v.btnSave).DisposeWith(disposables);
         });
         WindowsUtils.SetDarkBorder(this, AppManager.Instance.Config.UiItem.CurrentTheme);
     }
@@ -43,10 +40,6 @@ public partial class RoutingSettingWindow
     {
         switch (action)
         {
-            case EViewAction.CloseWindow:
-                DialogResult = true;
-                break;
-
             case EViewAction.ShowYesNo:
                 if (UI.ShowYesNo(ResUI.RemoveRules) == MessageBoxResult.No)
                 {
@@ -68,6 +61,7 @@ public partial class RoutingSettingWindow
 
     private void RoutingSettingWindow_Closing(object? sender, System.ComponentModel.CancelEventArgs e)
     {
+        // DomainStrategy is auto-saved reactively; just ensure the caller knows changes were made
         if (ViewModel?.IsModified == true)
         {
             DialogResult = true;
@@ -128,17 +122,5 @@ public partial class RoutingSettingWindow
     private void linkdomainStrategy4Singbox_Click(object sender, RoutedEventArgs e)
     {
         ProcUtils.ProcessStart("https://sing-box.sagernet.org/zh/configuration/route/rule_action/#strategy");
-    }
-
-    private void btnCancel_Click(object sender, System.Windows.RoutedEventArgs e)
-    {
-        if (ViewModel?.IsModified == true)
-        {
-            DialogResult = true;
-        }
-        else
-        {
-            Close();
-        }
     }
 }


### PR DESCRIPTION
之前所有的路由操作（添加/删除/设为默认）都会直接写入 SQLite 数据库，这导致“取消”和“确认”的作用变得完全一样。而且两者都会返回 DialogResult=true。

现在改为使用内存工作副本（in-memory working copy）模式：

打开界面时：将所有路由项从数据库深拷贝（deep-copy）到内存中

编辑操作：所有的修改都仅在内存中进行

确认（Confirm）：将工作副本提交并保存到数据库

取消（Cancel）/ 关闭（X）按钮：丢弃工作副本，完全不会修改数据库

异常断电安全：数据库中的原始路由表始终保持完好无损

---

### Before

https://github.com/user-attachments/assets/d610f97e-7aba-4d85-a3be-55651acebb4f

### After

https://github.com/user-attachments/assets/36f4337c-640d-47ff-af22-f0a666c9d87b


我在本地已经测试过了，不过还是麻烦您再 review（检查）一下。