### PR TITLE
CI: Sleep 0-2s before upload release for race condition between matrix jobs

### DIFF
--- a/.github/workflows/build-osx.yml
+++ b/.github/workflows/build-osx.yml
@@ -61,6 +61,9 @@ jobs:
 
     - name: Package dmg
       run: ./package-osx.sh macos-$Arch v2rayN-macos-$Arch ${{ inputs.release_tag }}
+
+    - name: Sleep for race condition between matrix jobs
+      run: sleep $(awk 'BEGIN { srand(); printf "%.3f", rand()*2 }')
     
     - name: Upload dmg to release
       uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/package-zip.yml
+++ b/.github/workflows/package-zip.yml
@@ -55,6 +55,9 @@ jobs:
       if: inputs.target == 'windows-desktop'
       run: mv "v2rayN-$Target-$Arch.zip" "v2rayN-$Target-$Arch-desktop.zip"
     
+    - name: Sleep for race condition between matrix jobs
+      run: sleep $(awk 'BEGIN { srand(); printf "%.3f", rand()*2 }')
+
     - name: Upload zip archive to release
       uses: svenstaro/upload-release-action@v2
       with:


### PR DESCRIPTION
fix race condition between matrix jobs.

https://github.com/2dust/v2rayN/actions/runs/24494177476/job/71585408136
> Run svenstaro/upload-release-action@v2
> Getting release by tag 7.20.4.
> Release for tag 7.20.4 doesn't exist - creating it
> Tried to create a release for tag 7.20.4, but it already exists - probably due to race condition between matrix jobs.
>
> Getting release by tag 7.20.4.
> Error: Not Found - https://docs.github.com/rest/releases/releases#get-a-release-by-tag-name

Added a randomized sleep (0–2 seconds) before running the release upload step.
Dispatched 5 times successfully without errors.
Verification workflow:
https://github.com/bonjour-py/v2rayN/actions