### PR TITLE
fix: decompress gzip-encoded subscription responses

### DIFF
--- a/v2rayN/ServiceLib.Tests/Fmt/SubscriptionDownloadTests.cs
+++ b/v2rayN/ServiceLib.Tests/Fmt/SubscriptionDownloadTests.cs
@@ -1,0 +1,79 @@
+using System.IO.Compression;
+using System.Text;
+using AwesomeAssertions;
+using ServiceLib.Common;
+using ServiceLib.Enums;
+using ServiceLib.Handler.Fmt;
+using Xunit;
+
+namespace ServiceLib.Tests.Fmt;
+
+public class SubscriptionDownloadTests
+{
+    private const string SampleVlessUri1 =
+        "vless://00000000-0000-4000-8000-000000000001@node1.example.com:443?encryption=none&security=reality&sni=www.example.com&fp=chrome&pbk=ZGVtb1B1YmxpY0tleTE&sid=abc123&type=tcp#Node%201";
+
+    private const string SampleVlessUri2 =
+        "vless://00000000-0000-4000-8000-000000000002@node2.example.com:443?encryption=none&security=reality&sni=www.example.org&fp=chrome&pbk=ZGVtb1B1YmxpY0tleTI&sid=def456&type=tcp#Node%202";
+
+    private static string SampleBase64Subscription =>
+        Utils.Base64Encode($"{SampleVlessUri1}\n{SampleVlessUri2}");
+
+    [Fact]
+    public void ResolveConfig_Base64Subscription_ShouldParseAllLines()
+    {
+        var strData = Utils.Base64Decode(SampleBase64Subscription);
+        var lines = strData.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+
+        lines.Length.Should().Be(2);
+
+        foreach (var line in lines)
+        {
+            var profile = FmtHandler.ResolveConfig(line, out var msg);
+            profile.Should().NotBeNull(msg);
+            profile!.ConfigType.Should().Be(EConfigType.VLESS);
+        }
+    }
+
+    [Fact]
+    public void IsBase64String_Base64Subscription_WithTrailingNewline_ShouldStillDecode()
+    {
+        var base64 = SampleBase64Subscription;
+
+        Utils.IsBase64String(base64).Should().BeTrue();
+        Utils.IsBase64String(base64 + "\n").Should().BeTrue("trailing newline should not break base64 detection");
+        Utils.IsBase64String(base64 + "\r\n").Should().BeTrue("trailing CRLF should not break base64 detection");
+
+        var decoded = Utils.Base64Decode(base64 + "\n");
+        decoded.Should().StartWith("vless://");
+    }
+
+    [Fact]
+    public void DecodeDownloadedContent_GzipWrappedBase64Subscription_ShouldDecodeAndParseVless()
+    {
+        var plainText = Encoding.UTF8.GetBytes(SampleBase64Subscription);
+
+        byte[] gzipped;
+        using (var output = new MemoryStream())
+        {
+            using (var gzip = new GZipStream(output, CompressionLevel.SmallestSize, leaveOpen: true))
+            {
+                gzip.Write(plainText, 0, plainText.Length);
+            }
+            gzipped = output.ToArray();
+        }
+
+        gzipped[0].Should().Be(0x1F);
+        gzipped[1].Should().Be(0x8B);
+
+        var decoded = Utils.DecodeDownloadedContent(gzipped);
+        decoded.Should().Be(SampleBase64Subscription);
+
+        var subscription = Utils.Base64Decode(decoded);
+        var firstLine = subscription.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)[0];
+        var profile = FmtHandler.ResolveConfig(firstLine, out var msg);
+        profile.Should().NotBeNull(msg);
+        profile!.ConfigType.Should().Be(EConfigType.VLESS);
+        profile.Address.Should().Be("node1.example.com");
+    }
+}

--- a/v2rayN/ServiceLib/Common/Utils.cs
+++ b/v2rayN/ServiceLib/Common/Utils.cs
@@ -1,4 +1,5 @@
 using System.Collections.Specialized;
+using System.IO.Compression;
 using System.Security.Principal;
 using CliWrap;
 using CliWrap.Buffered;
