### PR TITLE
CI: Explicitly define GitHub token permissions in config

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -7,6 +7,9 @@ on:
         required: false
         type: string
 
+permissions: 
+  actions: write
+
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub has updated its behavior: new forks no longer inherit the original repository's GitHub token permissions.  To ensure consistent access, this change explicitly defines the required permissions in the configuration file.