### PR TITLE
i18n(ru): translate new strings and fix terminology casing

### DIFF
--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -673,7 +673,7 @@
     <value>Ядро: базовые настройки</value>
   </data>
   <data name="TbCustomDnsRay" xml:space="preserve">
-    <value>Пользовательский DNS для V2ray</value>
+    <value>Пользовательский DNS для v2ray</value>
   </data>
   <data name="TbSettingsCoreKcp" xml:space="preserve">
     <value>Ядро: настройки KCP</value>
@@ -931,7 +931,7 @@
     <value>User-Agent</value>
   </data>
   <data name="TbSettingsDefUserAgentTips" xml:space="preserve">
-    <value>This parameter is valid only for raw/http, ws, gRPC and xhttp</value>
+    <value>Параметр действует только для raw/http, ws, gRPC и xhttp</value>
   </data>
   <data name="TbSettingsCurrentFontFamily" xml:space="preserve">
     <value>Шрифт (требуется перезапуск)</value>
@@ -1318,7 +1318,7 @@
     <value>XHTTP-режим</value>
   </data>
   <data name="TransportExtraTip" xml:space="preserve">
-    <value>Raw JSON, format: { XHTTP Object }</value>
+    <value>Сырой JSON, формат: { XHTTP Object }</value>
   </data>
   <data name="TbSettingsHide2TrayWhenClose" xml:space="preserve">
     <value>Сворачивать в трей при закрытии окна</value>
@@ -1336,7 +1336,7 @@
     <value>Включить второй смешанный порт</value>
   </data>
   <data name="TbRoutingInboundTagTips" xml:space="preserve">
-    <value>socks: локальный порт, socks2: второй локальный порт, socks3: LAN порт</value>
+    <value>socks: локальный порт, socks2: второй локальный порт, socks3: LAN-порт</value>
   </data>
   <data name="TbSettingsTheme" xml:space="preserve">
     <value>Тема</value>
@@ -1378,7 +1378,7 @@
     <value>Mldsa65Verify</value>
   </data>
   <data name="menuAddAnytlsServer" xml:space="preserve">
-    <value>Добавить сервер [Anytls]</value>
+    <value>Добавить сервер [AnyTLS]</value>
   </data>
   <data name="TbRemoteDNS" xml:space="preserve">
     <value>Удалённый DNS</value>
@@ -1693,27 +1693,33 @@
     <value>Устаревшая защита TUN (Legacy Protect)</value>
   </data>
   <data name="TbSettingsSendThroughTip" xml:space="preserve">
-    <value>For multi-interface environments, enter the local machine's IPv4 address</value>
+    <value>Для среды с несколькими сетевыми интерфейсами укажите IPv4-адрес локального компьютера</value>
   </data>
   <data name="TbCamouflageDomain" xml:space="preserve">
     <value>Камуфляжный домен</value>
   </data>
   <data name="TbHost" xml:space="preserve">
-    <value>Host</value>
+    <value>Хост</value>
   </data>
   <data name="TransportExtra" xml:space="preserve">
-    <value>XHTTP Extra</value>
+    <value>Дополнительные параметры XHTTP (Extra)</value>
   </data>
   <data name="TbAllowInsecureCertFetch" xml:space="preserve">
-    <value>Allow insecure cert fetch (self-signed)</value>
+    <value>Разрешить небезопасную загрузку сертификата (самоподписанного)</value>
   </data>
   <data name="TbAllowInsecureCertFetchTips" xml:space="preserve">
-    <value>Only for fetching self-signed certificates. This may expose you to MITM risks.</value>
+    <value>Только для загрузки самоподписанных сертификатов. Это может подвергнуть вас риску атаки «человек посередине» (MITM).</value>
   </data>
   <data name="menuUdpTestServer" xml:space="preserve">
-    <value>Test Configurations UDP Delay</value>
+    <value>Тест UDP-задержки конфигураций</value>
   </data>
   <data name="TbSettingsUdpTestUrl" xml:space="preserve">
-    <value>UDP Test Url</value>
+    <value>URL для UDP-теста</value>
+  </data>
+  <data name="FillCorrectSendThroughIPv4" xml:space="preserve">
+    <value>Укажите корректный IPv4-адрес для SendThrough.</value>
+  </data>
+  <data name="TbSettingsSendThrough" xml:space="preserve">
+    <value>Локальный исходящий адрес (SendThrough)</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary

Translate **11 new strings** introduced in recent upstream updates and fix casing of several technical terms in `ResUI.ru.resx`.

## Changes

**File changed:** `v2rayN/ServiceLib/Resx/ResUI.ru.resx`

### New translations (11 strings)

**9 strings updated from English:**
- `TbAllowInsecureCertFetch` — "Allow insecure cert fetch (self-signed)" checkbox
- `TbAllowInsecureCertFetchTips` — MITM risk warning tooltip
- `TbHost` — host field label
- `TbSettingsDefUserAgentTips` — updated transport list (raw/http, ws, gRPC, xhttp)
- `TbSettingsSendThroughTip` — multi-interface IPv4 hint
- `TbSettingsUdpTestUrl` — UDP test URL setting
- `TransportExtra`, `TransportExtraTip` — XHTTP Extra raw JSON
- `menuUdpTestServer` — UDP delay test menu item

**2 strings added (were missing in ru.resx):**
- `FillCorrectSendThroughIPv4` — invalid IPv4 validation message
- `TbSettingsSendThrough` — "Local outbound address (SendThrough)" label

### Terminology casing fixes

| Before | After | Reason |
|--------|-------|--------|
| `V2ray` | `v2ray` | Core name is lowercase by convention |
| `[Anytls]` | `[AnyTLS]` | Canonical protocol spelling |
| `LAN порт` | `LAN-порт` | Hyphen between abbreviation and noun per Russian grammar |

## Translation approach

- All translations use canonical casing for:
  - **Protocols:** VMess, VLESS, Shadowsocks, Trojan, WireGuard, Hysteria, Hysteria2, TUIC, AnyTLS, NaiveProxy
  - **Cores:** Xray, sing-box, mihomo, v2ray
  - **Abbreviations:** TLS, DNS, UUID, HTTP, HTTPS, IPv4, IPv6, MTU, TUN, PAC, SOCKS, gRPC, XHTTP, ECH, SVCB, ICMP
- Transport identifiers from config (`ws`, `http upgrade`, `xhttp`, `socks`, `socks2`, `socks3`) intentionally kept in original casing to match config keys
- All `{0}`, `{1}`, `{2}` format placeholders preserved

## Testing

- XML validity verified — parsed successfully with no errors
- All 534 `<data>` elements present
- Zero untranslated strings, zero missing strings vs `ResUI.resx`
- Format string placeholders preserved correctly
