### PR TITLE
Fix desktop bind interface setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,48 @@
-# v2rayN
+<div align="center">
 
-A GUI client for Windows, Linux and macOS, support [Xray](https://github.com/XTLS/Xray-core)
-and [sing-box](https://github.com/SagerNet/sing-box)
-and [others](https://github.com/2dust/v2rayN/wiki/List-of-supported-cores)
+# ⚡ v2rayN - Unofficial Branch
 
-[![GitHub commit activity](https://img.shields.io/github/commit-activity/m/2dust/v2rayN)](https://github.com/2dust/v2rayN/commits/master)
-[![CodeFactor](https://www.codefactor.io/repository/github/2dust/v2rayn/badge)](https://www.codefactor.io/repository/github/2dust/v2rayn)
-[![GitHub Releases](https://img.shields.io/github/downloads/2dust/v2rayN/latest/total?logo=github)](https://github.com/2dust/v2rayN/releases)
-[![Chat on Telegram](https://img.shields.io/badge/Chat%20on-Telegram-brightgreen.svg)](https://t.me/v2rayn)
+### Custom build / experimental branch of v2rayN
 
-## How to use
+![GitHub repo size](https://img.shields.io/github/repo-size/vinnythefemboy/v2rayN?style=for-the-badge)
+![GitHub last commit](https://img.shields.io/github/last-commit/vinnythefemboy/v2rayN/V2rayN-Branch?style=for-the-badge)
+![License](https://img.shields.io/github/license/vinnythefemboy/v2rayN?style=for-the-badge)
 
-Read the [Wiki](https://github.com/2dust/v2rayN/wiki) for details.
+</div>
 
-## Telegram Channel
+---
 
-[github_2dust](https://t.me/github_2dust)
+## 🧪 What is this?
+
+This is an **unofficial branch** of `v2rayN`.
+
+It is not the official release, not the upstream stable build, and not pretending to be.  
+This branch exists for custom changes, experiments, tweaks, builds, fixes, and whatever else needs testing before it becomes useful.
+
+Use it like a lab build, not a polished product.
+
+---
+
+## ⚠️ Disclaimer
+
+This branch may include:
+
+- unfinished changes
+- broken features
+- random experiments
+- custom patches
+- unstable builds
+- things that worked once and then decided not to
+
+No promises. No warranty. No corporate nonsense.
+
+If something breaks, check the code, open an issue, or go back to the official version.
+
+---
+
+## 🚀 Based On
+
+This project is based on the original:
+
+```txt
+2dust/v2rayN

--- a/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
+++ b/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
@@ -29,6 +29,29 @@ public class CoreConfigSingboxServiceTests
     }
 
     [Fact]
+    public void GenerateClientConfigContent_BindInterface_ShouldUseDialBindInterface()
+    {
+        var config = CoreConfigTestFactory.CreateConfig(ECoreType.sing_box);
+        config.CoreBasicItem.BindInterface = "eth0";
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+
+        var node = CoreConfigTestFactory.CreateVmessNode(ECoreType.sing_box);
+        var context = CoreConfigTestFactory.CreateContext(config, node, ECoreType.sing_box) with
+        {
+            IsTunEnabled = true,
+        };
+
+        var result = new CoreConfigSingboxService(context).GenerateClientConfigContent();
+
+        result.Success.Should().BeTrue($"ret msg: {result.Msg}");
+        var cfg = JsonUtils.Deserialize<SingboxConfig>(result.Data!.ToString())!;
+        var proxy = cfg.outbounds.First(o => o.tag == Global.ProxyTag);
+
+        proxy.bind_interface.Should().Be("eth0");
+        proxy.detour.Should().BeNullOrEmpty();
+    }
+
+    [Fact]
     public void GenerateClientConfigContent_PolicyGroup_ShouldExpandChildrenAndBuildSelector()
     {
         var config = CoreConfigTestFactory.CreateConfig(ECoreType.sing_box);

--- a/v2rayN/ServiceLib/Models/ConfigItems.cs
+++ b/v2rayN/ServiceLib/Models/ConfigItems.cs
@@ -83,6 +83,7 @@ public class MsgUIItem
 {
     public string? MainMsgFilter { get; set; }
     public bool? AutoRefresh { get; set; }
+    public bool? AutoScrollToEnd { get; set; }
 }
 
 [Serializable]

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxConfigTemplateService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxConfigTemplateService.cs
@@ -72,7 +72,7 @@ public partial class CoreConfigSingboxService
         }
         foreach (var outbound in _coreConfig.outbounds ?? [])
         {
-            outbound.detour = ShouldBindNet(outbound) ? bindInterface : null;
+            outbound.bind_interface = ShouldBindNet(outbound) ? bindInterface : null;
         }
     }
 

--- a/v2rayN/ServiceLib/ViewModels/MsgViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MsgViewModel.cs
@@ -13,21 +13,30 @@ public class MsgViewModel : MyReactiveObject
     [Reactive]
     public bool AutoRefresh { get; set; }
 
+    [Reactive]
+    public bool AutoScrollToEnd { get; set; }
+
     public MsgViewModel(Func<EViewAction, object?, Task<bool>>? updateView)
     {
         _config = AppManager.Instance.Config;
         _updateView = updateView;
         MsgFilter = _config.MsgUIItem.MainMsgFilter ?? string.Empty;
         AutoRefresh = _config.MsgUIItem.AutoRefresh ?? true;
+        AutoScrollToEnd = _config.MsgUIItem.AutoScrollToEnd ?? true;
 
         this.WhenAnyValue(
            x => x.MsgFilter)
                .Subscribe(c => DoMsgFilter());
 
         this.WhenAnyValue(
-          x => x.AutoRefresh,
-          y => y == true)
-              .Subscribe(c => _config.MsgUIItem.AutoRefresh = AutoRefresh);
+           x => x.AutoRefresh,
+           y => y == true)
+               .Subscribe(c => _config.MsgUIItem.AutoRefresh = AutoRefresh);
+
+        this.WhenAnyValue(
+           x => x.AutoScrollToEnd,
+           y => y == true)
+               .Subscribe(c => _config.MsgUIItem.AutoScrollToEnd = AutoScrollToEnd);
 
         AppEvents.SendMsgViewRequested
          .AsObservable()

--- a/v2rayN/v2rayN.Desktop/Views/MsgView.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MsgView.axaml.cs
@@ -16,6 +16,7 @@ public partial class MsgView : ReactiveUserControl<MsgViewModel>
         {
             this.Bind(ViewModel, vm => vm.MsgFilter, v => v.cmbMsgFilter.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.AutoRefresh, v => v.togAutoRefresh.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.AutoScrollToEnd, v => v.togScrollToEnd.IsChecked).DisposeWith(disposables);
         });
 
         TextEditorKeywordHighlighter.Attach(txtMsg, Global.LogLevelColors.ToDictionary(
@@ -55,7 +56,7 @@ public partial class MsgView : ReactiveUserControl<MsgViewModel>
         }
 
         txtMsg.AppendText(msg.ToString());
-        if (togScrollToEnd.IsChecked ?? true)
+        if (ViewModel?.AutoScrollToEnd == true)
         {
             txtMsg.ScrollToEnd();
         }

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
@@ -77,6 +77,7 @@ public partial class OptionSettingWindow : WindowBase<OptionSettingViewModel>
             this.Bind(ViewModel, vm => vm.defAllowInsecure, v => v.togdefAllowInsecure.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.defFingerprint, v => v.cmbdefFingerprint.SelectedValue).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.defUserAgent, v => v.cmbdefUserAgent.SelectedValue).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.bindInterface, v => v.txtbindInterface.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.sendThrough, v => v.txtsendThrough.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.mux4SboxProtocol, v => v.cmbmux4SboxProtocol.SelectedValue).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.enableCacheFile4Sbox, v => v.togenableCacheFile4Sbox.IsChecked).DisposeWith(disposables);

--- a/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml.cs
@@ -8,6 +8,7 @@ public partial class ProfilesView : ReactiveUserControl<ProfilesViewModel>
     private static Config _config;
     private Window? _window;
     private static readonly string _tag = "ProfilesView";
+    private const int MinRestoredColumnWidth = 20;
 
     public ProfilesView()
     {
@@ -420,9 +421,13 @@ public partial class ProfilesView : ReactiveUserControl<ProfilesViewModel>
                         {
                             item2.IsVisible = false;
                         }
-                        else
+                        else if (item.Width >= MinRestoredColumnWidth)
                         {
                             item2.Width = new DataGridLength(item.Width, DataGridLengthUnitType.Pixel);
+                            item2.DisplayIndex = displayIndex++;
+                        }
+                        else
+                        {
                             item2.DisplayIndex = displayIndex++;
                         }
                         if (item.Name.ToLower().StartsWith("to"))

--- a/v2rayN/v2rayN/Views/MsgView.xaml.cs
+++ b/v2rayN/v2rayN/Views/MsgView.xaml.cs
@@ -12,6 +12,7 @@ public partial class MsgView
         {
             this.Bind(ViewModel, vm => vm.MsgFilter, v => v.cmbMsgFilter.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.AutoRefresh, v => v.togAutoRefresh.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.AutoScrollToEnd, v => v.togScrollToEnd.IsChecked).DisposeWith(disposables);
         });
 
         btnCopy.Click += menuMsgViewCopyAll_Click;
@@ -51,7 +52,7 @@ public partial class MsgView
         }
 
         txtMsg.AppendText(msg.ToString());
-        if (togScrollToEnd.IsChecked ?? true)
+        if (ViewModel?.AutoScrollToEnd == true)
         {
             txtMsg.ScrollToEnd();
         }


### PR DESCRIPTION
Bind the Avalonia Bind Interface textbox to OptionSettingViewModel.bindInterface                                                                                                               
Keep v2rayN.Desktop behavior aligned with the WPF settings window                                                                                                                                                                      
Allow the bind interface setting to be saved from the desktop UI