### PR TITLE
Fix

### DIFF
--- a/package-osx.sh
+++ b/package-osx.sh
@@ -28,7 +28,7 @@ cat >"$PackagePath/v2rayN.app/Contents/Info.plist" <<-EOF
     <string>zh-Hans</string>
     <string>zh-Hant</string>
     <string>en</string>
-    <string>fa-IR</string>
+    <string>fa</string>
     <string>fr</string>
     <string>ru</string>
     <string>hu</string>

--- a/package-osx.sh
+++ b/package-osx.sh
@@ -22,7 +22,17 @@ cat >"$PackagePath/v2rayN.app/Contents/Info.plist" <<-EOF
 <plist version="1.0">
 <dict>
   <key>CFBundleDevelopmentRegion</key>
-  <string>English</string>
+  <string>en</string>
+  <key>CFBundleLocalizations</key>
+  <array>
+    <string>zh-Hans</string>
+    <string>zh-Hant</string>
+    <string>en</string>
+    <string>fa-IR</string>
+    <string>fr</string>
+    <string>ru</string>
+    <string>hu</string>
+  </array>
   <key>CFBundleDisplayName</key>
   <string>v2rayN</string>
   <key>CFBundleExecutable</key>


### PR DESCRIPTION
macOS 软件包需要明确声明软件支持哪些语言，才会传递对应信息