### PR TITLE
Improve Windows TUN startup resilience

### DIFF
--- a/v2rayN/ServiceLib/Common/WindowsTunCompatibility.cs
+++ b/v2rayN/ServiceLib/Common/WindowsTunCompatibility.cs
@@ -1,0 +1,79 @@
+using Microsoft.Win32;
+
+namespace ServiceLib.Common;
+
+[SupportedOSPlatform("windows")]
+internal static class WindowsTunCompatibility
+{
+    private static readonly string _tag = "WindowsTunCompatibility";
+    private const string AffectedBuildMessage = "Windows 26200.8524/26100.8524 TUN compatibility mode";
+
+    public static bool IsAffectedBuild()
+    {
+        if (!Utils.IsWindows())
+        {
+            return false;
+        }
+
+        try
+        {
+            using var key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows NT\CurrentVersion");
+            var currentBuild = key?.GetValue("CurrentBuildNumber")?.ToString();
+            var ubrValue = key?.GetValue("UBR");
+
+            if (!int.TryParse(currentBuild, out var build))
+            {
+                build = Environment.OSVersion.Version.Build;
+            }
+
+            var ubr = ubrValue switch
+            {
+                int i => i,
+                string s when int.TryParse(s, out var parsed) => parsed,
+                _ => 0
+            };
+
+            return (build is 26100 or 26200) && ubr >= 8524;
+        }
+        catch (Exception ex)
+        {
+            Logging.SaveLog(_tag, ex);
+            return Environment.OSVersion.Version.Build is 26100 or 26200;
+        }
+    }
+
+    public static void ApplyAffectedBuildDefaults(TunModeItem item, out string? message)
+    {
+        message = null;
+
+        if (!IsAffectedBuild())
+        {
+            return;
+        }
+
+        var changed = false;
+        if (item.Mtu <= 0 || item.Mtu > 1500)
+        {
+            item.Mtu = 1500;
+            changed = true;
+        }
+
+        if (item.StrictRoute)
+        {
+            item.StrictRoute = false;
+            changed = true;
+        }
+
+        if (item.Stack.IsNullOrEmpty() || item.Stack.Equals("gvisor", StringComparison.OrdinalIgnoreCase))
+        {
+            item.Stack = "system";
+            changed = true;
+        }
+
+        if (changed)
+        {
+            message = $"{AffectedBuildMessage}: stack=system, mtu=1500, strict_route=false";
+            Logging.SaveLog($"{_tag}: {message}");
+        }
+    }
+}

