### PR TITLE
Fix NUGET_CERT_REVOCATION_MODE=offline

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -341,7 +341,7 @@ jobs:
       QCOW2_IMAGE: debian13-loong64.qcow2
       EFI_CODE: edk2-loongarch64-code.fd
       EFI_VARS: edk2-loongarch64-vars.fd
-      QEMU_VERSION: 10.2.2
+      QEMU_VERSION: 10.2.3
 
     steps:
     - name: Prepare host tools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
         )
       }}
     env:
+      NUGET_CERT_REVOCATION_MODE: offline
       Output: "${{ github.workspace }}/${{ matrix.arch }}"
       RID: |-
         ${{

--- a/package-debian-loong.sh
+++ b/package-debian-loong.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export NUGET_CERT_REVOCATION_MODE="${NUGET_CERT_REVOCATION_MODE:-offline}"
+
 VERSION_ARG=""
 WITH_CORE="both"
 FORCE_NETCORE=0

--- a/package-debian-riscv.sh
+++ b/package-debian-riscv.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export NUGET_CERT_REVOCATION_MODE="${NUGET_CERT_REVOCATION_MODE:-offline}"
+
 VERSION_ARG=""
 WITH_CORE="both"
 FORCE_NETCORE=0

--- a/package-debian.sh
+++ b/package-debian.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export NUGET_CERT_REVOCATION_MODE="${NUGET_CERT_REVOCATION_MODE:-offline}"
+
 VERSION_ARG=""
 WITH_CORE="both"
 FORCE_NETCORE=0

--- a/package-rhel-riscv.sh
+++ b/package-rhel-riscv.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export NUGET_CERT_REVOCATION_MODE="${NUGET_CERT_REVOCATION_MODE:-offline}"
+
 VERSION_ARG=""
 WITH_CORE="both"
 FORCE_NETCORE=0

--- a/package-rhel.sh
+++ b/package-rhel.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export NUGET_CERT_REVOCATION_MODE="${NUGET_CERT_REVOCATION_MODE:-offline}"
+
 VERSION_ARG=""
 WITH_CORE="both"
 FORCE_NETCORE=0

--- a/v2rayN/Directory.Packages.props
+++ b/v2rayN/Directory.Packages.props
@@ -26,7 +26,7 @@
         <PackageVersion Include="Semi.Avalonia.DataGrid" Version="11.3.7.3" />
         <PackageVersion Include="NLog" Version="6.1.3" />
         <PackageVersion Include="sqlite-net-e" Version="1.11.0" />
-        <PackageVersion Include="Repobot.SQLite.Unofficial" Version="3.53.1.7" />
+        <PackageVersion Include="Repobot.SQLite.Unofficial" Version="3.53.2" />
         <PackageVersion Include="TaskScheduler" Version="2.12.2" />
         <PackageVersion Include="Tmds.DBus.Protocol" Version="0.94.1" />
         <PackageVersion Include="WebDav.Client" Version="2.9.0" />


### PR DESCRIPTION
上游的证书出现了问题，
临时将nuget证书验证改为本地自带缓存验证

~~nuget老毛病~~
~~可以确认上游希望强抬Avalonia版本，Avalonia 12现在都不稳定~~

https://github.com/reactiveui/ReactiveUI.Avalonia/issues/113