### PR TITLE
fix: hide CMD window when launching upgrade process (AmazTool)

### DIFF
--- a/v2rayN/ServiceLib/Common/ProcUtils.cs
+++ b/v2rayN/ServiceLib/Common/ProcUtils.cs
@@ -33,7 +33,8 @@ public static class ProcUtils
                     UseShellExecute = true,
                     FileName = fileName,
                     Arguments = arguments,
-                    WorkingDirectory = dir ?? string.Empty
+                    WorkingDirectory = dir ?? string.Empty,
+                    WindowStyle = ProcessWindowStyle.Hidden
                 }
             };
             _ = proc.Start();
@@ -57,6 +58,7 @@ public static class ProcUtils
                 WorkingDirectory = Utils.StartupPath(),
                 FileName = Utils.GetExePath().AppendQuotes(),
                 Verb = blAdmin ? "runas" : null,
+                WindowStyle = ProcessWindowStyle.Hidden
             };
             return Process.Start(startInfo) != null;
         }


### PR DESCRIPTION
Add WindowStyle = ProcessWindowStyle.Hidden to ProcUtils.ProcessStart and ProcUtils.RebootAsAdmin to prevent the black console window from popping up during automatic updates and restarts, which is disturbing and annoying.

Fixes #8240