--- a/v2rayN/ServiceLib/Common/WindowsUtils.cs
+++ b/v2rayN/ServiceLib/Common/WindowsUtils.cs
@@ -54,7 +54,7 @@ internal static class WindowsUtils
 
     public static async Task RemoveTunDevice()
     {
-        var tunNameList = new List<string> { "wintunsingbox_tun", "xray_tun" };
+        var tunNameList = new List<string> { "singbox_tun", "wintunsingbox_tun", "xray_tun" };
         foreach (var tunName in tunNameList)
         {
             try

--- a/v2rayN/ServiceLib/Manager/CoreManager.cs
+++ b/v2rayN/ServiceLib/Manager/CoreManager.cs
@@ -60,12 +60,12 @@ public class CoreManager
 
     /// <param name="mainContext">Resolved main context (with pre-socks ports already merged if applicable).</param>
     /// <param name="preContext">Optional pre-socks context passed to <see cref="CoreStartPreService"/>.</param>
-    public async Task LoadCore(CoreConfigContext? mainContext, CoreConfigContext? preContext)
+    public async Task<bool> LoadCore(CoreConfigContext? mainContext, CoreConfigContext? preContext)
     {
         if (mainContext == null)
         {
             await UpdateFunc(false, ResUI.CheckServerSettings);
-            return;
+            return false;
         }
 
         var node = mainContext.Node;
@@ -74,7 +74,7 @@ public class CoreManager
         if (result.Success != true)
         {
             await UpdateFunc(true, result.Msg);
-            return;
+            return false;
         }
 
         await UpdateFunc(false, $"{node.GetSummary()}");
@@ -90,7 +90,19 @@ public class CoreManager
         }
 
         await CoreStart(mainContext);
+        if (_processService is null or { HasExited: true })
+        {
+            await SysProxyHandler.UpdateSysProxy(_config, true);
+            return false;
+        }
+
         await CoreStartPreService(preContext);
+        if (preContext != null && (_processPreService is null or { HasExited: true }))
+        {
+            await CoreStop();
+            await SysProxyHandler.UpdateSysProxy(_config, true);
+            return false;
+        }
 
         AppManager.Instance.RunningCoreType = preContext?.RunCoreType ?? mainContext.RunCoreType;
 
@@ -98,6 +110,7 @@ public class CoreManager
         {
             await UpdateFunc(true, $"{node.GetSummary()}");
         }
+        return true;
     }
 
     public async Task<ProcessService?> LoadCoreConfigSpeedtest(List<ServerTestItem> selecteds)
@@ -268,7 +281,7 @@ public class CoreManager
 
         await procService.StartAsync();
 
-        await Task.Delay(100);
+        await Task.Delay(_config.TunModeItem.EnableTun && Utils.IsWindows() ? 1500 : 100);
 
         if (procService is null or { HasExited: true })
         {

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxInboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxInboundService.cs
@@ -52,6 +52,11 @@ public partial class CoreConfigSingboxService
 
             if (context.IsTunEnabled)
             {
+                if (Utils.IsWindows())
+                {
+                    WindowsTunCompatibility.ApplyAffectedBuildDefaults(_config.TunModeItem, out _);
+                }
+
                 if (_config.TunModeItem.Mtu <= 0)
                 {
                     _config.TunModeItem.Mtu = Global.TunMtus.First();

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayInboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayInboundService.cs
@@ -49,6 +49,11 @@ public partial class CoreConfigV2rayService
 
             if (context.IsTunEnabled)
             {
+                if (Utils.IsWindows())
+                {
+                    WindowsTunCompatibility.ApplyAffectedBuildDefaults(_config.TunModeItem, out _);
+                }
+
                 if (_config.TunModeItem.Mtu <= 0)
                 {
                     _config.TunModeItem.Mtu = Global.TunMtus.First();

--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -578,8 +578,8 @@ public class MainWindowViewModel : MyReactiveObject
 
             await Task.Run(async () =>
             {
-                await LoadCore(allResult.MainResult.Context, allResult.PreSocksResult?.Context);
-                await SysProxyHandler.UpdateSysProxy(_config, false);
+                var coreStarted = await LoadCore(allResult.MainResult.Context, allResult.PreSocksResult?.Context);
+                await SysProxyHandler.UpdateSysProxy(_config, !coreStarted);
                 await Task.Delay(1000);
             });
             AppEvents.TestServerRequested.Publish();
@@ -619,9 +619,9 @@ public class MainWindowViewModel : MyReactiveObject
         RxSchedulers.MainThreadScheduler.Schedule(() => BlReloadEnabled = enabled);
     }
 
-    private async Task LoadCore(CoreConfigContext? mainContext, CoreConfigContext? preContext)
+    private async Task<bool> LoadCore(CoreConfigContext? mainContext, CoreConfigContext? preContext)
     {
-        await CoreManager.Instance.LoadCore(mainContext, preContext);
+        return await CoreManager.Instance.LoadCore(mainContext, preContext);
     }
 
     #endregion core job

--- a/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
@@ -491,6 +491,15 @@ public class StatusBarViewModel : MyReactiveObject
             }
         }
 
+        if (EnableTun && Utils.IsWindows())
+        {
+            WindowsTunCompatibility.ApplyAffectedBuildDefaults(_config.TunModeItem, out var message);
+            if (message.IsNotEmpty())
+            {
+                NoticeManager.Instance.SendMessageAndEnqueue(message);
+            }
+        }
+
         await ConfigHandler.SaveConfig(_config);
         AppEvents.ReloadRequested.Publish();
     }


### PR DESCRIPTION
# Improve Windows TUN startup resilience

## Summary

- Add a Windows TUN compatibility helper for affected Windows 11 builds.
- Normalize TUN defaults on Windows builds `26100/26200` with `UBR >= 8524` to `stack=system`, `mtu=1500`, and `strict_route=false`.
- Include `singbox_tun` in stale Wintun device cleanup.
- Return core startup success from `CoreManager.LoadCore`.
- Clear system proxy when the core fails to start so browsers are not left pointing at a closed local proxy port.
- Wait longer before checking Windows TUN core process startup.

## Rationale

On Windows 11 build `26200.8524` after KB5089573, TUN startup can fail slowly or leave v2rayN running without a core process listening on the local proxy port. In that state the system proxy can still point to `127.0.0.1:10808`, causing browsers to fail with proxy connection errors.

The change keeps the behavior scoped to affected Windows builds and avoids adding policy decisions such as blocking other proxy clients.

## Validation

- `dotnet build v2rayN/v2rayN/v2rayN.csproj -c Release --no-restore`
- `dotnet test v2rayN/ServiceLib.Tests/ServiceLib.Tests.csproj -c Release --no-build`

Result: 45 tests passed.
