### PR TITLE
i18n(ru): translate two missing Russian strings (PreSharedKey, Export menu)

### DIFF
--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1726,9 +1726,9 @@
     <value>Для среды с несколькими сетевыми интерфейсами укажите имя интерфейса для привязки. Работает только в Windows и режиме TUN</value>
   </data>
   <data name="TbPreSharedKey" xml:space="preserve">
-    <value>PreSharedKey</value>
+    <value>Общий ключ (PSK)</value>
   </data>
   <data name="menuExport2InnerUri" xml:space="preserve">
-    <value>Export v2rayN Internal Share Link to Clipboard</value>
+    <value>Экспорт внутренней ссылки v2rayN в буфер обмена</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary

Two strings in `ResUI.ru.resx` were surfacing in English on a Russian UI culture — the WireGuard pre-shared-key label was left as the raw identifier `PreSharedKey`, and the recently added `Export v2rayN Internal Share Link to Clipboard` context-menu item was committed without a Russian translation.

This PR fixes both. No other strings are touched, no other files are modified.

## Diff

```diff
   <data name="TbPreSharedKey" xml:space="preserve">
-    <value>PreSharedKey</value>
+    <value>Общий ключ (PSK)</value>
   </data>
   <data name="menuExport2InnerUri" xml:space="preserve">
-    <value>Export v2rayN Internal Share Link to Clipboard</value>
+    <value>Экспорт внутренней ссылки v2rayN в буфер обмена</value>
   </data>
```

## Rationale

### 1. `TbPreSharedKey` → "Общий ключ (PSK)"

This label belongs to the WireGuard configuration form. The sibling WireGuard fields in the same file are already translated:

| Key | English | Russian (current `master`) |
| --- | --- | --- |
| `TbPublicKey` | Public Key | Открытый ключ |
| `TbPrivateKey` | Private Key | Приватный ключ |
| `TbPreSharedKey` | PreSharedKey | **PreSharedKey** ← inconsistent |

Leaving `TbPreSharedKey` as the raw identifier was inconsistent with the other two and broke the Russian form's look. `Общий ключ` is the wording used by every major Russian-localized network UI for this concept (NetworkManager, MikroTik RouterOS, OpenVPN GUI clients, etc.), and the `(PSK)` suffix preserves the standard cryptographic abbreviation so users who recognize PSK from the WireGuard documentation immediately know which field this is.

### 2. `menuExport2InnerUri` → "Экспорт внутренней ссылки v2rayN в буфер обмена"

This context-menu item was added recently and the Russian resource kept the English string verbatim. The translation follows the convention of the existing sibling clipboard-export items:

- `menuExport2ShareUrl` → "Копировать ссылку общего доступа в буфер обмена"
- `menuExport2ShareUrlBase64` → "Экспорт ссылок в формате Base64 в буфер обмена"
- `menuExport2ClientConfigClipboard` → "Экспортировать полную конфигурацию в буфер обмена"

The phrase "внутренней ссылки v2rayN" preserves the `Internal` qualifier from the source, because this share-link format is specific to v2rayN's own importer and is not interchangeable with the standard VMess/VLESS/Trojan/SS/Hysteria2/etc. URI schemes — so the "internal" distinction is important for the user to understand what the menu item actually does.

## Scope and verification

- **Diff scope:** only `v2rayN/ServiceLib/Resx/ResUI.ru.resx`, only the two `<value>` elements above. The `.resx` XML schema headers and all other keys are untouched.
- **Audit:** I diffed `ResUI.ru.resx` against `ResUI.resx` key-by-key. Every other key is present and translated; these were the only two strings still surfacing in English on a Russian UI culture.
- **Build:** `dotnet build v2rayN/v2rayN.sln -c Release` passes with 0 errors and 0 warnings.
- **No code or behavior change** — the runtime reads the same keys; only the Russian satellite assembly now returns Russian text for these two resources.
