### PR TITLE
Fix JSON parser handling of malformed config plus signs

### DIFF
--- a/v2rayN/ServiceLib/Common/JsonUtils.cs
+++ b/v2rayN/ServiceLib/Common/JsonUtils.cs
@@ -93,7 +93,8 @@ public class JsonUtils
             {
                 return null;
             }
-            return JsonNode.Parse(strJson, nodeOptions: null, _defaultDocumentOptions);
+
+            return JsonNode.Parse(NormalizeBrokenJson(strJson), nodeOptions: null, _defaultDocumentOptions);
         }
         catch
         {
@@ -166,5 +167,75 @@ public class JsonUtils
     public static JsonNode? SerializeToNode(object? obj, JsonSerializerOptions? options = null)
     {
         return JsonSerializer.SerializeToNode(obj, options);
+    }
+
+    /// <summary>
+    /// Normalizes a broken JSON-like string by removing plus signs (+)
+    /// that are located outside quoted string values.
+    /// </summary>
+    /// <param name="json">
+    /// The JSON-like input string that may contain invalid plus signs.
+    /// </param>
+    /// <returns>
+    /// A normalized JSON string that can be parsed by <see cref="JsonNode.Parse(string?, JsonNodeOptions?, JsonDocumentOptions)"/>.
+    /// </returns>
+    /// <remarks>
+    /// This method is designed for cases where the input looks similar to JSON
+    /// but contains invalid plus signs, such as:
+    ///
+    /// <code>
+    /// {"scMaxEachPostBytes":+1000000,+"scMaxConcurrentPosts":+100,+"xPaddingBytes":+"100-1000"}
+    /// </code>
+    ///
+    /// The method removes only plus signs that are outside string values.
+    ///
+    /// It does not remove plus signs inside quoted strings:
+    ///
+    /// <code>
+    /// {"phone":"+49123456789"}
+    /// </code>
+    ///
+    /// This behavior prevents accidental modification of valid string data.
+    /// </remarks>
+    private static string NormalizeBrokenJson(string json)
+    {
+        var result = new StringBuilder(json.Length);
+
+        bool insideString = false;
+        bool escaped = false;
+
+        foreach (char ch in json)
+        {
+            if (escaped)
+            {
+                result.Append(ch);
+                escaped = false;
+                continue;
+            }
+
+            if (ch == '\\' && insideString)
+            {
+                result.Append(ch);
+                escaped = true;
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                insideString = !insideString;
+                result.Append(ch);
+                continue;
+            }
+
+            // Remove plus signs only when they are outside string values.
+            if (!insideString && ch == '+')
+            {
+                continue;
+            }
+
+            result.Append(ch);
+        }
+
+        return result.ToString();
     }
 }


### PR DESCRIPTION
# PR Summary

## Summary

This update improves JSON parsing by normalizing malformed JSON-like configuration strings before passing them to `JsonNode.Parse()`.

## Changes

- Added a normalization step for invalid plus signs (`+`) outside quoted string values.
- Preserved plus signs inside quoted strings.
- Kept the existing safe parsing behavior by returning `null` when parsing still fails.
- Added XML documentation for the parser and normalization logic.

## Example

Before normalization:

```json
{"scMaxEachPostBytes":+1000000,+"scMaxConcurrentPosts":+100}
```

After normalization:

```json
{"scMaxEachPostBytes":1000000,"scMaxConcurrentPosts":100}
```

## Validation

- Malformed JSON-like config with invalid plus signs is parsed successfully.
- Valid JSON continues to parse normally.
- Plus signs inside string values remain unchanged.
- Invalid JSON still returns `null` without throwing an exception.
