### PR TITLE
Modernize dependency stack after .NET 10 migration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5.2.0
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Build v2rayN
       working-directory: ./v2rayN

--- a/package-debian.sh
+++ b/package-debian.sh
@@ -88,10 +88,10 @@ if command -v apt-get >/dev/null 2>&1; then
       libc6:arm64 libgcc-s1:arm64 libstdc++6:arm64 zlib1g:arm64 libfontconfig1:arm64
   fi
 
-  # Install .NET SDK 8 via official script
+  # Install .NET SDK 10 via official script
   wget -q https://dot.net/v1/dotnet-install.sh
   chmod +x dotnet-install.sh
-  ./dotnet-install.sh --channel 8.0 --install-dir "$HOME/.dotnet"
+  ./dotnet-install.sh --channel 10.0 --install-dir "$HOME/.dotnet"
 
   export PATH="$HOME/.dotnet:$PATH"
   export DOTNET_ROOT="$HOME/.dotnet"
@@ -101,7 +101,7 @@ fi
 
 if [[ "$install_ok" -ne 1 ]]; then
   echo "Could not auto-install dependencies for '$ID'. Make sure these are available:"
-  echo "dotnet-sdk 8.x, curl, unzip, tar, rsync, git, dpkg-deb, desktop-file-utils, xdg-utils"
+  echo "dotnet-sdk 10.x, curl, unzip, tar, rsync, git, dpkg-deb, desktop-file-utils, xdg-utils"
   exit 1
 fi
 
