### PR TITLE
Fix bind interface handling in desktop and sing-box

### DIFF
--- a/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
+++ b/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using ServiceLib.Common;
 using ServiceLib.Enums;
+using ServiceLib.Manager;
 using ServiceLib.Models;
 using ServiceLib.Services.CoreConfig;
 using Xunit;
@@ -26,6 +27,31 @@ public class CoreConfigSingboxServiceTests
         singboxConfig.Should().NotBeNull();
         singboxConfig!.outbounds.Should().Contain(o => o.tag == Global.ProxyTag && o.type == "socks");
         singboxConfig.inbounds.Should().Contain(i => i.type == nameof(EInboundProtocol.mixed));
+    }
+
+    [Fact]
+    public void GenerateClientConfigContent_TunWithLoopbackPreSocks_ShouldKeepMixedInbound()
+    {
+        var config = CoreConfigTestFactory.CreateConfig(ECoreType.sing_box);
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+        var node = CoreConfigTestFactory.CreateSocksNode(ECoreType.sing_box);
+        node.Address = Global.Loopback;
+        node.Port = 1080;
+        var context = CoreConfigTestFactory.CreateContext(config, node, ECoreType.sing_box) with
+        {
+            IsTunEnabled = true,
+        };
+
+        var result = new CoreConfigSingboxService(context).GenerateClientConfigContent();
+
+        result.Success.Should().BeTrue($"ret msg: {result.Msg}");
+        var cfg = JsonUtils.Deserialize<SingboxConfig>(result.Data!.ToString())!;
+
+        cfg.inbounds.Should().Contain(i =>
+            i.type == nameof(EInboundProtocol.mixed)
+            && i.listen == Global.Loopback
+            && i.listen_port == AppManager.Instance.GetLocalPort(EInboundProtocol.socks));
+        cfg.inbounds.Should().Contain(i => i.type == "tun");
     }
 
     [Fact]

--- a/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
+++ b/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
@@ -29,6 +29,29 @@ public class CoreConfigSingboxServiceTests
     }
 
     [Fact]
+    public void GenerateClientConfigContent_BindInterface_ShouldUseDialBindInterface()
+    {
+        var config = CoreConfigTestFactory.CreateConfig(ECoreType.sing_box);
+        config.CoreBasicItem.BindInterface = "eth0";
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+
+        var node = CoreConfigTestFactory.CreateVmessNode(ECoreType.sing_box);
+        var context = CoreConfigTestFactory.CreateContext(config, node, ECoreType.sing_box) with
+        {
+            IsTunEnabled = true,
+        };
+
+        var result = new CoreConfigSingboxService(context).GenerateClientConfigContent();
+
+        result.Success.Should().BeTrue($"ret msg: {result.Msg}");
+        var cfg = JsonUtils.Deserialize<SingboxConfig>(result.Data!.ToString())!;
+        var proxy = cfg.outbounds.First(o => o.tag == Global.ProxyTag);
+
+        proxy.bind_interface.Should().Be("eth0");
+        proxy.detour.Should().BeNullOrEmpty();
+    }
+
+    [Fact]
     public void GenerateClientConfigContent_PolicyGroup_ShouldExpandChildrenAndBuildSelector()
     {
         var config = CoreConfigTestFactory.CreateConfig(ECoreType.sing_box);

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxConfigTemplateService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxConfigTemplateService.cs
@@ -72,7 +72,7 @@ public partial class CoreConfigSingboxService
         }
         foreach (var outbound in _coreConfig.outbounds ?? [])
         {
-            outbound.detour = ShouldBindNet(outbound) ? bindInterface : null;
+            outbound.bind_interface = ShouldBindNet(outbound) ? bindInterface : null;
         }
     }
 

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
@@ -77,6 +77,7 @@ public partial class OptionSettingWindow : WindowBase<OptionSettingViewModel>
             this.Bind(ViewModel, vm => vm.defAllowInsecure, v => v.togdefAllowInsecure.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.defFingerprint, v => v.cmbdefFingerprint.SelectedValue).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.defUserAgent, v => v.cmbdefUserAgent.SelectedValue).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.bindInterface, v => v.txtbindInterface.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.sendThrough, v => v.txtsendThrough.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.mux4SboxProtocol, v => v.cmbmux4SboxProtocol.SelectedValue).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.enableCacheFile4Sbox, v => v.togenableCacheFile4Sbox.IsChecked).DisposeWith(disposables);


### PR DESCRIPTION
## Summary
- Bind the Avalonia desktop Bind Interface textbox so the setting is saved from the UI.
- Write sing-box Bind Interface values to the correct `bind_interface` dial field instead of `detour`.
- Add a regression test for sing-box bind interface config generation.

## Test
- `dotnet test ./ServiceLib.Tests -c Debug`
- `dotnet build ./v2rayN.Desktop/v2rayN.Desktop.csproj -c Debug`