### PR TITLE
Remove NoWarn and fix .NET 10 build warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5.2.0
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Build v2rayN
       working-directory: ./v2rayN

--- a/package-debian.sh
+++ b/package-debian.sh
@@ -88,10 +88,10 @@ if command -v apt-get >/dev/null 2>&1; then
       libc6:arm64 libgcc-s1:arm64 libstdc++6:arm64 zlib1g:arm64 libfontconfig1:arm64
   fi
 
-  # Install .NET SDK 8 via official script
+  # Install .NET SDK 10 via official script
   wget -q https://dot.net/v1/dotnet-install.sh
   chmod +x dotnet-install.sh
-  ./dotnet-install.sh --channel 8.0 --install-dir "$HOME/.dotnet"
+  ./dotnet-install.sh --channel 10.0 --install-dir "$HOME/.dotnet"
 
   export PATH="$HOME/.dotnet:$PATH"
   export DOTNET_ROOT="$HOME/.dotnet"
@@ -101,7 +101,7 @@ fi
 
 if [[ "$install_ok" -ne 1 ]]; then
   echo "Could not auto-install dependencies for '$ID'. Make sure these are available:"
-  echo "dotnet-sdk 8.x, curl, unzip, tar, rsync, git, dpkg-deb, desktop-file-utils, xdg-utils"
+  echo "dotnet-sdk 10.x, curl, unzip, tar, rsync, git, dpkg-deb, desktop-file-utils, xdg-utils"
   exit 1
 fi
 
