### PR TITLE
Fix sing-box TUN custom config inbound

### DIFF
--- a/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
+++ b/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using ServiceLib.Common;
 using ServiceLib.Enums;
+using ServiceLib.Manager;
 using ServiceLib.Models;
 using ServiceLib.Services.CoreConfig;
 using Xunit;
@@ -26,6 +27,31 @@ public class CoreConfigSingboxServiceTests
         singboxConfig.Should().NotBeNull();
         singboxConfig!.outbounds.Should().Contain(o => o.tag == Global.ProxyTag && o.type == "socks");
         singboxConfig.inbounds.Should().Contain(i => i.type == nameof(EInboundProtocol.mixed));
+    }
+
+    [Fact]
+    public void GenerateClientConfigContent_TunWithLoopbackPreSocks_ShouldKeepMixedInbound()
+    {
+        var config = CoreConfigTestFactory.CreateConfig(ECoreType.sing_box);
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+        var node = CoreConfigTestFactory.CreateSocksNode(ECoreType.sing_box);
+        node.Address = Global.Loopback;
+        node.Port = 1080;
+        var context = CoreConfigTestFactory.CreateContext(config, node, ECoreType.sing_box) with
+        {
+            IsTunEnabled = true,
+        };
+
+        var result = new CoreConfigSingboxService(context).GenerateClientConfigContent();
+
+        result.Success.Should().BeTrue($"ret msg: {result.Msg}");
+        var cfg = JsonUtils.Deserialize<SingboxConfig>(result.Data!.ToString())!;
+
+        cfg.inbounds.Should().Contain(i =>
+            i.type == nameof(EInboundProtocol.mixed)
+            && i.listen == Global.Loopback
+            && i.listen_port == AppManager.Instance.GetLocalPort(EInboundProtocol.socks));
+        cfg.inbounds.Should().Contain(i => i.type == "tun");
     }
 
     [Fact]

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxInboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxInboundService.cs
@@ -8,10 +8,10 @@ public partial class CoreConfigSingboxService
         {
             var listen = "0.0.0.0";
             var listenPort = AppManager.Instance.GetLocalPort(EInboundProtocol.socks);
+            var isUsingLocalMixedPort = _node.Address == Global.Loopback && _node.Port == listenPort;
             _coreConfig.inbounds = [];
 
-            if (!context.IsTunEnabled
-                || (context.IsTunEnabled && _node.Address != Global.Loopback && _node.Port != listenPort))
+            if (!context.IsTunEnabled || !isUsingLocalMixedPort)
             {
                 var inbound = new Inbound4Sbox()
                 {


### PR DESCRIPTION
## Summary
- Keep the local mixed inbound when sing-box TUN uses a custom loopback pre-SOCKS port that does not collide with the app mixed port.
- Add a regression test covering loopback pre-SOCKS plus TUN so 127.0.0.1:10808 remains available.

## Tests
- dotnet test ./ServiceLib.Tests

Fixes #9248