@@ -389,7 +389,7 @@ build_for_arch() {
   echo "[*] Building for target: $short  (RID=$rid, DEB arch=$deb_arch)"
 
   dotnet clean "$PROJECT" -c Release
-  rm -rf "$(dirname "$PROJECT")/bin/Release/net8.0" || true
+  rm -rf "$(dirname "$PROJECT")/bin/Release/net10.0" || true
 
   dotnet restore "$PROJECT"
   dotnet publish "$PROJECT" \
@@ -399,7 +399,7 @@ build_for_arch() {
 
   local RID_DIR="$rid"
   local PUBDIR
-  PUBDIR="$(dirname "$PROJECT")/bin/Release/net8.0/${RID_DIR}/publish"
+  PUBDIR="$(dirname "$PROJECT")/bin/Release/net10.0/${RID_DIR}/publish"
   [[ -d "$PUBDIR" ]] || { echo "Publish directory not found: $PUBDIR"; return 1; }
 
   local WORKDIR PKGROOT STAGE DEBIAN_DIR

--- a/package-rhel-riscv.sh
+++ b/package-rhel-riscv.sh
@@ -69,7 +69,7 @@ if [[ -n "${VERSION_ARG:-}" && -n "${BUILD_FROM:-}" ]]; then
 fi
 
 apply_riscv_patch() {
-  # Upgrade net8.0 -> net10.0
+  # Ensure all project files target net10.0
   find . -type f \( -name "*.csproj" -o -name "*.props" -o -name "*.targets" \) \
     -exec sed -i 's/net8\.0/net10.0/g' {} +
 

--- a/package-rhel-riscv.sh
+++ b/package-rhel-riscv.sh
@@ -38,7 +38,7 @@ DOTNET_RISCV_BASE="https://github.com/filipnavara/dotnet-riscv/releases/download
 DOTNET_RISCV_FILE="dotnet-sdk-${DOTNET_RISCV_VERSION}-linux-riscv64.tar.gz"
 DOTNET_SDK_URL="${DOTNET_RISCV_BASE}/${DOTNET_RISCV_VERSION}/${DOTNET_RISCV_FILE}"
 SKIA_VER="${SKIA_VER:-3.119.2}"
-HARFBUZZ_VER="${HARFBUZZ_VER:-8.3.1.1}"
+HARFBUZZ_VER="${HARFBUZZ_VER:-8.3.1.3}"
 
 # If the first argument starts with --, do not treat it as a version number
 if [[ "${VERSION_ARG:-}" == --* ]]; then
@@ -111,9 +111,9 @@ build_sqlite_native_riscv64() {
   mkdir -p "$outdir"
   workdir="$(mktemp -d)"
 
-  # SQLite 3.51.3 amalgamation
+  # SQLite 3.53.0 amalgamation
   sqlite_year="2026"
-  sqlite_ver="3510300"
+  sqlite_ver="3530000"
   sqlite_zip="sqlite-amalgamation-${sqlite_ver}.zip"
 
   echo "[+] Download SQLite amalgamation: ${sqlite_zip}"

--- a/package-rhel-riscv.sh
+++ b/package-rhel-riscv.sh
@@ -40,6 +40,23 @@ DOTNET_SDK_URL="${DOTNET_RISCV_BASE}/${DOTNET_RISCV_VERSION}/${DOTNET_RISCV_FILE
 SKIA_VER="${SKIA_VER:-3.119.2}"
 HARFBUZZ_VER="${HARFBUZZ_VER:-8.3.1.3}"
 
+# SQLite amalgamation version for the linux-riscv64 native build.
+#
+# Keep in sync with the SourceGear.sqlite3 package referenced from
+# v2rayN/Directory.Packages.props (it pins the SQLite binaries shipped on the
+# x64/arm64/macOS RIDs).
+#
+# Mapping rule:  SourceGear.sqlite3 X.Y.Z.W  ->  SQLite vX.Y.Z
+#   ->  SQLITE_AMALGAMATION_VER  = sprintf("%d%02d%02d00", X, Y, Z)
+#   ->  SQLITE_AMALGAMATION_YEAR = year of the upstream SQLite release
+#
+# Currently: SourceGear.sqlite3 3.50.4.5  ->  SQLite 3.50.4 (released 2025).
+#
+# Override via the environment if you need a different version on RISC-V:
+#   SQLITE_AMALGAMATION_YEAR=2026 SQLITE_AMALGAMATION_VER=3530000 ./package-rhel-riscv.sh
+SQLITE_AMALGAMATION_YEAR="${SQLITE_AMALGAMATION_YEAR:-2025}"
+SQLITE_AMALGAMATION_VER="${SQLITE_AMALGAMATION_VER:-3500400}"
+
 # If the first argument starts with --, do not treat it as a version number
 if [[ "${VERSION_ARG:-}" == --* ]]; then
   VERSION_ARG=""
@@ -111,9 +128,11 @@ build_sqlite_native_riscv64() {
   mkdir -p "$outdir"
   workdir="$(mktemp -d)"
 
-  # SQLite 3.53.0 amalgamation
-  sqlite_year="2026"
-  sqlite_ver="3530000"
+  # SQLite amalgamation. Version is configured at the top of this script
+  # (SQLITE_AMALGAMATION_YEAR / SQLITE_AMALGAMATION_VER) and must be kept in
+  # sync with the SourceGear.sqlite3 package version used on other RIDs.
+  sqlite_year="$SQLITE_AMALGAMATION_YEAR"
+  sqlite_ver="$SQLITE_AMALGAMATION_VER"
   sqlite_zip="sqlite-amalgamation-${sqlite_ver}.zip"
 
   echo "[+] Download SQLite amalgamation: ${sqlite_zip}"

--- a/package-rhel.sh
+++ b/package-rhel.sh
@@ -71,13 +71,13 @@ host_arch="$(uname -m)"
 install_ok=0
 
 if command -v dnf >/dev/null 2>&1; then
-  sudo dnf -y install rpm-build rpmdevtools curl unzip tar jq rsync dotnet-sdk-8.0 \
+  sudo dnf -y install rpm-build rpmdevtools curl unzip tar jq rsync dotnet-sdk-10.0 \
     && install_ok=1
 fi
 
 if [[ "$install_ok" -ne 1 ]]; then
   echo "Could not auto-install dependencies for '$ID'. Make sure these are available:"
-  echo "dotnet-sdk 8.x, curl, unzip, tar, rsync, rpm, rpmdevtools, rpm-build (on Red Hat branch)"
+  echo "dotnet-sdk 10.x, curl, unzip, tar, rsync, rpm, rpmdevtools, rpm-build (on Red Hat branch)"
 fi
 
 # Root directory
@@ -372,7 +372,7 @@ build_for_arch() {
 
   # .NET publish (self-contained) for this RID
   dotnet clean "$PROJECT" -c Release
-  rm -rf "$(dirname "$PROJECT")/bin/Release/net8.0" || true
+  rm -rf "$(dirname "$PROJECT")/bin/Release/net10.0" || true
 
   dotnet restore "$PROJECT"
   dotnet publish "$PROJECT" \
@@ -383,7 +383,7 @@ build_for_arch() {
   # Per-arch variables (scoped)
   local RID_DIR="$rid"
   local PUBDIR
-  PUBDIR="$(dirname "$PROJECT")/bin/Release/net8.0/${RID_DIR}/publish"
+  PUBDIR="$(dirname "$PROJECT")/bin/Release/net10.0/${RID_DIR}/publish"
   [[ -d "$PUBDIR" ]] || { echo "Publish directory not found: $PUBDIR"; return 1; }
 
   # Per-arch working area

--- a/v2rayN/Directory.Build.props
+++ b/v2rayN/Directory.Build.props
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
         <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
         <NoWarn>CA1031;CS1591;NU1507;CA1416;IDE0058;IDE0053;IDE0200</NoWarn>

--- a/v2rayN/Directory.Build.props
+++ b/v2rayN/Directory.Build.props
@@ -8,7 +8,6 @@
         <TargetFramework>net10.0</TargetFramework>
         <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
         <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-        <NoWarn>CA1031;CS1591;NU1507;CA1416;IDE0058;IDE0053;IDE0200</NoWarn>
         <Nullable>annotations</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <Authors>2dust</Authors>

--- a/v2rayN/Directory.Packages.props
+++ b/v2rayN/Directory.Packages.props
@@ -24,9 +24,11 @@
     <PackageVersion Include="Semi.Avalonia" Version="11.3.7.3" />
     <PackageVersion Include="Semi.Avalonia.AvaloniaEdit" Version="11.2.0.2" />
     <PackageVersion Include="Semi.Avalonia.DataGrid" Version="11.3.7.3" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />
     <PackageVersion Include="NLog" Version="6.1.2" />
     <PackageVersion Include="sqlite-net-pcl" Version="1.9.172" />
     <PackageVersion Include="TaskScheduler" Version="2.12.2" />
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.21.3" />
     <PackageVersion Include="WebDav.Client" Version="2.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />

--- a/v2rayN/Directory.Packages.props
+++ b/v2rayN/Directory.Packages.props
@@ -7,32 +7,33 @@
   <ItemGroup>
     <PackageVersion Include="Avalonia.AvaloniaEdit" Version="11.4.1" />
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.3.13" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.13" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.13" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.3.14" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.14" />
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="DialogHost.Avalonia" Version="0.11.0" />
     <PackageVersion Include="ReactiveUI.Avalonia" Version="11.4.12" />
     <PackageVersion Include="CliWrap" Version="3.10.1" />
-    <PackageVersion Include="Downloader" Version="5.2.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Downloader" Version="5.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="H.NotifyIcon.Wpf" Version="2.4.1" />
-    <PackageVersion Include="MaterialDesignThemes" Version="5.3.1" />
+    <PackageVersion Include="MaterialDesignThemes" Version="5.3.2" />
     <PackageVersion Include="QRCoder" Version="1.8.0" />
-    <PackageVersion Include="ReactiveUI" Version="23.2.1" />
-    <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />
-    <PackageVersion Include="ReactiveUI.WPF" Version="23.2.1" />
-    <PackageVersion Include="Semi.Avalonia" Version="11.3.7.3" />
+    <PackageVersion Include="ReactiveUI" Version="23.2.19" />
+    <PackageVersion Include="ReactiveUI.SourceGenerators" Version="2.6.30" />
+    <PackageVersion Include="ReactiveUI.WPF" Version="23.2.19" />
+    <PackageVersion Include="Semi.Avalonia" Version="11.3.14" />
     <PackageVersion Include="Semi.Avalonia.AvaloniaEdit" Version="11.2.0.2" />
     <PackageVersion Include="Semi.Avalonia.DataGrid" Version="11.3.7.3" />
-    <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />
+    <PackageVersion Include="SQLitePCLRaw.config.e_sqlite3" Version="3.0.2" />
+    <PackageVersion Include="SourceGear.sqlite3" Version="3.50.4.5" />
     <PackageVersion Include="NLog" Version="6.1.2" />
-    <PackageVersion Include="sqlite-net-pcl" Version="1.9.172" />
+    <PackageVersion Include="sqlite-net-base" Version="1.9.172" />
     <PackageVersion Include="TaskScheduler" Version="2.12.2" />
-    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.21.3" />
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.93.0" />
     <PackageVersion Include="WebDav.Client" Version="2.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
-    <PackageVersion Include="YamlDotNet" Version="16.3.0" />
-    <PackageVersion Include="ZXing.Net.Bindings.SkiaSharp" Version="0.16.14" />
+    <PackageVersion Include="YamlDotNet" Version="17.1.0" />
+    <PackageVersion Include="ZXing.Net.Bindings.SkiaSharp" Version="0.16.22" />
   </ItemGroup>
 </Project>

--- a/v2rayN/ServiceLib.Tests/ServiceLib.Tests.csproj
+++ b/v2rayN/ServiceLib.Tests/ServiceLib.Tests.csproj
@@ -20,4 +20,8 @@
     <ProjectReference Include="..\ServiceLib\ServiceLib.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/v2rayN/ServiceLib.Tests/xunit.runner.json
+++ b/v2rayN/ServiceLib.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "culture": "invariant"
+}

--- a/v2rayN/ServiceLib/Common/Utils.cs
+++ b/v2rayN/ServiceLib/Common/Utils.cs
@@ -1114,12 +1114,14 @@ public class Utils
 
     #region Platform
 
+    [SupportedOSPlatformGuard("windows")]
     public static bool IsWindows() => OperatingSystem.IsWindows();
 
     public static bool IsLinux() => OperatingSystem.IsLinux();
 
     public static bool IsMacOS() => OperatingSystem.IsMacOS();
 
+    [UnsupportedOSPlatformGuard("windows")]
     public static bool IsNonWindows() => !OperatingSystem.IsWindows();
 
     public static string GetExeName(string name)
@@ -1214,6 +1216,16 @@ public class Utils
     }
 
     public static bool SetUnixFileMode(string? fileName)
+    {
+        if (IsWindows())
+        {
+            return false;
+        }
+        return SetUnixFileModeInternal(fileName);
+    }
+
+    [UnsupportedOSPlatform("windows")]
+    private static bool SetUnixFileModeInternal(string? fileName)
     {
         try
         {

--- a/v2rayN/ServiceLib/Common/Utils.cs
+++ b/v2rayN/ServiceLib/Common/Utils.cs
@@ -862,17 +862,34 @@ public class Utils
         return systemHosts;
     }
 
+    /// <summary>
+    /// Reads and merges the system hosts file(s) for the current platform.
+    /// On Windows: <c>C:\Windows\System32\drivers\etc\hosts</c> plus
+    /// <c>hosts.ics</c> (created by Internet Connection Sharing).
+    /// On Linux/macOS: <c>/etc/hosts</c>.
+    /// On any other platform: returns an empty dictionary.
+    /// </summary>
     public static Dictionary<string, string> GetSystemHosts()
     {
-        var hosts = GetSystemHosts(@"C:\Windows\System32\drivers\etc\hosts");
-        var hostsIcs = GetSystemHosts(@"C:\Windows\System32\drivers\etc\hosts.ics");
-
-        foreach (var (key, value) in hostsIcs)
+        if (IsWindows())
         {
-            hosts[key] = value;
+            var hosts = GetSystemHosts(@"C:\Windows\System32\drivers\etc\hosts");
+            var hostsIcs = GetSystemHosts(@"C:\Windows\System32\drivers\etc\hosts.ics");
+
+            foreach (var (key, value) in hostsIcs)
+            {
+                hosts[key] = value;
+            }
+
+            return hosts;
         }
 
-        return hosts;
+        if (IsLinux() || IsMacOS())
+        {
+            return GetSystemHosts("/etc/hosts");
+        }
+
+        return new Dictionary<string, string>();
     }
 
     public static async Task<string?> GetCliWrapOutput(string filePath, string? arg)
@@ -1117,8 +1134,10 @@ public class Utils
     [SupportedOSPlatformGuard("windows")]
     public static bool IsWindows() => OperatingSystem.IsWindows();
 
+    [SupportedOSPlatformGuard("linux")]
     public static bool IsLinux() => OperatingSystem.IsLinux();
 
+    [SupportedOSPlatformGuard("macos")]
     public static bool IsMacOS() => OperatingSystem.IsMacOS();
 
     [UnsupportedOSPlatformGuard("windows")]

--- a/v2rayN/ServiceLib/Common/WindowsUtils.cs
+++ b/v2rayN/ServiceLib/Common/WindowsUtils.cs
@@ -2,6 +2,7 @@ using Microsoft.Win32;
 
 namespace ServiceLib.Common;
 
+[SupportedOSPlatform("windows")]
 internal static class WindowsUtils
 {
     private static readonly string _tag = "WindowsUtils";

--- a/v2rayN/ServiceLib/FodyWeavers.xml
+++ b/v2rayN/ServiceLib/FodyWeavers.xml
@@ -1,3 +1,0 @@
-﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <ReactiveUI />
-</Weavers>

--- a/v2rayN/ServiceLib/GlobalUsings.cs
+++ b/v2rayN/ServiceLib/GlobalUsings.cs
@@ -8,6 +8,7 @@ global using System.Reactive.Disposables;
 global using System.Reactive.Linq;
 global using System.Reflection;
 global using System.Runtime.InteropServices;
+global using System.Runtime.Versioning;
 global using System.Security.Cryptography;
 global using System.Text;
 global using System.Text.Encodings.Web;

--- a/v2rayN/ServiceLib/GlobalUsings.cs
+++ b/v2rayN/ServiceLib/GlobalUsings.cs
@@ -19,7 +19,7 @@ global using System.Text.RegularExpressions;
 global using DynamicData;
 global using DynamicData.Binding;
 global using ReactiveUI;
-global using ReactiveUI.Fody.Helpers;
+global using ReactiveUI.SourceGenerators;
 global using ServiceLib.Base;
 global using ServiceLib.Common;
 global using ServiceLib.Enums;

--- a/v2rayN/ServiceLib/Handler/AutoStartupHandler.cs
+++ b/v2rayN/ServiceLib/Handler/AutoStartupHandler.cs
@@ -41,6 +41,7 @@ public static class AutoStartupHandler
 
     #region Windows
 
+    [SupportedOSPlatform("windows")]
     private static async Task ClearTaskWindows()
     {
         var autoRunName = GetAutoRunNameWindows();
@@ -53,6 +54,7 @@ public static class AutoStartupHandler
         await Task.CompletedTask;
     }
 
+    [SupportedOSPlatform("windows")]
     private static async Task SetTaskWindows()
     {
         try
@@ -82,6 +84,7 @@ public static class AutoStartupHandler
     /// <param name="fileName"></param>
     /// <param name="description"></param>
     /// <exception cref="ArgumentNullException"></exception>
+    [SupportedOSPlatform("windows")]
     public static void AutoStartTaskService(string taskName, string fileName, string description)
     {
         if (taskName.IsNullOrEmpty())

--- a/v2rayN/ServiceLib/Handler/AutoStartupHandler.cs
+++ b/v2rayN/ServiceLib/Handler/AutoStartupHandler.cs
@@ -127,6 +127,7 @@ public static class AutoStartupHandler
 
     #region Linux
 
+    [SupportedOSPlatform("linux")]
     private static async Task ClearTaskLinux()
     {
         try
@@ -140,6 +141,7 @@ public static class AutoStartupHandler
         await Task.CompletedTask;
     }
 
+    [SupportedOSPlatform("linux")]
     private static async Task SetTaskLinux()
     {
         try
@@ -160,6 +162,7 @@ public static class AutoStartupHandler
         }
     }
 
+    [SupportedOSPlatform("linux")]
     private static string GetHomePathLinux()
     {
         var homePath = Path.Combine(Utils.GetHomePath(), ".config", "autostart", $"{Global.AppName}.desktop");
@@ -171,6 +174,7 @@ public static class AutoStartupHandler
 
     #region macOS
 
+    [SupportedOSPlatform("macos")]
     private static async Task ClearTaskOSX()
     {
         try
@@ -190,6 +194,7 @@ public static class AutoStartupHandler
         }
     }
 
+    [SupportedOSPlatform("macos")]
     private static async Task SetTaskOSX()
     {
         try
@@ -207,6 +212,7 @@ public static class AutoStartupHandler
         }
     }
 
+    [SupportedOSPlatform("macos")]
     private static string GetLaunchAgentPathMacOS()
     {
         var homePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
@@ -215,6 +221,7 @@ public static class AutoStartupHandler
         return launchAgentPath;
     }
 
+    [SupportedOSPlatform("macos")]
     private static string GenerateLaunchAgentPlist()
     {
         var exePath = Utils.GetExePath();

--- a/v2rayN/ServiceLib/Handler/SysProxy/ProxySettingLinux.cs
+++ b/v2rayN/ServiceLib/Handler/SysProxy/ProxySettingLinux.cs
@@ -1,5 +1,6 @@
 namespace ServiceLib.Handler.SysProxy;
 
+[SupportedOSPlatform("linux")]
 public static class ProxySettingLinux
 {
     private static readonly string _proxySetFileName = $"{Global.ProxySetLinuxShellFileName.Replace(Global.NamespaceSample, "")}.sh";

--- a/v2rayN/ServiceLib/Handler/SysProxy/ProxySettingOSX.cs
+++ b/v2rayN/ServiceLib/Handler/SysProxy/ProxySettingOSX.cs
@@ -1,5 +1,6 @@
 namespace ServiceLib.Handler.SysProxy;
 
+[SupportedOSPlatform("macos")]
 public static class ProxySettingOSX
 {
     private static readonly string _proxySetFileName = $"{Global.ProxySetOSXShellFileName.Replace(Global.NamespaceSample, "")}.sh";

--- a/v2rayN/ServiceLib/Handler/SysProxy/ProxySettingWindows.cs
+++ b/v2rayN/ServiceLib/Handler/SysProxy/ProxySettingWindows.cs
@@ -2,6 +2,7 @@ using static ServiceLib.Handler.SysProxy.ProxySettingWindows.InternetConnectionO
 
 namespace ServiceLib.Handler.SysProxy;
 
+[SupportedOSPlatform("windows")]
 public static class ProxySettingWindows
 {
     private const string _regPath = @"Software\Microsoft\Windows\CurrentVersion\Internet Settings";

--- a/v2rayN/ServiceLib/Handler/SysProxy/SysProxyHandler.cs
+++ b/v2rayN/ServiceLib/Handler/SysProxy/SysProxyHandler.cs
@@ -88,6 +88,7 @@ public static class SysProxyHandler
         }
     }
 
+    [SupportedOSPlatform("windows")]
     private static async Task SetWindowsProxyPac(int port)
     {
         var portPac = AppManager.Instance.GetLocalPort(EInboundProtocol.pac);

--- a/v2rayN/ServiceLib/Helper/SqliteHelper.cs
+++ b/v2rayN/ServiceLib/Helper/SqliteHelper.cs
@@ -11,6 +11,11 @@ public sealed class SQLiteHelper
     private SQLiteAsyncConnection _dbAsync;
     private readonly string _configDB = "guiNDB.db";
 
+    static SQLiteHelper()
+    {
+        SQLitePCL.Batteries_V2.Init();
+    }
+
     public SQLiteHelper()
     {
         _connstr = Utils.GetConfigPath(_configDB);

--- a/v2rayN/ServiceLib/Manager/AppManager.cs
+++ b/v2rayN/ServiceLib/Manager/AppManager.cs
@@ -54,6 +54,13 @@ public sealed class AppManager
 
     public bool InitApp()
     {
+        // Initialize the native SQLite provider explicitly before any database
+        // access. The call is idempotent, so it cooperates with the static
+        // constructor in SQLiteHelper. Having it here as well ensures that any
+        // future code path which reaches the database without going through
+        // SQLiteHelper still works (e.g. background services or tests).
+        SQLitePCL.Batteries_V2.Init();
+
         if (Utils.HasWritePermission() == false)
         {
             Environment.SetEnvironmentVariable(Global.LocalAppData, "1", EnvironmentVariableTarget.Process);

--- a/v2rayN/ServiceLib/Manager/CoreManager.cs
+++ b/v2rayN/ServiceLib/Manager/CoreManager.cs
@@ -8,6 +8,7 @@ public class CoreManager
     private static readonly Lazy<CoreManager> _instance = new(() => new());
     public static CoreManager Instance => _instance.Value;
     private Config _config;
+    [SupportedOSPlatform("windows")]
     private WindowsJobService? _processJob;
     private ProcessService? _processService;
     private ProcessService? _processPreService;

--- a/v2rayN/ServiceLib/Manager/CoreManager.cs
+++ b/v2rayN/ServiceLib/Manager/CoreManager.cs
@@ -8,6 +8,11 @@ public class CoreManager
     private static readonly Lazy<CoreManager> _instance = new(() => new());
     public static CoreManager Instance => _instance.Value;
     private Config _config;
+
+    // WindowsJobService is a Windows-only type. The field-level attribute
+    // narrows the platform context for the analyzer in every read/assign
+    // location. Actual access goes through AddProcessJob, which guards the
+    // usage with Utils.IsWindows() so the field stays null on non-Windows.
     [SupportedOSPlatform("windows")]
     private WindowsJobService? _processJob;
     private ProcessService? _processService;

--- a/v2rayN/ServiceLib/Models/CheckUpdateModel.cs
+++ b/v2rayN/ServiceLib/Models/CheckUpdateModel.cs
@@ -1,10 +1,10 @@
 namespace ServiceLib.Models;
 
-public class CheckUpdateModel : ReactiveObject
+public partial class CheckUpdateModel : ReactiveObject
 {
     public bool? IsSelected { get; set; }
     public string? CoreType { get; set; }
-    [Reactive] public string? Remarks { get; set; }
+    [Reactive] public partial string? Remarks { get; set; }
     public string? FileName { get; set; }
     public bool? IsFinished { get; set; }
 }

--- a/v2rayN/ServiceLib/Models/ClashProxyModel.cs
+++ b/v2rayN/ServiceLib/Models/ClashProxyModel.cs
@@ -1,7 +1,7 @@
 namespace ServiceLib.Models;
 
 [Serializable]
-public class ClashProxyModel : ReactiveObject
+public partial class ClashProxyModel : ReactiveObject
 {
     public string? Name { get; set; }
 
@@ -9,9 +9,9 @@ public class ClashProxyModel : ReactiveObject
 
     public string? Now { get; set; }
 
-    [Reactive] public int Delay { get; set; }
+    [Reactive] public partial int Delay { get; set; }
 
-    [Reactive] public string? DelayName { get; set; }
+    [Reactive] public partial string? DelayName { get; set; }
 
     public bool IsActive { get; set; }
 }

--- a/v2rayN/ServiceLib/Models/ProfileItemModel.cs
+++ b/v2rayN/ServiceLib/Models/ProfileItemModel.cs
@@ -1,7 +1,7 @@
 namespace ServiceLib.Models;
 
 [Serializable]
-public class ProfileItemModel : ReactiveObject
+public partial class ProfileItemModel : ReactiveObject
 {
     public bool IsActive { get; set; }
     public string IndexId { get; set; }
@@ -16,27 +16,27 @@ public class ProfileItemModel : ReactiveObject
     public int Sort { get; set; }
 
     [Reactive]
-    public int Delay { get; set; }
+    public partial int Delay { get; set; }
 
     public decimal Speed { get; set; }
 
     [Reactive]
-    public string DelayVal { get; set; }
+    public partial string DelayVal { get; set; }
 
     [Reactive]
-    public string SpeedVal { get; set; }
+    public partial string SpeedVal { get; set; }
 
     [Reactive]
-    public string TodayUp { get; set; }
+    public partial string TodayUp { get; set; }
 
     [Reactive]
-    public string TodayDown { get; set; }
+    public partial string TodayDown { get; set; }
 
     [Reactive]
-    public string TotalUp { get; set; }
+    public partial string TotalUp { get; set; }
 
     [Reactive]
-    public string TotalDown { get; set; }
+    public partial string TotalDown { get; set; }
 
     public string GetSummary()
     {

--- a/v2rayN/ServiceLib/ServiceLib.csproj
+++ b/v2rayN/ServiceLib/ServiceLib.csproj
@@ -9,8 +9,10 @@
 		<PackageReference Include="ReactiveUI">
 			<TreatAsUsed>true</TreatAsUsed>
 		</PackageReference>
-		<PackageReference Include="ReactiveUI.Fody" />
-		<PackageReference Include="sqlite-net-pcl" />
+		<PackageReference Include="ReactiveUI.SourceGenerators" PrivateAssets="all" />
+		<PackageReference Include="sqlite-net-base" />
+		<PackageReference Include="SQLitePCLRaw.config.e_sqlite3" />
+		<PackageReference Include="SourceGear.sqlite3" />
 		<PackageReference Include="NLog" />
 		<PackageReference Include="WebDav.Client" />
 		<PackageReference Include="YamlDotNet" />

--- a/v2rayN/ServiceLib/Services/WindowsJobService.cs
+++ b/v2rayN/ServiceLib/Services/WindowsJobService.cs
@@ -3,6 +3,7 @@ namespace ServiceLib.Services;
 /// <summary>
 /// http://stackoverflow.com/questions/6266820/working-example-of-createjobobject-setinformationjobobject-pinvoke-in-net
 /// </summary>
+[SupportedOSPlatform("windows")]
 public sealed class WindowsJobService : IDisposable
 {
     private nint handle = nint.Zero;

--- a/v2rayN/ServiceLib/ViewModels/AddGroupServerViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/AddGroupServerViewModel.cs
@@ -1,27 +1,27 @@
 namespace ServiceLib.ViewModels;
 
-public class AddGroupServerViewModel : MyReactiveObject
+public partial class AddGroupServerViewModel : MyReactiveObject
 {
     [Reactive]
-    public ProfileItem SelectedSource { get; set; }
+    public partial ProfileItem SelectedSource { get; set; }
 
     [Reactive]
-    public ProfileItem SelectedChild { get; set; }
+    public partial ProfileItem SelectedChild { get; set; }
 
     [Reactive]
-    public IList<ProfileItem> SelectedChildren { get; set; }
+    public partial IList<ProfileItem> SelectedChildren { get; set; }
 
     [Reactive]
-    public string? CoreType { get; set; }
+    public partial string? CoreType { get; set; }
 
     [Reactive]
-    public string? PolicyGroupType { get; set; }
+    public partial string? PolicyGroupType { get; set; }
 
     [Reactive]
-    public SubItem? SelectedSubItem { get; set; }
+    public partial SubItem? SelectedSubItem { get; set; }
 
     [Reactive]
-    public string? Filter { get; set; }
+    public partial string? Filter { get; set; }
 
     public IObservableCollection<SubItem> SubItems { get; } = new ObservableCollectionExtended<SubItem>();
 

--- a/v2rayN/ServiceLib/ViewModels/AddServer2ViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/AddServer2ViewModel.cs
@@ -1,12 +1,12 @@
 namespace ServiceLib.ViewModels;
 
-public class AddServer2ViewModel : MyReactiveObject
+public partial class AddServer2ViewModel : MyReactiveObject
 {
     [Reactive]
-    public ProfileItem SelectedSource { get; set; }
+    public partial ProfileItem SelectedSource { get; set; }
 
     [Reactive]
-    public string? CoreType { get; set; }
+    public partial string? CoreType { get; set; }
 
     public ReactiveCommand<Unit, Unit> BrowseServerCmd { get; }
     public ReactiveCommand<Unit, Unit> EditServerCmd { get; }

--- a/v2rayN/ServiceLib/ViewModels/AddServerViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/AddServerViewModel.cs
@@ -1,113 +1,113 @@
 namespace ServiceLib.ViewModels;
 
-public class AddServerViewModel : MyReactiveObject
+public partial class AddServerViewModel : MyReactiveObject
 {
     [Reactive]
-    public ProfileItem SelectedSource { get; set; }
+    public partial ProfileItem SelectedSource { get; set; }
 
     [Reactive]
-    public string? CoreType { get; set; }
+    public partial string? CoreType { get; set; }
 
     [Reactive]
-    public string Cert { get; set; }
+    public partial string Cert { get; set; }
 
     [Reactive]
-    public string CertTip { get; set; }
+    public partial string CertTip { get; set; }
 
     [Reactive]
-    public string CertSha { get; set; }
+    public partial string CertSha { get; set; }
 
     [Reactive]
-    public bool AllowInsecureCertFetch { get; set; }
+    public partial bool AllowInsecureCertFetch { get; set; }
 
     [Reactive]
-    public string SalamanderPass { get; set; }
+    public partial string SalamanderPass { get; set; }
 
     [Reactive]
-    public int AlterId { get; set; }
+    public partial int AlterId { get; set; }
 
     [Reactive]
-    public string Ports { get; set; }
+    public partial string Ports { get; set; }
 
     [Reactive]
-    public int? UpMbps { get; set; }
+    public partial int? UpMbps { get; set; }
 
     [Reactive]
-    public int? DownMbps { get; set; }
+    public partial int? DownMbps { get; set; }
 
     [Reactive]
-    public string HopInterval { get; set; }
+    public partial string HopInterval { get; set; }
 
     [Reactive]
-    public string Flow { get; set; }
+    public partial string Flow { get; set; }
 
     [Reactive]
-    public string VmessSecurity { get; set; }
+    public partial string VmessSecurity { get; set; }
 
     [Reactive]
-    public string VlessEncryption { get; set; }
+    public partial string VlessEncryption { get; set; }
 
     [Reactive]
-    public string SsMethod { get; set; }
+    public partial string SsMethod { get; set; }
 
     [Reactive]
-    public string WgPublicKey { get; set; }
+    public partial string WgPublicKey { get; set; }
 
     //[Reactive]
     //public string WgPresharedKey { get; set; }
     [Reactive]
-    public string WgInterfaceAddress { get; set; }
+    public partial string WgInterfaceAddress { get; set; }
 
     [Reactive]
-    public string WgReserved { get; set; }
+    public partial string WgReserved { get; set; }
 
     [Reactive]
-    public int WgMtu { get; set; }
+    public partial int WgMtu { get; set; }
 
     [Reactive]
-    public bool Uot { get; set; }
+    public partial bool Uot { get; set; }
 
     [Reactive]
-    public string CongestionControl { get; set; }
+    public partial string CongestionControl { get; set; }
 
     [Reactive]
-    public int? InsecureConcurrency { get; set; }
+    public partial int? InsecureConcurrency { get; set; }
 
     [Reactive]
-    public bool NaiveQuic { get; set; }
+    public partial bool NaiveQuic { get; set; }
 
     [Reactive]
-    public string RawHeaderType { get; set; }
+    public partial string RawHeaderType { get; set; }
 
     [Reactive]
-    public string Host { get; set; }
+    public partial string Host { get; set; }
 
     [Reactive]
-    public string Path { get; set; }
+    public partial string Path { get; set; }
 
     [Reactive]
-    public string XhttpMode { get; set; }
+    public partial string XhttpMode { get; set; }
 
     [Reactive]
-    public string XhttpExtra { get; set; }
+    public partial string XhttpExtra { get; set; }
 
     [Reactive]
-    public string GrpcAuthority { get; set; }
+    public partial string GrpcAuthority { get; set; }
 
     [Reactive]
-    public string GrpcServiceName { get; set; }
+    public partial string GrpcServiceName { get; set; }
 
     [Reactive]
-    public string GrpcMode { get; set; }
+    public partial string GrpcMode { get; set; }
 
     [Reactive]
-    public string KcpHeaderType { get; set; }
+    public partial string KcpHeaderType { get; set; }
 
     [Reactive]
-    public string KcpSeed { get; set; }
+    public partial string KcpSeed { get; set; }
 
     [Reactive]
-    public int? KcpMtu { get; set; }
+    public partial int? KcpMtu { get; set; }
 
     public string TransportHeaderType
     {

--- a/v2rayN/ServiceLib/ViewModels/BackupAndRestoreViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/BackupAndRestoreViewModel.cs
@@ -1,6 +1,6 @@
 namespace ServiceLib.ViewModels;
 
-public class BackupAndRestoreViewModel : MyReactiveObject
+public partial class BackupAndRestoreViewModel : MyReactiveObject
 {
     private readonly string _guiConfigs = "guiConfigs";
     private static string BackupFileName => $"backup_{DateTime.Now:yyyyMMddHHmmss}.zip";
@@ -10,10 +10,10 @@ public class BackupAndRestoreViewModel : MyReactiveObject
     public ReactiveCommand<Unit, Unit> WebDavCheckCmd { get; }
 
     [Reactive]
-    public WebDavItem SelectedSource { get; set; }
+    public partial WebDavItem SelectedSource { get; set; }
 
     [Reactive]
-    public string OperationMsg { get; set; }
+    public partial string OperationMsg { get; set; }
 
     public BackupAndRestoreViewModel(Func<EViewAction, object?, Task<bool>>? updateView)
     {

--- a/v2rayN/ServiceLib/ViewModels/CheckUpdateViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/CheckUpdateViewModel.cs
@@ -1,6 +1,6 @@
 namespace ServiceLib.ViewModels;
 
-public class CheckUpdateViewModel : MyReactiveObject
+public partial class CheckUpdateViewModel : MyReactiveObject
 {
     private const string _geo = "GeoFiles";
     private readonly string _v2rayN = ECoreType.v2rayN.ToString();
@@ -9,7 +9,7 @@ public class CheckUpdateViewModel : MyReactiveObject
 
     public IObservableCollection<CheckUpdateModel> CheckUpdateModels { get; } = new ObservableCollectionExtended<CheckUpdateModel>();
     public ReactiveCommand<Unit, Unit> CheckUpdateCmd { get; }
-    [Reactive] public bool EnableCheckPreReleaseUpdate { get; set; }
+    [Reactive] public partial bool EnableCheckPreReleaseUpdate { get; set; }
 
     public CheckUpdateViewModel(Func<EViewAction, object?, Task<bool>>? updateView)
     {

--- a/v2rayN/ServiceLib/ViewModels/ClashConnectionsViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ClashConnectionsViewModel.cs
@@ -1,20 +1,20 @@
 namespace ServiceLib.ViewModels;
 
-public class ClashConnectionsViewModel : MyReactiveObject
+public partial class ClashConnectionsViewModel : MyReactiveObject
 {
     public IObservableCollection<ClashConnectionModel> ConnectionItems { get; } = new ObservableCollectionExtended<ClashConnectionModel>();
 
     [Reactive]
-    public ClashConnectionModel SelectedSource { get; set; }
+    public partial ClashConnectionModel SelectedSource { get; set; }
 
     public ReactiveCommand<Unit, Unit> ConnectionCloseCmd { get; }
     public ReactiveCommand<Unit, Unit> ConnectionCloseAllCmd { get; }
 
     [Reactive]
-    public string HostFilter { get; set; }
+    public partial string HostFilter { get; set; }
 
     [Reactive]
-    public bool AutoRefresh { get; set; }
+    public partial bool AutoRefresh { get; set; }
 
     public ClashConnectionsViewModel(Func<EViewAction, object?, Task<bool>>? updateView)
     {

--- a/v2rayN/ServiceLib/ViewModels/ClashProxiesViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ClashProxiesViewModel.cs
@@ -4,7 +4,7 @@ using static ServiceLib.Models.ClashProxies;
 
 namespace ServiceLib.ViewModels;
 
-public class ClashProxiesViewModel : MyReactiveObject
+public partial class ClashProxiesViewModel : MyReactiveObject
 {
     private Dictionary<string, ProxiesItem>? _proxies;
     private Dictionary<string, ProvidersItem>? _providers;
@@ -14,10 +14,10 @@ public class ClashProxiesViewModel : MyReactiveObject
     public IObservableCollection<ClashProxyModel> ProxyDetails { get; } = new ObservableCollectionExtended<ClashProxyModel>();
 
     [Reactive]
-    public ClashProxyModel SelectedGroup { get; set; }
+    public partial ClashProxyModel SelectedGroup { get; set; }
 
     [Reactive]
-    public ClashProxyModel SelectedDetail { get; set; }
+    public partial ClashProxyModel SelectedDetail { get; set; }
 
     public ReactiveCommand<Unit, Unit> ProxiesReloadCmd { get; }
     public ReactiveCommand<Unit, Unit> ProxiesDelayTestCmd { get; }
@@ -25,13 +25,13 @@ public class ClashProxiesViewModel : MyReactiveObject
     public ReactiveCommand<Unit, Unit> ProxiesSelectActivityCmd { get; }
 
     [Reactive]
-    public int RuleModeSelected { get; set; }
+    public partial int RuleModeSelected { get; set; }
 
     [Reactive]
-    public int SortingSelected { get; set; }
+    public partial int SortingSelected { get; set; }
 
     [Reactive]
-    public bool AutoRefresh { get; set; }
+    public partial bool AutoRefresh { get; set; }
 
     public ClashProxiesViewModel(Func<EViewAction, object?, Task<bool>>? updateView)
     {

--- a/v2rayN/ServiceLib/ViewModels/DNSSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/DNSSettingViewModel.cs
@@ -1,35 +1,35 @@
 namespace ServiceLib.ViewModels;
 
-public class DNSSettingViewModel : MyReactiveObject
+public partial class DNSSettingViewModel : MyReactiveObject
 {
-    [Reactive] public bool? UseSystemHosts { get; set; }
-    [Reactive] public bool? AddCommonHosts { get; set; }
-    [Reactive] public bool? FakeIP { get; set; }
-    [Reactive] public bool? BlockBindingQuery { get; set; }
-    [Reactive] public string? DirectDNS { get; set; }
-    [Reactive] public string? RemoteDNS { get; set; }
-    [Reactive] public string? BootstrapDNS { get; set; }
-    [Reactive] public string? Strategy4Freedom { get; set; }
-    [Reactive] public string? Strategy4Proxy { get; set; }
-    [Reactive] public string? Hosts { get; set; }
-    [Reactive] public string? DirectExpectedIPs { get; set; }
-    [Reactive] public bool? ParallelQuery { get; set; }
-    [Reactive] public bool? ServeStale { get; set; }
+    [Reactive] public partial bool? UseSystemHosts { get; set; }
+    [Reactive] public partial bool? AddCommonHosts { get; set; }
+    [Reactive] public partial bool? FakeIP { get; set; }
+    [Reactive] public partial bool? BlockBindingQuery { get; set; }
+    [Reactive] public partial string? DirectDNS { get; set; }
+    [Reactive] public partial string? RemoteDNS { get; set; }
+    [Reactive] public partial string? BootstrapDNS { get; set; }
+    [Reactive] public partial string? Strategy4Freedom { get; set; }
+    [Reactive] public partial string? Strategy4Proxy { get; set; }
+    [Reactive] public partial string? Hosts { get; set; }
+    [Reactive] public partial string? DirectExpectedIPs { get; set; }
+    [Reactive] public partial bool? ParallelQuery { get; set; }
+    [Reactive] public partial bool? ServeStale { get; set; }
 
-    [Reactive] public bool UseSystemHostsCompatible { get; set; }
-    [Reactive] public string DomainStrategy4FreedomCompatible { get; set; }
-    [Reactive] public string DomainDNSAddressCompatible { get; set; }
-    [Reactive] public string NormalDNSCompatible { get; set; }
-    [Reactive] public string TunDNSCompatible { get; set; }
+    [Reactive] public partial bool UseSystemHostsCompatible { get; set; }
+    [Reactive] public partial string DomainStrategy4FreedomCompatible { get; set; }
+    [Reactive] public partial string DomainDNSAddressCompatible { get; set; }
+    [Reactive] public partial string NormalDNSCompatible { get; set; }
+    [Reactive] public partial string TunDNSCompatible { get; set; }
 
-    [Reactive] public string DomainStrategy4Freedom2Compatible { get; set; }
-    [Reactive] public string DomainDNSAddress2Compatible { get; set; }
-    [Reactive] public string NormalDNS2Compatible { get; set; }
-    [Reactive] public string TunDNS2Compatible { get; set; }
-    [Reactive] public bool RayCustomDNSEnableCompatible { get; set; }
-    [Reactive] public bool SBCustomDNSEnableCompatible { get; set; }
+    [Reactive] public partial string DomainStrategy4Freedom2Compatible { get; set; }
+    [Reactive] public partial string DomainDNSAddress2Compatible { get; set; }
+    [Reactive] public partial string NormalDNS2Compatible { get; set; }
+    [Reactive] public partial string TunDNS2Compatible { get; set; }
+    [Reactive] public partial bool RayCustomDNSEnableCompatible { get; set; }
+    [Reactive] public partial bool SBCustomDNSEnableCompatible { get; set; }
 
-    [ObservableAsProperty] public bool IsSimpleDNSEnabled { get; }
+    [ObservableAsProperty] private bool _isSimpleDNSEnabled;
 
     public ReactiveCommand<Unit, Unit> SaveCmd { get; }
     public ReactiveCommand<Unit, Unit> ImportDefConfig4V2rayCompatibleCmd { get; }
@@ -55,9 +55,9 @@ public class DNSSettingViewModel : MyReactiveObject
             await Task.CompletedTask;
         });
 
-        this.WhenAnyValue(x => x.RayCustomDNSEnableCompatible, x => x.SBCustomDNSEnableCompatible)
+        _isSimpleDNSEnabledHelper = this.WhenAnyValue(x => x.RayCustomDNSEnableCompatible, x => x.SBCustomDNSEnableCompatible)
             .Select(x => !(x.Item1 && x.Item2))
-            .ToPropertyEx(this, x => x.IsSimpleDNSEnabled);
+            .ToProperty(this, nameof(IsSimpleDNSEnabled));
 
         _ = Init();
     }

--- a/v2rayN/ServiceLib/ViewModels/FullConfigTemplateViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/FullConfigTemplateViewModel.cs
@@ -1,38 +1,38 @@
 namespace ServiceLib.ViewModels;
 
-public class FullConfigTemplateViewModel : MyReactiveObject
+public partial class FullConfigTemplateViewModel : MyReactiveObject
 {
     #region Reactive
 
     [Reactive]
-    public bool EnableFullConfigTemplate4Ray { get; set; }
+    public partial bool EnableFullConfigTemplate4Ray { get; set; }
 
     [Reactive]
-    public bool EnableFullConfigTemplate4Singbox { get; set; }
+    public partial bool EnableFullConfigTemplate4Singbox { get; set; }
 
     [Reactive]
-    public string FullConfigTemplate4Ray { get; set; }
+    public partial string FullConfigTemplate4Ray { get; set; }
 
     [Reactive]
-    public string FullTunConfigTemplate4Ray { get; set; }
+    public partial string FullTunConfigTemplate4Ray { get; set; }
 
     [Reactive]
-    public string FullConfigTemplate4Singbox { get; set; }
+    public partial string FullConfigTemplate4Singbox { get; set; }
 
     [Reactive]
-    public string FullTunConfigTemplate4Singbox { get; set; }
+    public partial string FullTunConfigTemplate4Singbox { get; set; }
 
     [Reactive]
-    public bool AddProxyOnly4Ray { get; set; }
+    public partial bool AddProxyOnly4Ray { get; set; }
 
     [Reactive]
-    public bool AddProxyOnly4Singbox { get; set; }
+    public partial bool AddProxyOnly4Singbox { get; set; }
 
     [Reactive]
-    public string ProxyDetour4Ray { get; set; }
+    public partial string ProxyDetour4Ray { get; set; }
 
     [Reactive]
-    public string ProxyDetour4Singbox { get; set; }
+    public partial string ProxyDetour4Singbox { get; set; }
 
     public ReactiveCommand<Unit, Unit> SaveCmd { get; }
 

--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -2,7 +2,7 @@ using System.Reactive.Concurrency;
 
 namespace ServiceLib.ViewModels;
 
-public class MainWindowViewModel : MyReactiveObject
+public partial class MainWindowViewModel : MyReactiveObject
 {
     #region Menu
 
@@ -55,15 +55,15 @@ public class MainWindowViewModel : MyReactiveObject
     public ReactiveCommand<Unit, Unit> ReloadCmd { get; }
 
     [Reactive]
-    public bool BlReloadEnabled { get; set; }
+    public partial bool BlReloadEnabled { get; set; }
 
     [Reactive]
-    public bool ShowClashUI { get; set; }
+    public partial bool ShowClashUI { get; set; }
 
     [Reactive]
-    public int TabMainSelectedIndex { get; set; }
+    public partial int TabMainSelectedIndex { get; set; }
 
-    [Reactive] public bool BlIsWindows { get; set; }
+    [Reactive] public partial bool BlIsWindows { get; set; }
 
     #endregion Menu
 

--- a/v2rayN/ServiceLib/ViewModels/MsgViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MsgViewModel.cs
@@ -1,6 +1,6 @@
 namespace ServiceLib.ViewModels;
 
-public class MsgViewModel : MyReactiveObject
+public partial class MsgViewModel : MyReactiveObject
 {
     private readonly ConcurrentQueue<string> _queueMsg = new();
     private volatile bool _lastMsgFilterNotAvailable;
@@ -8,10 +8,10 @@ public class MsgViewModel : MyReactiveObject
     public int NumMaxMsg { get; } = 500;
 
     [Reactive]
-    public string MsgFilter { get; set; }
+    public partial string MsgFilter { get; set; }
 
     [Reactive]
-    public bool AutoRefresh { get; set; }
+    public partial bool AutoRefresh { get; set; }
 
     public MsgViewModel(Func<EViewAction, object?, Task<bool>>? updateView)
     {

--- a/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
@@ -1,31 +1,31 @@
 namespace ServiceLib.ViewModels;
 
-public class OptionSettingViewModel : MyReactiveObject
+public partial class OptionSettingViewModel : MyReactiveObject
 {
     #region Core
 
-    [Reactive] public int localPort { get; set; }
-    [Reactive] public bool SecondLocalPortEnabled { get; set; }
-    [Reactive] public bool udpEnabled { get; set; }
-    [Reactive] public bool sniffingEnabled { get; set; }
+    [Reactive] public partial int localPort { get; set; }
+    [Reactive] public partial bool SecondLocalPortEnabled { get; set; }
+    [Reactive] public partial bool udpEnabled { get; set; }
+    [Reactive] public partial bool sniffingEnabled { get; set; }
     public IList<string> destOverride { get; set; }
-    [Reactive] public bool routeOnly { get; set; }
-    [Reactive] public bool allowLANConn { get; set; }
-    [Reactive] public bool newPort4LAN { get; set; }
-    [Reactive] public string user { get; set; }
-    [Reactive] public string pass { get; set; }
-    [Reactive] public bool muxEnabled { get; set; }
-    [Reactive] public bool logEnabled { get; set; }
-    [Reactive] public string loglevel { get; set; }
-    [Reactive] public bool defAllowInsecure { get; set; }
-    [Reactive] public string defFingerprint { get; set; }
-    [Reactive] public string defUserAgent { get; set; }
-    [Reactive] public string sendThrough { get; set; }
-    [Reactive] public string mux4SboxProtocol { get; set; }
-    [Reactive] public bool enableCacheFile4Sbox { get; set; }
-    [Reactive] public int? hyUpMbps { get; set; }
-    [Reactive] public int? hyDownMbps { get; set; }
-    [Reactive] public bool enableFragment { get; set; }
+    [Reactive] public partial bool routeOnly { get; set; }
+    [Reactive] public partial bool allowLANConn { get; set; }
+    [Reactive] public partial bool newPort4LAN { get; set; }
+    [Reactive] public partial string user { get; set; }
+    [Reactive] public partial string pass { get; set; }
+    [Reactive] public partial bool muxEnabled { get; set; }
+    [Reactive] public partial bool logEnabled { get; set; }
+    [Reactive] public partial string loglevel { get; set; }
+    [Reactive] public partial bool defAllowInsecure { get; set; }
+    [Reactive] public partial string defFingerprint { get; set; }
+    [Reactive] public partial string defUserAgent { get; set; }
+    [Reactive] public partial string sendThrough { get; set; }
+    [Reactive] public partial string mux4SboxProtocol { get; set; }
+    [Reactive] public partial bool enableCacheFile4Sbox { get; set; }
+    [Reactive] public partial int? hyUpMbps { get; set; }
+    [Reactive] public partial int? hyDownMbps { get; set; }
+    [Reactive] public partial bool enableFragment { get; set; }
 
     #endregion Core
 
@@ -43,75 +43,75 @@ public class OptionSettingViewModel : MyReactiveObject
 
     #region UI
 
-    [Reactive] public bool AutoRun { get; set; }
-    [Reactive] public bool EnableStatistics { get; set; }
-    [Reactive] public bool KeepOlderDedupl { get; set; }
-    [Reactive] public bool DisplayRealTimeSpeed { get; set; }
-    [Reactive] public bool EnableAutoAdjustMainLvColWidth { get; set; }
-    [Reactive] public bool AutoHideStartup { get; set; }
-    [Reactive] public bool Hide2TrayWhenClose { get; set; }
-    [Reactive] public bool MacOSShowInDock { get; set; }
-    [Reactive] public bool EnableDragDropSort { get; set; }
-    [Reactive] public bool DoubleClick2Activate { get; set; }
-    [Reactive] public int AutoUpdateInterval { get; set; }
-    [Reactive] public int TrayMenuServersLimit { get; set; }
-    [Reactive] public string CurrentFontFamily { get; set; }
-    [Reactive] public int SpeedTestTimeout { get; set; }
-    [Reactive] public string SpeedTestUrl { get; set; }
-    [Reactive] public string SpeedPingTestUrl { get; set; }
-    [Reactive] public string UdpTestTarget { get; set; }
-    [Reactive] public int MixedConcurrencyCount { get; set; }
-    [Reactive] public bool EnableHWA { get; set; }
-    [Reactive] public string SubConvertUrl { get; set; }
-    [Reactive] public int MainGirdOrientation { get; set; }
-    [Reactive] public string GeoFileSourceUrl { get; set; }
-    [Reactive] public string SrsFileSourceUrl { get; set; }
-    [Reactive] public string RoutingRulesSourceUrl { get; set; }
-    [Reactive] public string IPAPIUrl { get; set; }
+    [Reactive] public partial bool AutoRun { get; set; }
+    [Reactive] public partial bool EnableStatistics { get; set; }
+    [Reactive] public partial bool KeepOlderDedupl { get; set; }
+    [Reactive] public partial bool DisplayRealTimeSpeed { get; set; }
+    [Reactive] public partial bool EnableAutoAdjustMainLvColWidth { get; set; }
+    [Reactive] public partial bool AutoHideStartup { get; set; }
+    [Reactive] public partial bool Hide2TrayWhenClose { get; set; }
+    [Reactive] public partial bool MacOSShowInDock { get; set; }
+    [Reactive] public partial bool EnableDragDropSort { get; set; }
+    [Reactive] public partial bool DoubleClick2Activate { get; set; }
+    [Reactive] public partial int AutoUpdateInterval { get; set; }
+    [Reactive] public partial int TrayMenuServersLimit { get; set; }
+    [Reactive] public partial string CurrentFontFamily { get; set; }
+    [Reactive] public partial int SpeedTestTimeout { get; set; }
+    [Reactive] public partial string SpeedTestUrl { get; set; }
+    [Reactive] public partial string SpeedPingTestUrl { get; set; }
+    [Reactive] public partial string UdpTestTarget { get; set; }
+    [Reactive] public partial int MixedConcurrencyCount { get; set; }
+    [Reactive] public partial bool EnableHWA { get; set; }
+    [Reactive] public partial string SubConvertUrl { get; set; }
+    [Reactive] public partial int MainGirdOrientation { get; set; }
+    [Reactive] public partial string GeoFileSourceUrl { get; set; }
+    [Reactive] public partial string SrsFileSourceUrl { get; set; }
+    [Reactive] public partial string RoutingRulesSourceUrl { get; set; }
+    [Reactive] public partial string IPAPIUrl { get; set; }
 
     #endregion UI
 
     #region UI visibility
 
-    [Reactive] public bool BlIsWindows { get; set; }
-    [Reactive] public bool BlIsLinux { get; set; }
-    [Reactive] public bool BlIsIsMacOS { get; set; }
-    [Reactive] public bool BlIsNonWindows { get; set; }
+    [Reactive] public partial bool BlIsWindows { get; set; }
+    [Reactive] public partial bool BlIsLinux { get; set; }
+    [Reactive] public partial bool BlIsIsMacOS { get; set; }
+    [Reactive] public partial bool BlIsNonWindows { get; set; }
 
     #endregion UI visibility
 
     #region System proxy
 
-    [Reactive] public bool notProxyLocalAddress { get; set; }
-    [Reactive] public string systemProxyAdvancedProtocol { get; set; }
-    [Reactive] public string systemProxyExceptions { get; set; }
-    [Reactive] public string CustomSystemProxyPacPath { get; set; }
-    [Reactive] public string CustomSystemProxyScriptPath { get; set; }
+    [Reactive] public partial bool notProxyLocalAddress { get; set; }
+    [Reactive] public partial string systemProxyAdvancedProtocol { get; set; }
+    [Reactive] public partial string systemProxyExceptions { get; set; }
+    [Reactive] public partial string CustomSystemProxyPacPath { get; set; }
+    [Reactive] public partial string CustomSystemProxyScriptPath { get; set; }
 
     #endregion System proxy
 
     #region Tun mode
 
-    [Reactive] public bool TunAutoRoute { get; set; }
-    [Reactive] public bool TunStrictRoute { get; set; }
-    [Reactive] public string TunStack { get; set; }
-    [Reactive] public int TunMtu { get; set; }
-    [Reactive] public bool TunEnableIPv6Address { get; set; }
-    [Reactive] public string TunIcmpRouting { get; set; }
-    [Reactive] public bool TunEnableLegacyProtect { get; set; }
+    [Reactive] public partial bool TunAutoRoute { get; set; }
+    [Reactive] public partial bool TunStrictRoute { get; set; }
+    [Reactive] public partial string TunStack { get; set; }
+    [Reactive] public partial int TunMtu { get; set; }
+    [Reactive] public partial bool TunEnableIPv6Address { get; set; }
+    [Reactive] public partial string TunIcmpRouting { get; set; }
+    [Reactive] public partial bool TunEnableLegacyProtect { get; set; }
 
     #endregion Tun mode
 
     #region CoreType
 
-    [Reactive] public string CoreType1 { get; set; }
-    [Reactive] public string CoreType2 { get; set; }
-    [Reactive] public string CoreType3 { get; set; }
-    [Reactive] public string CoreType4 { get; set; }
-    [Reactive] public string CoreType5 { get; set; }
-    [Reactive] public string CoreType6 { get; set; }
-    [Reactive] public string CoreType7 { get; set; }
-    [Reactive] public string CoreType9 { get; set; }
+    [Reactive] public partial string CoreType1 { get; set; }
+    [Reactive] public partial string CoreType2 { get; set; }
+    [Reactive] public partial string CoreType3 { get; set; }
+    [Reactive] public partial string CoreType4 { get; set; }
+    [Reactive] public partial string CoreType5 { get; set; }
+    [Reactive] public partial string CoreType6 { get; set; }
+    [Reactive] public partial string CoreType7 { get; set; }
+    [Reactive] public partial string CoreType9 { get; set; }
 
     #endregion CoreType
 

--- a/v2rayN/ServiceLib/ViewModels/ProfilesSelectViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ProfilesSelectViewModel.cs
@@ -1,6 +1,6 @@
 namespace ServiceLib.ViewModels;
 
-public class ProfilesSelectViewModel : MyReactiveObject
+public partial class ProfilesSelectViewModel : MyReactiveObject
 {
     #region private prop
 
@@ -22,15 +22,15 @@ public class ProfilesSelectViewModel : MyReactiveObject
     public IObservableCollection<SubItem> SubItems { get; } = new ObservableCollectionExtended<SubItem>();
 
     [Reactive]
-    public ProfileItemModel SelectedProfile { get; set; }
+    public partial ProfileItemModel SelectedProfile { get; set; }
 
     public IList<ProfileItemModel> SelectedProfiles { get; set; }
 
     [Reactive]
-    public SubItem SelectedSub { get; set; }
+    public partial SubItem SelectedSub { get; set; }
 
     [Reactive]
-    public string ServerFilter { get; set; }
+    public partial string ServerFilter { get; set; }
 
     // Include/Exclude filter for ConfigType
     public List<EConfigType> FilterConfigTypes
@@ -39,7 +39,6 @@ public class ProfilesSelectViewModel : MyReactiveObject
         set => this.RaiseAndSetIfChanged(ref _filterConfigTypes, value);
     }
 
-    [Reactive]
     public bool FilterExclude
     {
         get => _filterExclude;

--- a/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
@@ -1,6 +1,6 @@
 namespace ServiceLib.ViewModels;
 
-public class ProfilesViewModel : MyReactiveObject
+public partial class ProfilesViewModel : MyReactiveObject
 {
     #region private prop
 
@@ -19,18 +19,18 @@ public class ProfilesViewModel : MyReactiveObject
     public IObservableCollection<SubItem> SubItems { get; } = new ObservableCollectionExtended<SubItem>();
 
     [Reactive]
-    public ProfileItemModel SelectedProfile { get; set; }
+    public partial ProfileItemModel SelectedProfile { get; set; }
 
     public IList<ProfileItemModel> SelectedProfiles { get; set; }
 
     [Reactive]
-    public SubItem SelectedSub { get; set; }
+    public partial SubItem SelectedSub { get; set; }
 
     [Reactive]
-    public SubItem SelectedMoveToGroup { get; set; }
+    public partial SubItem SelectedMoveToGroup { get; set; }
 
     [Reactive]
-    public string ServerFilter { get; set; }
+    public partial string ServerFilter { get; set; }
 
     #endregion ObservableCollection
 

--- a/v2rayN/ServiceLib/ViewModels/RoutingRuleDetailsViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/RoutingRuleDetailsViewModel.cs
@@ -1,27 +1,27 @@
 namespace ServiceLib.ViewModels;
 
-public class RoutingRuleDetailsViewModel : MyReactiveObject
+public partial class RoutingRuleDetailsViewModel : MyReactiveObject
 {
     public IList<string> ProtocolItems { get; set; }
     public IList<string> InboundTagItems { get; set; }
 
     [Reactive]
-    public RulesItem SelectedSource { get; set; }
+    public partial RulesItem SelectedSource { get; set; }
 
     [Reactive]
-    public string Domain { get; set; }
+    public partial string Domain { get; set; }
 
     [Reactive]
-    public string IP { get; set; }
+    public partial string IP { get; set; }
 
     [Reactive]
-    public string Process { get; set; }
+    public partial string Process { get; set; }
 
     [Reactive]
-    public string? RuleType { get; set; }
+    public partial string? RuleType { get; set; }
 
     [Reactive]
-    public bool AutoSort { get; set; }
+    public partial bool AutoSort { get; set; }
 
     public ReactiveCommand<Unit, Unit> SaveCmd { get; }
 

--- a/v2rayN/ServiceLib/ViewModels/RoutingRuleSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/RoutingRuleSettingViewModel.cs
@@ -1,16 +1,16 @@
 namespace ServiceLib.ViewModels;
 
-public class RoutingRuleSettingViewModel : MyReactiveObject
+public partial class RoutingRuleSettingViewModel : MyReactiveObject
 {
     private List<RulesItem> _rules;
 
     [Reactive]
-    public RoutingItem SelectedRouting { get; set; }
+    public partial RoutingItem SelectedRouting { get; set; }
 
     public IObservableCollection<RulesItemModel> RulesItems { get; } = new ObservableCollectionExtended<RulesItemModel>();
 
     [Reactive]
-    public RulesItemModel SelectedSource { get; set; }
+    public partial RulesItemModel SelectedSource { get; set; }
 
     public IList<RulesItemModel> SelectedSources { get; set; }
 

--- a/v2rayN/ServiceLib/ViewModels/RoutingSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/RoutingSettingViewModel.cs
@@ -1,21 +1,21 @@
 namespace ServiceLib.ViewModels;
 
-public class RoutingSettingViewModel : MyReactiveObject
+public partial class RoutingSettingViewModel : MyReactiveObject
 {
     #region Reactive
 
     public IObservableCollection<RoutingItemModel> RoutingItems { get; } = new ObservableCollectionExtended<RoutingItemModel>();
 
     [Reactive]
-    public RoutingItemModel SelectedSource { get; set; }
+    public partial RoutingItemModel SelectedSource { get; set; }
 
     public IList<RoutingItemModel> SelectedSources { get; set; }
 
     [Reactive]
-    public string DomainStrategy { get; set; }
+    public partial string DomainStrategy { get; set; }
 
     [Reactive]
-    public string DomainStrategy4Singbox { get; set; }
+    public partial string DomainStrategy4Singbox { get; set; }
 
     public ReactiveCommand<Unit, Unit> RoutingAdvancedAddCmd { get; }
     public ReactiveCommand<Unit, Unit> RoutingAdvancedRemoveCmd { get; }

--- a/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
@@ -1,6 +1,6 @@
 namespace ServiceLib.ViewModels;
 
-public class StatusBarViewModel : MyReactiveObject
+public partial class StatusBarViewModel : MyReactiveObject
 {
     private static readonly Lazy<StatusBarViewModel> _instance = new(() => new(null));
     public static StatusBarViewModel Instance => _instance.Value;
@@ -12,13 +12,13 @@ public class StatusBarViewModel : MyReactiveObject
     public IObservableCollection<ComboItem> Servers { get; } = new ObservableCollectionExtended<ComboItem>();
 
     [Reactive]
-    public RoutingItem SelectedRouting { get; set; }
+    public partial RoutingItem SelectedRouting { get; set; }
 
     [Reactive]
-    public ComboItem SelectedServer { get; set; }
+    public partial ComboItem SelectedServer { get; set; }
 
     [Reactive]
-    public bool BlServers { get; set; }
+    public partial bool BlServers { get; set; }
 
     #endregion ObservableCollection
 
@@ -34,16 +34,16 @@ public class StatusBarViewModel : MyReactiveObject
     #region System Proxy
 
     [Reactive]
-    public bool BlSystemProxyClear { get; set; }
+    public partial bool BlSystemProxyClear { get; set; }
 
     [Reactive]
-    public bool BlSystemProxySet { get; set; }
+    public partial bool BlSystemProxySet { get; set; }
 
     [Reactive]
-    public bool BlSystemProxyNothing { get; set; }
+    public partial bool BlSystemProxyNothing { get; set; }
 
     [Reactive]
-    public bool BlSystemProxyPac { get; set; }
+    public partial bool BlSystemProxyPac { get; set; }
 
     public ReactiveCommand<Unit, Unit> SystemProxyClearCmd { get; }
     public ReactiveCommand<Unit, Unit> SystemProxySetCmd { get; }
@@ -51,44 +51,44 @@ public class StatusBarViewModel : MyReactiveObject
     public ReactiveCommand<Unit, Unit> SystemProxyPacCmd { get; }
 
     [Reactive]
-    public bool BlRouting { get; set; }
+    public partial bool BlRouting { get; set; }
 
     [Reactive]
-    public int SystemProxySelected { get; set; }
+    public partial int SystemProxySelected { get; set; }
 
     [Reactive]
-    public bool BlSystemProxyPacVisible { get; set; }
+    public partial bool BlSystemProxyPacVisible { get; set; }
 
     #endregion System Proxy
 
     #region UI
 
     [Reactive]
-    public string InboundDisplay { get; set; }
+    public partial string InboundDisplay { get; set; }
 
     [Reactive]
-    public string InboundLanDisplay { get; set; }
+    public partial string InboundLanDisplay { get; set; }
 
     [Reactive]
-    public string RunningServerDisplay { get; set; }
+    public partial string RunningServerDisplay { get; set; }
 
     [Reactive]
-    public string RunningServerToolTipText { get; set; }
+    public partial string RunningServerToolTipText { get; set; }
 
     [Reactive]
-    public string RunningInfoDisplay { get; set; }
+    public partial string RunningInfoDisplay { get; set; }
 
     [Reactive]
-    public string SpeedProxyDisplay { get; set; }
+    public partial string SpeedProxyDisplay { get; set; }
 
     [Reactive]
-    public string SpeedDirectDisplay { get; set; }
+    public partial string SpeedDirectDisplay { get; set; }
 
     [Reactive]
-    public bool EnableTun { get; set; }
+    public partial bool EnableTun { get; set; }
 
     [Reactive]
-    public bool BlIsNonWindows { get; set; }
+    public partial bool BlIsNonWindows { get; set; }
 
     #endregion UI
 

--- a/v2rayN/ServiceLib/ViewModels/SubEditViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/SubEditViewModel.cs
@@ -1,9 +1,9 @@
 namespace ServiceLib.ViewModels;
 
-public class SubEditViewModel : MyReactiveObject
+public partial class SubEditViewModel : MyReactiveObject
 {
     [Reactive]
-    public SubItem SelectedSource { get; set; }
+    public partial SubItem SelectedSource { get; set; }
 
     public ReactiveCommand<Unit, Unit> SaveCmd { get; }
 

--- a/v2rayN/ServiceLib/ViewModels/SubSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/SubSettingViewModel.cs
@@ -1,11 +1,11 @@
 namespace ServiceLib.ViewModels;
 
-public class SubSettingViewModel : MyReactiveObject
+public partial class SubSettingViewModel : MyReactiveObject
 {
     public IObservableCollection<SubItem> SubItems { get; } = new ObservableCollectionExtended<SubItem>();
 
     [Reactive]
-    public SubItem SelectedSource { get; set; }
+    public partial SubItem SelectedSource { get; set; }
 
     public IList<SubItem> SelectedSources { get; set; }
 

--- a/v2rayN/v2rayN.Desktop/Common/QRCodeAvaloniaUtils.cs
+++ b/v2rayN/v2rayN.Desktop/Common/QRCodeAvaloniaUtils.cs
@@ -23,6 +23,7 @@ public partial class QRCodeAvaloniaUtils
         }
     }
 
+    [SupportedOSPlatform("windows")]
     private static byte[]? CaptureScreenWindows()
     {
         var hdcScreen = IntPtr.Zero;

--- a/v2rayN/v2rayN.Desktop/FodyWeavers.xml
+++ b/v2rayN/v2rayN.Desktop/FodyWeavers.xml
@@ -1,3 +1,0 @@
-﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <ReactiveUI />
-</Weavers>

--- a/v2rayN/v2rayN.Desktop/GlobalUsings.cs
+++ b/v2rayN/v2rayN.Desktop/GlobalUsings.cs
@@ -5,6 +5,7 @@ global using System.IO;
 global using System.Linq;
 global using System.Reactive.Disposables.Fluent;
 global using System.Reactive.Linq;
+global using System.Runtime.Versioning;
 global using System.Text;
 global using System.Threading;
 global using System.Threading.Tasks;

--- a/v2rayN/v2rayN.Desktop/GlobalUsings.cs
+++ b/v2rayN/v2rayN.Desktop/GlobalUsings.cs
@@ -23,7 +23,7 @@ global using Avalonia.Threading;
 global using DynamicData;
 global using ReactiveUI;
 global using ReactiveUI.Avalonia;
-global using ReactiveUI.Fody.Helpers;
+global using ReactiveUI.SourceGenerators;
 global using ServiceLib;
 global using ServiceLib.Base;
 global using ServiceLib.Common;

--- a/v2rayN/v2rayN.Desktop/Manager/HotkeyManager.cs
+++ b/v2rayN/v2rayN.Desktop/Manager/HotkeyManager.cs
@@ -8,6 +8,7 @@ public sealed class HotkeyManager
     private static readonly Lazy<HotkeyManager> _instance = new(() => new());
     public static HotkeyManager Instance = _instance.Value;
     private readonly Dictionary<int, EGlobalHotkey> _hotkeyTriggerDic = new();
+    [SupportedOSPlatform("windows")]
     private GlobalHotKeys.HotKeyManager? _hotKeyManager;
 
     private Config? _config;
@@ -16,6 +17,7 @@ public sealed class HotkeyManager
 
     public bool IsPause { get; set; } = false;
 
+    [SupportedOSPlatform("windows")]
     public void Init(Config config, Action<EGlobalHotkey> updateFunc)
     {
         _config = config;
@@ -26,9 +28,14 @@ public sealed class HotkeyManager
 
     public void Dispose()
     {
+        if (!Utils.IsWindows())
+        {
+            return;
+        }
         _hotKeyManager?.Dispose();
     }
 
+    [SupportedOSPlatform("windows")]
     private void Register()
     {
         if (_config.GlobalHotkeys.Any(t => t.KeyCode > 0) == false)

--- a/v2rayN/v2rayN.Desktop/ViewModels/ThemeSettingViewModel.cs
+++ b/v2rayN/v2rayN.Desktop/ViewModels/ThemeSettingViewModel.cs
@@ -5,13 +5,13 @@ using Semi.Avalonia;
 
 namespace v2rayN.Desktop.ViewModels;
 
-public class ThemeSettingViewModel : MyReactiveObject
+public partial class ThemeSettingViewModel : MyReactiveObject
 {
-    [Reactive] public string CurrentTheme { get; set; }
+    [Reactive] public partial string CurrentTheme { get; set; }
 
-    [Reactive] public int CurrentFontSize { get; set; }
+    [Reactive] public partial int CurrentFontSize { get; set; }
 
-    [Reactive] public string CurrentLanguage { get; set; }
+    [Reactive] public partial string CurrentLanguage { get; set; }
 
     public ThemeSettingViewModel()
     {

--- a/v2rayN/v2rayN.Desktop/Views/MessageBoxDialog.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MessageBoxDialog.axaml.cs
@@ -4,6 +4,11 @@ namespace v2rayN.Desktop.Views;
 
 public partial class MessageBoxDialog : Window
 {
+    public MessageBoxDialog()
+        : this(string.Empty, string.Empty)
+    {
+    }
+
     public MessageBoxDialog(string caption, string message)
     {
         InitializeComponent();

--- a/v2rayN/v2rayN.Desktop/v2rayN.Desktop.csproj
+++ b/v2rayN/v2rayN.Desktop/v2rayN.Desktop.csproj
@@ -26,9 +26,7 @@
 		<PackageReference Include="ReactiveUI">
 			<TreatAsUsed>true</TreatAsUsed>
 		</PackageReference>
-		<PackageReference Include="ReactiveUI.Fody">
-			<TreatAsUsed>true</TreatAsUsed>
-		</PackageReference>
+		<PackageReference Include="ReactiveUI.SourceGenerators" PrivateAssets="all" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/v2rayN/v2rayN/FodyWeavers.xml
+++ b/v2rayN/v2rayN/FodyWeavers.xml
@@ -1,3 +1,0 @@
-﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <ReactiveUI />
-</Weavers>

--- a/v2rayN/v2rayN/GlobalUsings.cs
+++ b/v2rayN/v2rayN/GlobalUsings.cs
@@ -21,7 +21,7 @@ global using DynamicData;
 global using DynamicData.Binding;
 global using ReactiveUI;
 global using ReactiveUI.Builder;
-global using ReactiveUI.Fody.Helpers;
+global using ReactiveUI.SourceGenerators;
 global using ServiceLib;
 global using ServiceLib.Base;
 global using ServiceLib.Common;

--- a/v2rayN/v2rayN/ViewModels/ThemeSettingViewModel.cs
+++ b/v2rayN/v2rayN/ViewModels/ThemeSettingViewModel.cs
@@ -5,7 +5,7 @@ using Microsoft.Win32;
 
 namespace v2rayN.ViewModels;
 
-public class ThemeSettingViewModel : MyReactiveObject
+public partial class ThemeSettingViewModel : MyReactiveObject
 {
     private readonly PaletteHelper _paletteHelper = new();
 
@@ -13,13 +13,13 @@ public class ThemeSettingViewModel : MyReactiveObject
     public IObservableCollection<Swatch> Swatches => _swatches;
 
     [Reactive]
-    public Swatch SelectedSwatch { get; set; }
+    public partial Swatch SelectedSwatch { get; set; }
 
-    [Reactive] public string CurrentTheme { get; set; }
+    [Reactive] public partial string CurrentTheme { get; set; }
 
-    [Reactive] public int CurrentFontSize { get; set; }
+    [Reactive] public partial int CurrentFontSize { get; set; }
 
-    [Reactive] public string CurrentLanguage { get; set; }
+    [Reactive] public partial string CurrentLanguage { get; set; }
 
     public ThemeSettingViewModel()
     {

--- a/v2rayN/v2rayN/app.manifest
+++ b/v2rayN/v2rayN/app.manifest
@@ -1,12 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-  <asmv3:application>
-    <asmv3:windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
-    </asmv3:windowsSettings>
-  </asmv3:application>
-	
 	<!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
 	<dependency>
 		<dependentAssembly>

--- a/v2rayN/v2rayN/v2rayN.csproj
+++ b/v2rayN/v2rayN/v2rayN.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+		<TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
 		<GenerateSatelliteAssembliesForCore>true</GenerateSatelliteAssembliesForCore>
 		<UseWPF>true</UseWPF>
 		<ApplicationIcon>Resources\v2rayN.ico</ApplicationIcon>

--- a/v2rayN/v2rayN/v2rayN.csproj
+++ b/v2rayN/v2rayN/v2rayN.csproj
@@ -7,6 +7,7 @@
 		<UseWPF>true</UseWPF>
 		<ApplicationIcon>Resources\v2rayN.ico</ApplicationIcon>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
+		<ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
 		<SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>

--- a/v2rayN/v2rayN/v2rayN.csproj
+++ b/v2rayN/v2rayN/v2rayN.csproj
@@ -15,9 +15,7 @@
 	<ItemGroup>
 		<PackageReference Include="MaterialDesignThemes" />
 		<PackageReference Include="H.NotifyIcon.Wpf" />
-		<PackageReference Include="ReactiveUI.Fody">
-			<TreatAsUsed>true</TreatAsUsed>
-		</PackageReference>
+		<PackageReference Include="ReactiveUI.SourceGenerators" PrivateAssets="all" />
 		<PackageReference Include="ReactiveUI.WPF" />
 	</ItemGroup>
 


### PR DESCRIPTION
## Modernize .NET 10 dependency stack

Closes #9179.
Closes #9211.

This PR consolidates the previously stacked .NET 10 work into a single reviewable change. It builds on top of [#9179 by @DHR60](https://github.com/2dust/v2rayN/pull/9179) (the initial *Update dotnet to 10* commit, included as-is with its original authorship preserved) and on my earlier follow-up [#9211](https://github.com/2dust/v2rayN/pull/9211) (*Remove NoWarn and fix .NET 10 build warnings*), then extends both with the dependency stack changes that the .NET 10 migration enables. It upgrades the project to **.NET 10** and modernizes the dependency stack to the latest stable versions of all NuGet packages compatible with the **Avalonia 11.x** branch. Avalonia 12 migration and the `GlobalHotKeys` submodule are explicitly out of scope and will be handled in follow-up PRs.

Once this PR is merged, both #9179 and #9211 can be closed as superseded — all of their changes are part of this PR (commit `Update dotnet to 10` retains @DHR60 as its author).

---

### Target framework

- Bump `<TargetFramework>` from `net8.0` to `net10.0` across all projects.
- Bump the WPF project to `net10.0-windows10.0.19041.0`.
- Drop the `NoWarn` properties and fix the underlying .NET 10 warnings instead of suppressing them.

### Reactive stack

- Migrate from `ReactiveUI.Fody` to `ReactiveUI.SourceGenerators` **2.6.30** (39 files updated to the new `[Reactive] partial` C# 13 syntax).
- Bump `ReactiveUI` to **23.2.19**, `ReactiveUI.WPF` to **23.2.19**, `ReactiveUI.Avalonia` to **11.4.12**.
- Remove the now-redundant `FodyWeavers.xml` files in three projects.

### SQLite stack

- Replace `sqlite-net-pcl` (which transitively pulls `bundle_green`) with `sqlite-net-base` **1.9.172** + `SQLitePCLRaw.config.e_sqlite3` **3.0.2** + `SourceGear.sqlite3` **3.50.4.5**. This pair is the option Eric Sink explicitly recommends in the [SQLitePCL.raw v3 migration guide](https://github.com/ericsink/SQLitePCL.raw/blob/main/v3.md) when explicit control over the bundled SQLite version is desired.
- Initialize the native provider explicitly via `SQLitePCL.Batteries_V2.Init()` in both `SqliteHelper`'s static constructor (existing) and `AppManager.InitApp()` (new) for defense-in-depth — the call is idempotent, and having it in two places ensures any future code path which reaches the database without going through `SqliteHelper` (background services, tests, future utilities) still finds an initialized native provider.
- Synchronize the `linux-riscv64` native build script (`package-rhel-riscv.sh`) with the `SourceGear.sqlite3`-shipped SQLite version (3.50.4) and parameterize it via env-overridable `SQLITE_AMALGAMATION_*` variables, so the next bump can be coordinated across `Directory.Packages.props` and the script in two places without drift.

### Other dependency updates

- `Tmds.DBus.Protocol` **0.93.0** (transitive pin)
- `xunit.v3` invariant culture configuration
- `xunit.runner.visualstudio` **3.1.5**
- `Microsoft.NET.Test.Sdk` **18.5.1**
- `AwesomeAssertions` **9.4.0**
- All other NuGet packages bumped to latest stable for the Avalonia 11.x branch.

### Platform-specific code organization

- Add `[SupportedOSPlatformGuard("linux")]` and `[SupportedOSPlatformGuard("macos")]` to `Utils.IsLinux()` / `Utils.IsMacOS()`, mirroring the existing annotation on `Utils.IsWindows()`. The analyzer can now narrow the platform context inside Linux/macOS guards in the same way it already does for Windows.
- Annotate Linux- and macOS-specific helpers in `AutoStartupHandler.cs`, `ProxySettingLinux.cs`, `ProxySettingOSX.cs` with `[SupportedOSPlatform("linux")]` / `[SupportedOSPlatform("macos")]` for symmetry with the Windows-only code paths.
- Add a clarifying comment to the field-level `[SupportedOSPlatform("windows")]` on `CoreManager._processJob` explaining that the attribute narrows the analyzer's platform context and that runtime safety is preserved by the `IsWindows()` guard inside `AddProcessJob`.
- Cross-platform refactor of `Utils.GetSystemHosts()`: previously a Windows-only no-op on Linux/macOS even when `UseSystemHosts=true` was selected; now reads `/etc/hosts` on Linux and macOS too. **Behavior on Windows is unchanged** (still merges `hosts` and `hosts.ics`).

---

### Verification

| Check | Result |
|---|---|
| `dotnet restore` + `dotnet build v2rayN.sln -c Release` | ✅ 0 errors, 1 warning (`CS8625` in `GlobalHotKeys` submodule, pre-existing, out of scope) |
| `dotnet test ServiceLib.Tests` | ✅ **41 / 41 passed** |
| `dotnet publish v2rayN.Desktop.csproj -r linux-x64 -p:SelfContained=true` | ✅ succeeds, no new warnings |
| `dotnet publish v2rayN.Desktop.csproj -r osx-x64 -p:SelfContained=true` | ✅ succeeds, no new warnings |
| `dotnet publish v2rayN.csproj -r win-x64 -p:SelfContained=true` | ✅ succeeds, no new warnings |
| `dotnet list package --outdated` against `v2rayN.sln` | ✅ Only the eight Avalonia 12.x packages appear; none are eligible while this PR stays on the Avalonia 11.x branch |

<details>
<summary><b>Outdated packages output</b> (click to expand)</summary>

```
Project "v2rayN.Desktop" has the following updates to its packages
   [net10.0]:
   Top-level Package                Requested   Resolved   Latest
   > Avalonia.AvaloniaEdit          11.4.1      11.4.1     12.0.0
   > Avalonia.Controls.DataGrid     11.3.13     11.3.13    12.0.0
   > Avalonia.Desktop               11.3.14     11.3.14    12.0.2
   > DialogHost.Avalonia            0.11.0      0.11.0     0.12.1
   > ReactiveUI.Avalonia            11.4.12     11.4.12    12.0.1
   > Semi.Avalonia                  11.3.14     11.3.14    12.0.1
   > Semi.Avalonia.AvaloniaEdit     11.2.0.2    11.2.0.2   12.0.0
   > Semi.Avalonia.DataGrid         11.3.7.3    11.3.7.3   12.0.0
```

All eight require Avalonia 12.x and are deferred to the Avalonia 12 migration PR.
</details>

---

### Out of scope

Deferred to follow-up PRs:

- Migration to **Avalonia 12.x** (and the dependent `DialogHost.Avalonia` 0.12+, `Semi.Avalonia` 12.x, `ReactiveUI.Avalonia` 12.0.1, `Avalonia.AvaloniaEdit` 12.0.0).
- Updates to the **`GlobalHotKeys`** submodule.