@@ -104,6 +105,33 @@ public class Utils
     /// </summary>
     /// <param name="plainText"></param>
     /// <returns></returns>
+    public static byte[] DecompressContentIfNeeded(byte[] data)
+    {
+        if (data.Length < 2 || data[0] != 0x1F || data[1] != 0x8B)
+        {
+            return data;
+        }
+
+        try
+        {
+            using var input = new MemoryStream(data);
+            using var gzip = new GZipStream(input, CompressionMode.Decompress);
+            using var output = new MemoryStream();
+            gzip.CopyTo(output);
+            return output.ToArray();
+        }
+        catch (Exception ex)
+        {
+            Logging.SaveLog(_tag, ex);
+            return data;
+        }
+    }
+
+    public static string DecodeDownloadedContent(byte[] data)
+    {
+        return Encoding.UTF8.GetString(DecompressContentIfNeeded(data));
+    }
+
     public static string Base64Decode(string? plainText)
     {
         try

--- a/v2rayN/ServiceLib/Helper/DownloaderHelper.cs
+++ b/v2rayN/ServiceLib/Helper/DownloaderHelper.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Downloader;
 
 namespace ServiceLib.Helper;
@@ -46,11 +47,12 @@ public class DownloaderHelper
 
         using var cts = new CancellationTokenSource();
         await using var stream = await downloader.DownloadFileTaskAsync(address: url, cts.Token).WaitAsync(TimeSpan.FromSeconds(timeout), cts.Token);
-        using StreamReader reader = new(stream);
+        using var memoryStream = new MemoryStream();
+        await stream.CopyToAsync(memoryStream, cts.Token);
 
         downloadOpt = null;
 
-        return await reader.ReadToEndAsync(cts.Token);
+        return Utils.DecodeDownloadedContent(memoryStream.ToArray());
     }
 
     public async Task DownloadDataAsync4Speed(IWebProxy webProxy, string url, IProgress<string> progress, int timeout)

--- a/v2rayN/ServiceLib/Services/DownloadService.cs
+++ b/v2rayN/ServiceLib/Services/DownloadService.cs
@@ -1,4 +1,7 @@
+using System.IO.Compression;
+using System.Net;
 using System.Net.Http.Headers;
+using System.Text;
 
 namespace ServiceLib.Services;
 
@@ -158,7 +161,8 @@ public class DownloadService
             var client = new HttpClient(new SocketsHttpHandler()
             {
                 Proxy = webProxy,
-                UseProxy = webProxy != null
+                UseProxy = webProxy != null,
+                AutomaticDecompression = DecompressionMethods.All
             });
 
             if (userAgent.IsNullOrEmpty())
@@ -175,8 +179,8 @@ public class DownloadService
             }
 
             using var cts = new CancellationTokenSource();
-            var result = await client.GetStringAsync(url, cts.Token).WaitAsync(TimeSpan.FromSeconds(timeout), cts.Token);
-            return result;
+            var bytes = await client.GetByteArrayAsync(url, cts.Token).WaitAsync(TimeSpan.FromSeconds(timeout), cts.Token);
+            return Utils.DecodeDownloadedContent(bytes);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- Fix subscription import failing when providers return gzip-compressed bodies (`Content-Encoding: gzip`)
- Enable `AutomaticDecompression` on `HttpClient` and decode downloads as bytes before UTF-8 conversion
- Add a gzip magic-byte fallback in `Utils.DecodeDownloadedContent` for the DownloaderHelper path
- Add regression tests covering base64 subscription parsing and gzip-wrapped subscription content

## Problem
Some subscription servers (e.g. providers using Cloudflare/nginx with gzip enabled) return compressed content. v2rayN logged "Got subscription content successfully" but then "Failed to import subscription content" because the compressed bytes were treated as plain text.

## Test plan
- [x] `dotnet test v2rayN/ServiceLib.Tests/ServiceLib.Tests.csproj` (48 tests passed)
- [ ] Manually update a gzip-encoded subscription URL and verify servers are imported