@@ -389,7 +389,7 @@ build_for_arch() {
   echo "[*] Building for target: $short  (RID=$rid, DEB arch=$deb_arch)"
 
   dotnet clean "$PROJECT" -c Release
-  rm -rf "$(dirname "$PROJECT")/bin/Release/net8.0" || true
+  rm -rf "$(dirname "$PROJECT")/bin/Release/net10.0" || true
 
   dotnet restore "$PROJECT"
   dotnet publish "$PROJECT" \
@@ -399,7 +399,7 @@ build_for_arch() {
 
   local RID_DIR="$rid"
   local PUBDIR
-  PUBDIR="$(dirname "$PROJECT")/bin/Release/net8.0/${RID_DIR}/publish"
+  PUBDIR="$(dirname "$PROJECT")/bin/Release/net10.0/${RID_DIR}/publish"
   [[ -d "$PUBDIR" ]] || { echo "Publish directory not found: $PUBDIR"; return 1; }
 
   local WORKDIR PKGROOT STAGE DEBIAN_DIR

--- a/package-rhel-riscv.sh
+++ b/package-rhel-riscv.sh
@@ -69,7 +69,7 @@ if [[ -n "${VERSION_ARG:-}" && -n "${BUILD_FROM:-}" ]]; then
 fi
 
 apply_riscv_patch() {
-  # Upgrade net8.0 -> net10.0
+  # Ensure all project files target net10.0
   find . -type f \( -name "*.csproj" -o -name "*.props" -o -name "*.targets" \) \
     -exec sed -i 's/net8\.0/net10.0/g' {} +
 

--- a/package-rhel.sh
+++ b/package-rhel.sh
@@ -71,13 +71,13 @@ host_arch="$(uname -m)"
 install_ok=0
 
 if command -v dnf >/dev/null 2>&1; then
-  sudo dnf -y install rpm-build rpmdevtools curl unzip tar jq rsync dotnet-sdk-8.0 \
+  sudo dnf -y install rpm-build rpmdevtools curl unzip tar jq rsync dotnet-sdk-10.0 \
     && install_ok=1
 fi
 
 if [[ "$install_ok" -ne 1 ]]; then
   echo "Could not auto-install dependencies for '$ID'. Make sure these are available:"
-  echo "dotnet-sdk 8.x, curl, unzip, tar, rsync, rpm, rpmdevtools, rpm-build (on Red Hat branch)"
+  echo "dotnet-sdk 10.x, curl, unzip, tar, rsync, rpm, rpmdevtools, rpm-build (on Red Hat branch)"
 fi
 
 # Root directory
@@ -372,7 +372,7 @@ build_for_arch() {
 
   # .NET publish (self-contained) for this RID
   dotnet clean "$PROJECT" -c Release
-  rm -rf "$(dirname "$PROJECT")/bin/Release/net8.0" || true
+  rm -rf "$(dirname "$PROJECT")/bin/Release/net10.0" || true
 
   dotnet restore "$PROJECT"
   dotnet publish "$PROJECT" \
@@ -383,7 +383,7 @@ build_for_arch() {
   # Per-arch variables (scoped)
   local RID_DIR="$rid"
   local PUBDIR
-  PUBDIR="$(dirname "$PROJECT")/bin/Release/net8.0/${RID_DIR}/publish"
+  PUBDIR="$(dirname "$PROJECT")/bin/Release/net10.0/${RID_DIR}/publish"
   [[ -d "$PUBDIR" ]] || { echo "Publish directory not found: $PUBDIR"; return 1; }
 
   # Per-arch working area

--- a/v2rayN/Directory.Build.props
+++ b/v2rayN/Directory.Build.props
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
         <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
         <NoWarn>CA1031;CS1591;NU1507;CA1416;IDE0058;IDE0053;IDE0200</NoWarn>

--- a/v2rayN/Directory.Build.props
+++ b/v2rayN/Directory.Build.props
@@ -8,7 +8,6 @@
         <TargetFramework>net10.0</TargetFramework>
         <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
         <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-        <NoWarn>CA1031;CS1591;NU1507;CA1416;IDE0058;IDE0053;IDE0200</NoWarn>
         <Nullable>annotations</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <Authors>2dust</Authors>

--- a/v2rayN/Directory.Packages.props
+++ b/v2rayN/Directory.Packages.props
@@ -24,9 +24,11 @@
     <PackageVersion Include="Semi.Avalonia" Version="11.3.7.3" />
     <PackageVersion Include="Semi.Avalonia.AvaloniaEdit" Version="11.2.0.2" />
     <PackageVersion Include="Semi.Avalonia.DataGrid" Version="11.3.7.3" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />
     <PackageVersion Include="NLog" Version="6.1.2" />
     <PackageVersion Include="sqlite-net-pcl" Version="1.9.172" />
     <PackageVersion Include="TaskScheduler" Version="2.12.2" />
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.21.3" />
     <PackageVersion Include="WebDav.Client" Version="2.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />

--- a/v2rayN/ServiceLib/Common/Utils.cs
+++ b/v2rayN/ServiceLib/Common/Utils.cs
@@ -1114,12 +1114,14 @@ public class Utils
 
     #region Platform
 
+    [SupportedOSPlatformGuard("windows")]
     public static bool IsWindows() => OperatingSystem.IsWindows();
 
     public static bool IsLinux() => OperatingSystem.IsLinux();
 
     public static bool IsMacOS() => OperatingSystem.IsMacOS();
 
+    [UnsupportedOSPlatformGuard("windows")]
     public static bool IsNonWindows() => !OperatingSystem.IsWindows();
 
     public static string GetExeName(string name)
@@ -1214,6 +1216,16 @@ public class Utils
     }
 
     public static bool SetUnixFileMode(string? fileName)
+    {
+        if (IsWindows())
+        {
+            return false;
+        }
+        return SetUnixFileModeInternal(fileName);
+    }
+
+    [UnsupportedOSPlatform("windows")]
+    private static bool SetUnixFileModeInternal(string? fileName)
     {
         try
         {

--- a/v2rayN/ServiceLib/Common/WindowsUtils.cs
+++ b/v2rayN/ServiceLib/Common/WindowsUtils.cs
@@ -2,6 +2,7 @@ using Microsoft.Win32;
 
 namespace ServiceLib.Common;
 
+[SupportedOSPlatform("windows")]
 internal static class WindowsUtils
 {
     private static readonly string _tag = "WindowsUtils";

--- a/v2rayN/ServiceLib/GlobalUsings.cs
+++ b/v2rayN/ServiceLib/GlobalUsings.cs
@@ -8,6 +8,7 @@ global using System.Reactive.Disposables;
 global using System.Reactive.Linq;
 global using System.Reflection;
 global using System.Runtime.InteropServices;
+global using System.Runtime.Versioning;
 global using System.Security.Cryptography;
 global using System.Text;
 global using System.Text.Encodings.Web;

--- a/v2rayN/ServiceLib/Handler/AutoStartupHandler.cs
+++ b/v2rayN/ServiceLib/Handler/AutoStartupHandler.cs
@@ -41,6 +41,7 @@ public static class AutoStartupHandler
 
     #region Windows
 
+    [SupportedOSPlatform("windows")]
     private static async Task ClearTaskWindows()
     {
         var autoRunName = GetAutoRunNameWindows();
@@ -53,6 +54,7 @@ public static class AutoStartupHandler
         await Task.CompletedTask;
     }
 
+    [SupportedOSPlatform("windows")]
     private static async Task SetTaskWindows()
     {
         try
@@ -82,6 +84,7 @@ public static class AutoStartupHandler
     /// <param name="fileName"></param>
     /// <param name="description"></param>
     /// <exception cref="ArgumentNullException"></exception>
+    [SupportedOSPlatform("windows")]
     public static void AutoStartTaskService(string taskName, string fileName, string description)
     {
         if (taskName.IsNullOrEmpty())

--- a/v2rayN/ServiceLib/Handler/SysProxy/ProxySettingWindows.cs
+++ b/v2rayN/ServiceLib/Handler/SysProxy/ProxySettingWindows.cs
@@ -2,6 +2,7 @@ using static ServiceLib.Handler.SysProxy.ProxySettingWindows.InternetConnectionO
 
 namespace ServiceLib.Handler.SysProxy;
 
+[SupportedOSPlatform("windows")]
 public static class ProxySettingWindows
 {
     private const string _regPath = @"Software\Microsoft\Windows\CurrentVersion\Internet Settings";

--- a/v2rayN/ServiceLib/Handler/SysProxy/SysProxyHandler.cs
+++ b/v2rayN/ServiceLib/Handler/SysProxy/SysProxyHandler.cs
@@ -88,6 +88,7 @@ public static class SysProxyHandler
         }
     }
 
+    [SupportedOSPlatform("windows")]
     private static async Task SetWindowsProxyPac(int port)
     {
         var portPac = AppManager.Instance.GetLocalPort(EInboundProtocol.pac);

--- a/v2rayN/ServiceLib/Manager/CoreManager.cs
+++ b/v2rayN/ServiceLib/Manager/CoreManager.cs
@@ -8,6 +8,7 @@ public class CoreManager
     private static readonly Lazy<CoreManager> _instance = new(() => new());
     public static CoreManager Instance => _instance.Value;
     private Config _config;
+    [SupportedOSPlatform("windows")]
     private WindowsJobService? _processJob;
     private ProcessService? _processService;
     private ProcessService? _processPreService;

--- a/v2rayN/ServiceLib/Services/WindowsJobService.cs
+++ b/v2rayN/ServiceLib/Services/WindowsJobService.cs
@@ -3,6 +3,7 @@ namespace ServiceLib.Services;
 /// <summary>
 /// http://stackoverflow.com/questions/6266820/working-example-of-createjobobject-setinformationjobobject-pinvoke-in-net
 /// </summary>
+[SupportedOSPlatform("windows")]
 public sealed class WindowsJobService : IDisposable
 {
     private nint handle = nint.Zero;

--- a/v2rayN/v2rayN.Desktop/Common/QRCodeAvaloniaUtils.cs
+++ b/v2rayN/v2rayN.Desktop/Common/QRCodeAvaloniaUtils.cs
@@ -23,6 +23,7 @@ public partial class QRCodeAvaloniaUtils
         }
     }
 
+    [SupportedOSPlatform("windows")]
     private static byte[]? CaptureScreenWindows()
     {
         var hdcScreen = IntPtr.Zero;

--- a/v2rayN/v2rayN.Desktop/GlobalUsings.cs
+++ b/v2rayN/v2rayN.Desktop/GlobalUsings.cs
@@ -5,6 +5,7 @@ global using System.IO;
 global using System.Linq;
 global using System.Reactive.Disposables.Fluent;
 global using System.Reactive.Linq;
+global using System.Runtime.Versioning;
 global using System.Text;
 global using System.Threading;
 global using System.Threading.Tasks;

--- a/v2rayN/v2rayN.Desktop/Manager/HotkeyManager.cs
+++ b/v2rayN/v2rayN.Desktop/Manager/HotkeyManager.cs
@@ -8,6 +8,7 @@ public sealed class HotkeyManager
     private static readonly Lazy<HotkeyManager> _instance = new(() => new());
     public static HotkeyManager Instance = _instance.Value;
     private readonly Dictionary<int, EGlobalHotkey> _hotkeyTriggerDic = new();
+    [SupportedOSPlatform("windows")]
     private GlobalHotKeys.HotKeyManager? _hotKeyManager;
 
     private Config? _config;
@@ -16,6 +17,7 @@ public sealed class HotkeyManager
 
     public bool IsPause { get; set; } = false;
 
+    [SupportedOSPlatform("windows")]
     public void Init(Config config, Action<EGlobalHotkey> updateFunc)
     {
         _config = config;
@@ -26,9 +28,14 @@ public sealed class HotkeyManager
 
     public void Dispose()
     {
+        if (!Utils.IsWindows())
+        {
+            return;
+        }
         _hotKeyManager?.Dispose();
     }
 
+    [SupportedOSPlatform("windows")]
     private void Register()
     {
         if (_config.GlobalHotkeys.Any(t => t.KeyCode > 0) == false)

--- a/v2rayN/v2rayN.Desktop/Views/MessageBoxDialog.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MessageBoxDialog.axaml.cs
@@ -4,6 +4,11 @@ namespace v2rayN.Desktop.Views;
 
 public partial class MessageBoxDialog : Window
 {
+    public MessageBoxDialog()
+        : this(string.Empty, string.Empty)
+    {
+    }
+
     public MessageBoxDialog(string caption, string message)
     {
         InitializeComponent();

--- a/v2rayN/v2rayN/app.manifest
+++ b/v2rayN/v2rayN/app.manifest
@@ -1,12 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-  <asmv3:application>
-    <asmv3:windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
-    </asmv3:windowsSettings>
-  </asmv3:application>
-	
 	<!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
 	<dependency>
 		<dependentAssembly>

--- a/v2rayN/v2rayN/v2rayN.csproj
+++ b/v2rayN/v2rayN/v2rayN.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+		<TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
 		<GenerateSatelliteAssembliesForCore>true</GenerateSatelliteAssembliesForCore>
 		<UseWPF>true</UseWPF>
 		<ApplicationIcon>Resources\v2rayN.ico</ApplicationIcon>

--- a/v2rayN/v2rayN/v2rayN.csproj
+++ b/v2rayN/v2rayN/v2rayN.csproj
@@ -7,6 +7,7 @@
 		<UseWPF>true</UseWPF>
 		<ApplicationIcon>Resources\v2rayN.ico</ApplicationIcon>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
+		<ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
 		<SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>


### PR DESCRIPTION
## Summary

Depends on #9179 and 2dust/GlobalHotKeys#2.

This PR is intended to be reviewed and merged after the .NET 10 migration in #9179 and the related GlobalHotKeys .NET 10 update.

It removes the repository-level `NoWarn` suppression and fixes the warnings that appear on top of the .NET 10 migration, keeping regular and release builds warning-free without suppressing warnings globally.

## Changes

- Removes `NoWarn` from `Directory.Build.props`.
- Adds platform annotations/guards for Windows-only APIs.
- Moves WPF high DPI configuration from `app.manifest` to `ApplicationHighDpiMode`.
- Adds a parameterless constructor for `MessageBoxDialog` to satisfy Avalonia runtime loading.
- Pins package versions to remove restore/build warnings:
  - `Tmds.DBus.Protocol`
  - `SQLitePCLRaw.bundle_green`

## Verification

Tested on top of #9179.

- `dotnet restore .\v2rayN\v2rayN.slnx`
- `dotnet build .\v2rayN\v2rayN.slnx -c Debug --no-restore`
- `dotnet build .\v2rayN\v2rayN.slnx -c Release --no-restore`
- `dotnet restore .\v2rayN\v2rayN.Desktop\v2rayN.Desktop.csproj -r linux-x64`
- `dotnet publish .\v2rayN\v2rayN.Desktop\v2rayN.Desktop.csproj -c Release -r linux-x64 -p:PublishSingleFile=false -p:SelfContained=true --no-restore`
- `dotnet restore .\v2rayN\v2rayN.Desktop\v2rayN.Desktop.csproj -r linux-arm64`
- `dotnet publish .\v2rayN\v2rayN.Desktop\v2rayN.Desktop.csproj -c Release -r linux-arm64 -p:PublishSingleFile=false -p:SelfContained=true --no-restore`

All tested builds completed with `0 warnings` and `0 errors` when the related `GlobalHotKeys` .NET 10 changes are present.