### PR TITLE
fix: Allow TUN mode to auto-enable for NOPASSWD sudo users on Linux

### DIFF
--- a/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
@@ -503,7 +503,27 @@ public class StatusBarViewModel : MyReactiveObject
         }
         else if (Utils.IsLinux())
         {
-            return AppManager.Instance.LinuxSudoPwd.IsNotEmpty();
+            if (AppManager.Instance.LinuxSudoPwd.IsNotEmpty())
+                return true;
+            // Check if sudo is configured with NOPASSWD
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "/usr/bin/sudo",
+                    Arguments = "-n true",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                };
+                using var proc = Process.Start(psi);
+                proc?.WaitForExit();
+                return proc?.ExitCode == 0;
+            }
+            catch
+            {
+                return false;
+            }
         }
         else if (Utils.IsMacOS())
         {


### PR DESCRIPTION
## Problem

Previously, `AllowEnableTun()` only checked if `LinuxSudoPwd` was non-empty, which is always null on startup. This caused the password dialog to always appear when enabling TUN mode, even for users with NOPASSWD sudo configured.

## Solution

Add a check using `sudo -n true` to detect NOPASSWD configuration. This allows users with NOPASSWD sudo to auto-enable TUN mode without being prompted for a password on each startup, matching the behavior of Windows (which auto-enables when run as administrator).

## Changes

- Modified `ServiceLib/ViewModels/StatusBarViewModel.cs` - `AllowEnableTun()` method
- +21/-1 lines, single method change
- No breaking changes - existing behavior preserved for non-NOPASSWD users

Related discussions: #7116, #8069