### PR TITLE
fix: omit country flag emoji on Windows

### DIFF
--- a/v2rayN/ServiceLib/Models/Dto/IPAPIInfo.cs
+++ b/v2rayN/ServiceLib/Models/Dto/IPAPIInfo.cs
@@ -22,7 +22,7 @@ public readonly record struct IpInfoResult(string Country, string? Ip)
 {
     public override string ToString()
     {
-        var emoji = Country.CountryToEmoji();
+        var emoji = Utils.IsWindows() ? null : Country.CountryToEmoji();
         return $"{emoji}({Country}) {Ip}";
     }
 }


### PR DESCRIPTION
## Summary

On Windows, `Segoe UI Emoji` does not render regional-indicator flag emoji, so the IP-info string `🇩🇪(DE) <ip>` displays as `DE(DE) <ip>`. This changes the Windows path to omit the emoji and show just the country code, e.g. `(DE) <ip>`.

Linux and macOS are unchanged — they keep the existing system emoji flag.

## Change

A single line in `IpInfoResult.ToString()`: the flag emoji is now only produced on non-Windows platforms.

```csharp
var emoji = Utils.IsWindows() ? null : Country.CountryToEmoji();
return $"{emoji}({Country}) {Ip}";
```

No new dependencies, no new files, no other behavior changes.

## Result

- Windows: `(DE) 203.0.113.1`
- Linux/macOS: `🇩🇪(DE) 203.0.113.1` (unchanged)