### PR TITLE
Improve proxy chain routing UX

### DIFF
--- a/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
+++ b/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
@@ -305,6 +305,61 @@ public class CoreConfigSingboxServiceTests
     }
 
     [Fact]
+    public void GenerateClientConfigContent_RoutingSplit_ClaudeDomainsToProxyChain_ShouldKeepDefaultTrafficOnMainProxy()
+    {
+        var config = CoreConfigTestFactory.CreateConfig(ECoreType.sing_box);
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+
+        var node = CoreConfigTestFactory.CreateSocksNode(ECoreType.sing_box, "n-main", "main");
+        var hop1 = CoreConfigTestFactory.CreateSocksNode(ECoreType.sing_box, "n-hop-1", "hop-1");
+        var hop2 = CoreConfigTestFactory.CreateSocksNode(ECoreType.sing_box, "n-hop-2", "hop-2");
+        var chain = CoreConfigTestFactory.CreateProxyChainNode(ECoreType.sing_box, "c-claude", "claude-chain",
+            [hop1.IndexId, hop2.IndexId]);
+
+        var context = CoreConfigTestFactory.CreateContext(config, node, ECoreType.sing_box) with
+        {
+            RoutingItem = new RoutingItem
+            {
+                Id = "r-claude-chain",
+                Remarks = "claude-chain-routing",
+                RuleSet = JsonUtils.Serialize(new List<RulesItem>
+                {
+                    new()
+                    {
+                        Enabled = true,
+                        RuleType = ERuleType.Routing,
+                        OutboundTag = chain.Remarks,
+                        Domain = ["domain:anthropic.com", "domain:claude.ai"],
+                    }
+                }),
+                DomainStrategy = Global.AsIs,
+                DomainStrategy4Singbox = string.Empty,
+            }
+        };
+        context.AllProxiesMap[hop1.IndexId] = hop1;
+        context.AllProxiesMap[hop2.IndexId] = hop2;
+        context.AllProxiesMap[chain.IndexId] = chain;
+        context.AllProxiesMap[$"remark:{chain.Remarks}"] = chain;
+
+        var result = new CoreConfigSingboxService(context).GenerateClientConfigContent();
+
+        result.Success.Should().BeTrue($"ret msg: {result.Msg}");
+        var cfg = JsonUtils.Deserialize<SingboxConfig>(result.Data!.ToString())!;
+        var expectedPrefix = $"{chain.IndexId}-{Global.ProxyTag}-{chain.Remarks}";
+
+        cfg.route.final.Should().Be(Global.ProxyTag);
+        cfg.outbounds.Should().Contain(o => o.tag == Global.ProxyTag && o.type == "socks");
+        cfg.outbounds.Should().Contain(o => o.tag.StartsWith(expectedPrefix, StringComparison.Ordinal));
+        cfg.outbounds.Should().Contain(o => o.tag.StartsWith($"chain-{expectedPrefix}-", StringComparison.Ordinal));
+
+        var hasClaudeRouteRule = cfg.route.rules.Any(r =>
+            r.domain_suffix != null
+            && r.domain_suffix.Contains("claude.ai")
+            && (r.outbound ?? string.Empty).StartsWith(expectedPrefix, StringComparison.Ordinal));
+        hasClaudeRouteRule.Should().BeTrue();
+    }
+
+    [Fact]
     public void GenerateClientConfigContent_DirectExpectedIPs_ShouldApplyGeoipAndCidrToDirectDnsRule()
     {
         var config = CoreConfigTestFactory.CreateConfigWithDirectExpectedIPs(

--- a/v2rayN/ServiceLib.Tests/CoreConfig/V2ray/CoreConfigV2rayServiceTests.cs
+++ b/v2rayN/ServiceLib.Tests/CoreConfig/V2ray/CoreConfigV2rayServiceTests.cs
@@ -258,6 +258,60 @@ public class CoreConfigV2rayServiceTests
     }
 
     [Fact]
+    public void GenerateClientConfigContent_RoutingSplit_ClaudeDomainsToProxyChain_ShouldKeepDefaultTrafficOnMainProxy()
+    {
+        var config = CoreConfigTestFactory.CreateConfig(ECoreType.Xray);
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+
+        var node = CoreConfigTestFactory.CreateVmessNode(ECoreType.Xray, "n-main", "main");
+        var hop1 = CoreConfigTestFactory.CreateSocksNode(ECoreType.Xray, "n-hop-1", "hop-1");
+        var hop2 = CoreConfigTestFactory.CreateSocksNode(ECoreType.Xray, "n-hop-2", "hop-2");
+        var chain = CoreConfigTestFactory.CreateProxyChainNode(ECoreType.Xray, "c-claude", "claude-chain",
+            [hop1.IndexId, hop2.IndexId]);
+
+        var context = CoreConfigTestFactory.CreateContext(config, node, ECoreType.Xray) with
+        {
+            RoutingItem = new RoutingItem
+            {
+                Id = "r-claude-chain",
+                Remarks = "claude-chain-routing",
+                RuleSet = JsonUtils.Serialize(new List<RulesItem>
+                {
+                    new()
+                    {
+                        Enabled = true,
+                        RuleType = ERuleType.Routing,
+                        OutboundTag = chain.Remarks,
+                        Domain = ["domain:anthropic.com", "domain:claude.ai"],
+                    }
+                }),
+                DomainStrategy = Global.AsIs,
+                DomainStrategy4Singbox = string.Empty,
+            }
+        };
+        context.AllProxiesMap[hop1.IndexId] = hop1;
+        context.AllProxiesMap[hop2.IndexId] = hop2;
+        context.AllProxiesMap[chain.IndexId] = chain;
+        context.AllProxiesMap[$"remark:{chain.Remarks}"] = chain;
+
+        var result = new CoreConfigV2rayService(context).GenerateClientConfigContent();
+
+        result.Success.Should().BeTrue();
+        var cfg = JsonUtils.Deserialize<V2rayConfig>(result.Data!.ToString())!;
+        var expectedPrefix = $"{chain.IndexId}-{Global.ProxyTag}-{chain.Remarks}";
+
+        cfg.outbounds.Should().Contain(o => o.tag == Global.ProxyTag && o.protocol == "vmess");
+        cfg.outbounds.Should().Contain(o => o.tag.StartsWith(expectedPrefix, StringComparison.Ordinal));
+        cfg.outbounds.Should().Contain(o => o.tag.StartsWith($"chain-{expectedPrefix}-", StringComparison.Ordinal));
+
+        var hasClaudeRouteRule = cfg.routing.rules.Any(r =>
+            r.domain != null
+            && r.domain.Contains("domain:claude.ai")
+            && (r.outboundTag ?? string.Empty).StartsWith(expectedPrefix, StringComparison.Ordinal));
+        hasClaudeRouteRule.Should().BeTrue();
+    }
+
+    [Fact]
     public void GenerateClientConfigContent_DirectExpectedIPs_ShouldApplyExpectedIPsToDirectDnsServer()
     {
         var config = CoreConfigTestFactory.CreateConfigWithDirectExpectedIPs(ECoreType.Xray, "192.168.0.0/16,geoip:cn");

--- a/v2rayN/ServiceLib/Manager/AppManager.cs
+++ b/v2rayN/ServiceLib/Manager/AppManager.cs
@@ -282,6 +282,15 @@ public sealed class AppManager
         return await SQLiteHelper.Instance.TableAsync<ProfileItem>().FirstOrDefaultAsync(it => it.Remarks == remarks);
     }
 
+    public async Task<List<ProfileItem>> GetProfileItemsViaRemarks(string? remarks)
+    {
+        if (remarks.IsNullOrEmpty())
+        {
+            return [];
+        }
+        return await SQLiteHelper.Instance.TableAsync<ProfileItem>().Where(it => it.Remarks == remarks).ToListAsync();
+    }
+
     public async Task<List<RoutingItem>?> RoutingItems()
     {
         return await SQLiteHelper.Instance.TableAsync<RoutingItem>().OrderBy(t => t.Sort).ToListAsync();

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -2165,7 +2165,16 @@ namespace ServiceLib.Resx {
                 return ResourceManager.GetString("MsgRoutingRuleOutboundNodeWarning", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   查找类似 Routing rules reference profiles by remarks. Multiple profiles named "{0}" exist. 的本地化字符串。
+        /// </summary>
+        public static string MsgRoutingRuleOutboundNodeRemarkDuplicate {
+            get {
+                return ResourceManager.GetString("MsgRoutingRuleOutboundNodeRemarkDuplicate", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   查找类似 Filter, press Enter to execute 的本地化字符串。
         /// </summary>
@@ -3383,7 +3392,25 @@ namespace ServiceLib.Resx {
                 return ResourceManager.GetString("TbPolicyGroupSubChildTip", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   查找类似 Select child configurations manually. Use the buttons or context menu to add, remove, and adjust order. 的本地化字符串。
+        /// </summary>
+        public static string TbPolicyGroupChildTip {
+            get {
+                return ResourceManager.GetString("TbPolicyGroupChildTip", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   查找类似 Proxy chain order: traffic enters the first child and exits through the last child. Use Move Up/Down to adjust the chain. 的本地化字符串。
+        /// </summary>
+        public static string TbProxyChainChildTip {
+            get {
+                return ResourceManager.GetString("TbProxyChainChildTip", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   查找类似 Policy Group Type 的本地化字符串。
         /// </summary>
@@ -3671,7 +3698,25 @@ namespace ServiceLib.Resx {
                 return ResourceManager.GetString("TbRuleOutboundTagTip", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   查找类似 Outbound 的本地化字符串。
+        /// </summary>
+        public static string TbRuleOutbound {
+            get {
+                return ResourceManager.GetString("TbRuleOutbound", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   查找类似 Use proxy/direct/block, or click Select Profile to route this rule to a node, policy group, or proxy chain. 的本地化字符串。
+        /// </summary>
+        public static string TbRuleOutboundProfileTip {
+            get {
+                return ResourceManager.GetString("TbRuleOutboundProfileTip", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   查找类似 Rule Type 的本地化字符串。
         /// </summary>

--- a/v2rayN/ServiceLib/Resx/ResUI.fa.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fa.resx
@@ -1614,6 +1614,9 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
   <data name="TbFinalmask" xml:space="preserve">
     <value>Finalmask</value>
   </data>
+  <data name="MsgRoutingRuleOutboundNodeRemarkDuplicate" xml:space="preserve">
+    <value>Routing rules reference profiles by remarks. Multiple profiles named "{0}" exist; please use unique remarks to avoid routing to an unexpected node.</value>
+  </data>
   <data name="MsgRoutingRuleOutboundNodeWarning" xml:space="preserve">
     <value>Routing rule {0} outbound node {1} warning: {2}</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.fa.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fa.resx
@@ -1749,4 +1749,16 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
   <data name="menuNewUpdate" xml:space="preserve">
     <value>New Update</value>
   </data>
+  <data name="TbPolicyGroupChildTip" xml:space="preserve">
+    <value>Select child configurations manually. Use the buttons or context menu to add, remove, and adjust order.</value>
+  </data>
+  <data name="TbProxyChainChildTip" xml:space="preserve">
+    <value>Proxy chain order: traffic enters the first child and exits through the last child. Use Move Up/Down to adjust the chain.</value>
+  </data>
+  <data name="TbRuleOutbound" xml:space="preserve">
+    <value>Outbound</value>
+  </data>
+  <data name="TbRuleOutboundProfileTip" xml:space="preserve">
+    <value>Use proxy/direct/block, or click Select Profile to route this rule to a node, policy group, or proxy chain.</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.fr.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fr.resx
@@ -1746,4 +1746,16 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
   <data name="menuNewUpdate" xml:space="preserve">
     <value>Nouvelle MAJ</value>
   </data>
+  <data name="TbPolicyGroupChildTip" xml:space="preserve">
+    <value>Select child configurations manually. Use the buttons or context menu to add, remove, and adjust order.</value>
+  </data>
+  <data name="TbProxyChainChildTip" xml:space="preserve">
+    <value>Proxy chain order: traffic enters the first child and exits through the last child. Use Move Up/Down to adjust the chain.</value>
+  </data>
+  <data name="TbRuleOutbound" xml:space="preserve">
+    <value>Outbound</value>
+  </data>
+  <data name="TbRuleOutboundProfileTip" xml:space="preserve">
+    <value>Use proxy/direct/block, or click Select Profile to route this rule to a node, policy group, or proxy chain.</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.fr.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fr.resx
@@ -1611,6 +1611,9 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
   <data name="TbFinalmask" xml:space="preserve">
     <value>Finalmask</value>
   </data>
+  <data name="MsgRoutingRuleOutboundNodeRemarkDuplicate" xml:space="preserve">
+    <value>Routing rules reference profiles by remarks. Multiple profiles named "{0}" exist; please use unique remarks to avoid routing to an unexpected node.</value>
+  </data>
   <data name="MsgRoutingRuleOutboundNodeWarning" xml:space="preserve">
     <value>Règle de routage {0} nœud sortant {1} avertissement: {2}</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.hu.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.hu.resx
@@ -1614,6 +1614,9 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
   <data name="TbFinalmask" xml:space="preserve">
     <value>Finalmask</value>
   </data>
+  <data name="MsgRoutingRuleOutboundNodeRemarkDuplicate" xml:space="preserve">
+    <value>Routing rules reference profiles by remarks. Multiple profiles named "{0}" exist; please use unique remarks to avoid routing to an unexpected node.</value>
+  </data>
   <data name="MsgRoutingRuleOutboundNodeWarning" xml:space="preserve">
     <value>Routing rule {0} outbound node {1} warning: {2}</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.hu.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.hu.resx
@@ -1749,4 +1749,16 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
   <data name="menuNewUpdate" xml:space="preserve">
     <value>New Update</value>
   </data>
+  <data name="TbPolicyGroupChildTip" xml:space="preserve">
+    <value>Select child configurations manually. Use the buttons or context menu to add, remove, and adjust order.</value>
+  </data>
+  <data name="TbProxyChainChildTip" xml:space="preserve">
+    <value>Proxy chain order: traffic enters the first child and exits through the last child. Use Move Up/Down to adjust the chain.</value>
+  </data>
+  <data name="TbRuleOutbound" xml:space="preserve">
+    <value>Outbound</value>
+  </data>
+  <data name="TbRuleOutboundProfileTip" xml:space="preserve">
+    <value>Use proxy/direct/block, or click Select Profile to route this rule to a node, policy group, or proxy chain.</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1617,6 +1617,9 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
   <data name="TbFinalmask" xml:space="preserve">
     <value>Finalmask</value>
   </data>
+  <data name="MsgRoutingRuleOutboundNodeRemarkDuplicate" xml:space="preserve">
+    <value>Routing rules reference profiles by remarks. Multiple profiles named "{0}" exist; please use unique remarks to avoid routing to an unexpected node.</value>
+  </data>
   <data name="MsgRoutingRuleOutboundNodeWarning" xml:space="preserve">
     <value>Routing rule {0} outbound node {1} warning: {2}</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1773,4 +1773,16 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
   <data name="TbEnableFinalFragmentTip" xml:space="preserve">
     <value>Split the tail of packets into smaller fragments. This may affect throughput and latency.</value>
   </data>
+  <data name="TbPolicyGroupChildTip" xml:space="preserve">
+    <value>Select child configurations manually. Use the buttons or context menu to add, remove, and adjust order.</value>
+  </data>
+  <data name="TbProxyChainChildTip" xml:space="preserve">
+    <value>Proxy chain order: traffic enters the first child and exits through the last child. Use Move Up/Down to adjust the chain.</value>
+  </data>
+  <data name="TbRuleOutbound" xml:space="preserve">
+    <value>Outbound</value>
+  </data>
+  <data name="TbRuleOutboundProfileTip" xml:space="preserve">
+    <value>Use proxy/direct/block, or click Select Profile to route this rule to a node, policy group, or proxy chain.</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1749,4 +1749,16 @@
   <data name="menuNewUpdate" xml:space="preserve">
     <value>Доступно обновление</value>
   </data>
+  <data name="TbPolicyGroupChildTip" xml:space="preserve">
+    <value>Select child configurations manually. Use the buttons or context menu to add, remove, and adjust order.</value>
+  </data>
+  <data name="TbProxyChainChildTip" xml:space="preserve">
+    <value>Proxy chain order: traffic enters the first child and exits through the last child. Use Move Up/Down to adjust the chain.</value>
+  </data>
+  <data name="TbRuleOutbound" xml:space="preserve">
+    <value>Outbound</value>
+  </data>
+  <data name="TbRuleOutboundProfileTip" xml:space="preserve">
+    <value>Use proxy/direct/block, or click Select Profile to route this rule to a node, policy group, or proxy chain.</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1614,6 +1614,9 @@
   <data name="TbFinalmask" xml:space="preserve">
     <value>Finalmask</value>
   </data>
+  <data name="MsgRoutingRuleOutboundNodeRemarkDuplicate" xml:space="preserve">
+    <value>Routing rules reference profiles by remarks. Multiple profiles named "{0}" exist; please use unique remarks to avoid routing to an unexpected node.</value>
+  </data>
   <data name="MsgRoutingRuleOutboundNodeWarning" xml:space="preserve">
     <value>Правило маршрутизации {0}, исходящий узел {1}, предупреждение: {2}</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1611,6 +1611,9 @@
   <data name="TbFinalmask" xml:space="preserve">
     <value>Finalmask</value>
   </data>
+  <data name="MsgRoutingRuleOutboundNodeRemarkDuplicate" xml:space="preserve">
+    <value>路由规则按备注名引用 Profile。当前存在多个名为“{0}”的 Profile，请使用唯一备注名，避免流量走到非预期节点。</value>
+  </data>
   <data name="MsgRoutingRuleOutboundNodeWarning" xml:space="preserve">
     <value>路由规则 {0} 出站节点 {1} 警告：{2}</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1770,4 +1770,16 @@
   <data name="TbEnableFinalFragmentTip" xml:space="preserve">
     <value>将数据包末端拆分为更小片段发送，可能影响吞吐与延迟。</value>
   </data>
+  <data name="TbPolicyGroupChildTip" xml:space="preserve">
+    <value>手动选择子配置项。使用按钮或右键菜单来添加、删除和调整顺序。</value>
+  </data>
+  <data name="TbProxyChainChildTip" xml:space="preserve">
+    <value>代理链顺序：流量从第一个子节点进入，从最后一个子节点流出。使用上移/下移调整链路。</value>
+  </data>
+  <data name="TbRuleOutbound" xml:space="preserve">
+    <value>出站目标</value>
+  </data>
+  <data name="TbRuleOutboundProfileTip" xml:space="preserve">
+    <value>可使用 proxy/direct/block，或点击“选择 Profile”将本规则指向某个节点、策略组或链式代理。</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -1770,4 +1770,16 @@
   <data name="TbEnableFinalFragmentTip" xml:space="preserve">
     <value>將封包末端拆分為更小的片段進行傳送，可能會影響吞吐量與延遲</value>
   </data>
+  <data name="TbPolicyGroupChildTip" xml:space="preserve">
+    <value>手動選擇子配置項。使用按鈕或右鍵選單來新增、刪除和調整順序。</value>
+  </data>
+  <data name="TbProxyChainChildTip" xml:space="preserve">
+    <value>代理鏈順序：流量從第一個子節點進入，從最後一個子節點流出。使用上移/下移調整鏈路。</value>
+  </data>
+  <data name="TbRuleOutbound" xml:space="preserve">
+    <value>出站目標</value>
+  </data>
+  <data name="TbRuleOutboundProfileTip" xml:space="preserve">
+    <value>可使用 proxy/direct/block，或點擊「選擇 Profile」將本規則指向某個節點、策略組或鏈式代理。</value>
+  </data>
 </root>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -1611,6 +1611,9 @@
   <data name="TbFinalmask" xml:space="preserve">
     <value>Finalmask</value>
   </data>
+  <data name="MsgRoutingRuleOutboundNodeRemarkDuplicate" xml:space="preserve">
+    <value>路由規則按備註名引用 Profile。當前存在多個名為「{0}」的 Profile，請使用唯一備註名，避免流量走到非預期節點。</value>
+  </data>
   <data name="MsgRoutingRuleOutboundNodeWarning" xml:space="preserve">
     <value>路由規則 {0} 的出站節點 {1} 發出警告：{2}</value>
   </data>

--- a/v2rayN/ServiceLib/ViewModels/AddGroupServerViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/AddGroupServerViewModel.cs
@@ -29,6 +29,12 @@ public class AddGroupServerViewModel : MyReactiveObject
 
     public IObservableCollection<ProfileItem> AllProfilePreviewItemsObs { get; } = new ObservableCollectionExtended<ProfileItem>();
 
+    public bool IsProxyChain => SelectedSource?.ConfigType == EConfigType.ProxyChain;
+
+    public bool IsPolicyGroup => SelectedSource?.ConfigType == EConfigType.PolicyGroup;
+
+    public string ChildListTip => IsProxyChain ? ResUI.TbProxyChainChildTip : ResUI.TbPolicyGroupChildTip;
+
     //public ReactiveCommand<Unit, Unit> AddCmd { get; }
     public ReactiveCommand<Unit, Unit> RemoveCmd { get; }
 

--- a/v2rayN/ServiceLib/ViewModels/RoutingRuleDetailsViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/RoutingRuleDetailsViewModel.cs
@@ -23,6 +23,8 @@ public class RoutingRuleDetailsViewModel : MyReactiveObject
     [Reactive]
     public bool AutoSort { get; set; }
 
+    public IObservableCollection<string> OutboundTagItems { get; } = new ObservableCollectionExtended<string>();
+
     public ReactiveCommand<Unit, Unit> SaveCmd { get; }
 
     public RoutingRuleDetailsViewModel(RulesItem rulesItem, Func<EViewAction, object?, Task<bool>>? updateView)
@@ -51,6 +53,32 @@ public class RoutingRuleDetailsViewModel : MyReactiveObject
         IP = Utils.List2String(SelectedSource.Ip, true);
         Process = Utils.List2String(SelectedSource.Process, true);
         RuleType = SelectedSource.RuleType?.ToString();
+
+        _ = InitOutboundTagItems();
+    }
+
+    public async Task CheckOutboundProfileRemarkDuplicate(string? remarks)
+    {
+        var profileItems = await AppManager.Instance.GetProfileItemsViaRemarks(remarks);
+        if (profileItems.Count > 1)
+        {
+            NoticeManager.Instance.Enqueue(string.Format(ResUI.MsgRoutingRuleOutboundNodeRemarkDuplicate, remarks));
+        }
+    }
+
+    private async Task InitOutboundTagItems()
+    {
+        OutboundTagItems.Clear();
+        OutboundTagItems.AddRange(Global.OutboundTags);
+
+        var profileItems = await AppManager.Instance.ProfileItems(string.Empty) ?? [];
+        var groupRemarks = profileItems
+            .Where(t => t.ConfigType.IsGroupType() && t.Remarks.IsNotEmpty())
+            .Select(t => t.Remarks)
+            .Distinct()
+            .OrderBy(t => t)
+            .ToList();
+        OutboundTagItems.AddRange(groupRemarks);
     }
 
     private async Task SaveRulesAsync()

--- a/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml
@@ -138,76 +138,112 @@
             </TabItem>
 
             <TabItem HorizontalAlignment="Left" Header="{x:Static resx:ResUI.menuServerList2}">
-                <DataGrid
-                    x:Name="lstChild"
-                    AutoGenerateColumns="False"
-                    Background="Transparent"
-                    BorderThickness="1"
-                    CanUserReorderColumns="False"
-                    CanUserResizeColumns="True"
-                    CanUserSortColumns="False"
-                    GridLinesVisibility="All"
-                    HeadersVisibility="Column"
-                    IsReadOnly="True"
-                    ItemsSource="{Binding ChildItemsObs}"
-                    SelectionMode="Extended">
-                    <DataGrid.ContextMenu>
-                        <ContextMenu>
-                            <MenuItem x:Name="menuAddChildServer" Header="{x:Static resx:ResUI.menuAddChildServer}" />
-                            <MenuItem
-                                x:Name="menuRemoveChildServer"
-                                Header="{x:Static resx:ResUI.menuRemoveChildServer}"
-                                InputGesture="Back" />
-                            <MenuItem
-                                x:Name="menuSelectAllChild"
-                                Header="{x:Static resx:ResUI.menuSelectAll}"
-                                InputGesture="Ctrl+A" />
-                            <Separator />
-                            <MenuItem
-                                x:Name="menuMoveTop"
-                                Header="{x:Static resx:ResUI.menuMoveTop}"
-                                InputGesture="T" />
-                            <MenuItem
-                                x:Name="menuMoveUp"
-                                Header="{x:Static resx:ResUI.menuMoveUp}"
-                                InputGesture="U" />
-                            <MenuItem
-                                x:Name="menuMoveDown"
-                                Header="{x:Static resx:ResUI.menuMoveDown}"
-                                InputGesture="D" />
-                            <MenuItem
-                                x:Name="menuMoveBottom"
-                                Header="{x:Static resx:ResUI.menuMoveBottom}"
-                                InputGesture="B" />
-                        </ContextMenu>
-                    </DataGrid.ContextMenu>
-                    <DataGrid.Columns>
-                        <DataGridTextColumn
-                            Width="150"
-                            Binding="{Binding ConfigType}"
-                            Header="{x:Static resx:ResUI.LvServiceType}" />
-                        <DataGridTextColumn
-                            Width="200"
-                            Binding="{Binding Remarks}"
-                            Header="{x:Static resx:ResUI.LvRemarks}" />
-                        <DataGridTextColumn
-                            Width="200"
-                            Binding="{Binding Address}"
-                            Header="{x:Static resx:ResUI.LvAddress}" />
-                        <DataGridTextColumn
-                            Width="100"
-                            Binding="{Binding Port}"
-                            Header="{x:Static resx:ResUI.LvPort}" />
-                        <DataGridTextColumn
-                            Width="100"
-                            Binding="{Binding Network}"
-                            Header="{x:Static resx:ResUI.LvTransportProtocol}" />
-                        <DataGridTextColumn
-                            Width="100"
-                            Binding="{Binding StreamSecurity}"
-                            Header="{x:Static resx:ResUI.LvTLS}" />
-                    </DataGrid.Columns>
-                </DataGrid>
+                <DockPanel Margin="{StaticResource Margin8}">
+                    <TextBlock
+                        Margin="{StaticResource Margin4}"
+                        DockPanel.Dock="Top"
+                        Text="{Binding ChildListTip}"
+                        TextWrapping="Wrap" />
+                    <StackPanel
+                        Margin="{StaticResource Margin4}"
+                        DockPanel.Dock="Top"
+                        Orientation="Horizontal">
+                        <Button
+                            x:Name="btnAddChildServer"
+                            Margin="{StaticResource Margin4}"
+                            Content="{x:Static resx:ResUI.menuAddChildServer}" />
+                        <Button
+                            x:Name="btnRemoveChildServer"
+                            Margin="{StaticResource Margin4}"
+                            Content="{x:Static resx:ResUI.menuRemoveChildServer}" />
+                        <Button
+                            x:Name="btnMoveTop"
+                            Margin="{StaticResource Margin4}"
+                            Content="{x:Static resx:ResUI.menuMoveTop}" />
+                        <Button
+                            x:Name="btnMoveUp"
+                            Margin="{StaticResource Margin4}"
+                            Content="{x:Static resx:ResUI.menuMoveUp}" />
+                        <Button
+                            x:Name="btnMoveDown"
+                            Margin="{StaticResource Margin4}"
+                            Content="{x:Static resx:ResUI.menuMoveDown}" />
+                        <Button
+                            x:Name="btnMoveBottom"
+                            Margin="{StaticResource Margin4}"
+                            Content="{x:Static resx:ResUI.menuMoveBottom}" />
+                    </StackPanel>
+                    <DataGrid
+                        x:Name="lstChild"
+                        AutoGenerateColumns="False"
+                        Background="Transparent"
+                        BorderThickness="1"
+                        CanUserReorderColumns="False"
+                        CanUserResizeColumns="True"
+                        CanUserSortColumns="False"
+                        GridLinesVisibility="All"
+                        HeadersVisibility="All"
+                        IsReadOnly="True"
+                        ItemsSource="{Binding ChildItemsObs}"
+                        SelectionMode="Extended">
+                        <DataGrid.ContextMenu>
+                            <ContextMenu>
+                                <MenuItem x:Name="menuAddChildServer" Header="{x:Static resx:ResUI.menuAddChildServer}" />
+                                <MenuItem
+                                    x:Name="menuRemoveChildServer"
+                                    Header="{x:Static resx:ResUI.menuRemoveChildServer}"
+                                    InputGesture="Back" />
+                                <MenuItem
+                                    x:Name="menuSelectAllChild"
+                                    Header="{x:Static resx:ResUI.menuSelectAll}"
+                                    InputGesture="Ctrl+A" />
+                                <Separator />
+                                <MenuItem
+                                    x:Name="menuMoveTop"
+                                    Header="{x:Static resx:ResUI.menuMoveTop}"
+                                    InputGesture="T" />
+                                <MenuItem
+                                    x:Name="menuMoveUp"
+                                    Header="{x:Static resx:ResUI.menuMoveUp}"
+                                    InputGesture="U" />
+                                <MenuItem
+                                    x:Name="menuMoveDown"
+                                    Header="{x:Static resx:ResUI.menuMoveDown}"
+                                    InputGesture="D" />
+                                <MenuItem
+                                    x:Name="menuMoveBottom"
+                                    Header="{x:Static resx:ResUI.menuMoveBottom}"
+                                    InputGesture="B" />
+                            </ContextMenu>
+                        </DataGrid.ContextMenu>
+                        <DataGrid.Columns>
+                            <DataGridTextColumn
+                                Width="150"
+                                Binding="{Binding ConfigType}"
+                                Header="{x:Static resx:ResUI.LvServiceType}" />
+                            <DataGridTextColumn
+                                Width="200"
+                                Binding="{Binding Remarks}"
+                                Header="{x:Static resx:ResUI.LvRemarks}" />
+                            <DataGridTextColumn
+                                Width="200"
+                                Binding="{Binding Address}"
+                                Header="{x:Static resx:ResUI.LvAddress}" />
+                            <DataGridTextColumn
+                                Width="100"
+                                Binding="{Binding Port}"
+                                Header="{x:Static resx:ResUI.LvPort}" />
+                            <DataGridTextColumn
+                                Width="100"
+                                Binding="{Binding Network}"
+                                Header="{x:Static resx:ResUI.LvTransportProtocol}" />
+                            <DataGridTextColumn
+                                Width="100"
+                                Binding="{Binding StreamSecurity}"
+                                Header="{x:Static resx:ResUI.LvTLS}" />
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </DockPanel>
             </TabItem>
             <TabItem HorizontalAlignment="Left" Header="{x:Static resx:ResUI.menuServerListPreview}">
                 <DataGrid

--- a/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/AddGroupServerWindow.axaml.cs
@@ -43,6 +43,7 @@ public partial class AddGroupServerWindow : WindowBase<AddGroupServerViewModel>
                 if (tabControl.Items.Count > 0)
                 {
                     tabControl.Items.RemoveAt(0);
+                    tabControl.SelectedIndex = 0;
                 }
                 break;
         }
@@ -59,15 +60,21 @@ public partial class AddGroupServerWindow : WindowBase<AddGroupServerViewModel>
             this.Bind(ViewModel, vm => vm.SelectedChild, v => v.lstChild.SelectedItem).DisposeWith(disposables);
 
             this.BindCommand(ViewModel, vm => vm.RemoveCmd, v => v.menuRemoveChildServer).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.RemoveCmd, v => v.btnRemoveChildServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.MoveTopCmd, v => v.menuMoveTop).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.MoveTopCmd, v => v.btnMoveTop).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.MoveUpCmd, v => v.menuMoveUp).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.MoveUpCmd, v => v.btnMoveUp).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.MoveDownCmd, v => v.menuMoveDown).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.MoveDownCmd, v => v.btnMoveDown).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.MoveBottomCmd, v => v.menuMoveBottom).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.MoveBottomCmd, v => v.btnMoveBottom).DisposeWith(disposables);
 
             this.BindCommand(ViewModel, vm => vm.SaveCmd, v => v.btnSave).DisposeWith(disposables);
         });
 
         // Context menu actions that require custom logic (Add, SelectAll)
+        btnAddChildServer.Click += MenuAddChild_Click;
         menuAddChildServer.Click += MenuAddChild_Click;
         menuSelectAllChild.Click += (s, e) => lstChild.SelectAll();
 

--- a/v2rayN/v2rayN.Desktop/Views/RoutingRuleDetailsWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/RoutingRuleDetailsWindow.axaml
@@ -74,7 +74,7 @@
                 Grid.Column="0"
                 Margin="{StaticResource Margin4}"
                 VerticalAlignment="Center"
-                Text="outboundTag" />
+                Text="{x:Static resx:ResUI.TbRuleOutbound}" />
             <ComboBox
                 Name="cmbOutboundTag"
                 Grid.Row="2"
@@ -96,7 +96,7 @@
                     Content="{x:Static resx:ResUI.TbSelectProfile}" />
                 <TextBlock
                     VerticalAlignment="Center"
-                    Text="{x:Static resx:ResUI.TbRuleOutboundTagTip}"
+                    Text="{x:Static resx:ResUI.TbRuleOutboundProfileTip}"
                     TextWrapping="Wrap" />
             </StackPanel>
 

--- a/v2rayN/v2rayN.Desktop/Views/RoutingRuleDetailsWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/RoutingRuleDetailsWindow.axaml.cs
@@ -20,7 +20,6 @@ public partial class RoutingRuleDetailsWindow : WindowBase<RoutingRuleDetailsVie
 
         ViewModel = new RoutingRuleDetailsViewModel(rulesItem, UpdateViewHandler);
 
-        cmbOutboundTag.ItemsSource = Global.OutboundTags;
         clbProtocol.ItemsSource = Global.RuleProtocols;
         clbInboundTag.ItemsSource = Global.InboundTags;
         cmbNetwork.ItemsSource = Global.RuleNetworks;
@@ -40,7 +39,7 @@ public partial class RoutingRuleDetailsWindow : WindowBase<RoutingRuleDetailsVie
 
         this.WhenActivated(disposables =>
         {
-            this.Bind(ViewModel, vm => vm.SelectedSource.OutboundTag, v => v.cmbOutboundTag.Text).DisposeWith(disposables);
+            this.OneWayBind(ViewModel, vm => vm.OutboundTagItems, v => v.cmbOutboundTag.ItemsSource).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Remarks, v => v.txtRemarks.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.OutboundTag, v => v.cmbOutboundTag.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Port, v => v.txtPort.Text).DisposeWith(disposables);
@@ -104,6 +103,7 @@ public partial class RoutingRuleDetailsWindow : WindowBase<RoutingRuleDetailsVie
             if (profile != null)
             {
                 cmbOutboundTag.Text = profile.Remarks;
+                await ViewModel.CheckOutboundProfileRemarkDuplicate(profile.Remarks);
             }
         }
     }

--- a/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml
+++ b/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml
@@ -196,84 +196,128 @@
             </TabItem>
 
             <TabItem HorizontalAlignment="Left" Header="{x:Static resx:ResUI.menuServerList2}">
-                <DataGrid
-                    x:Name="lstChild"
-                    AutoGenerateColumns="False"
-                    BorderThickness="1"
-                    CanUserAddRows="False"
-                    CanUserResizeRows="False"
-                    CanUserSortColumns="False"
-                    EnableRowVirtualization="True"
-                    GridLinesVisibility="All"
-                    HeadersVisibility="Column"
-                    IsReadOnly="True"
-                    Style="{StaticResource DefDataGrid}">
-                    <DataGrid.ContextMenu>
-                        <ContextMenu Style="{StaticResource DefContextMenu}">
-                            <MenuItem
-                                x:Name="menuAddChildServer"
-                                Height="{StaticResource MenuItemHeight}"
-                                Click="MenuAddChild_Click"
-                                Header="{x:Static resx:ResUI.menuAddChildServer}" />
-                            <MenuItem
-                                x:Name="menuRemoveChildServer"
-                                Height="{StaticResource MenuItemHeight}"
-                                Header="{x:Static resx:ResUI.menuRemoveChildServer}" />
-                            <MenuItem
-                                x:Name="menuSelectAllChild"
-                                Height="{StaticResource MenuItemHeight}"
-                                Header="{x:Static resx:ResUI.menuSelectAll}"
-                                InputGestureText="Ctrl+A" />
-                            <Separator />
-                            <MenuItem
-                                x:Name="menuMoveTop"
-                                Height="{StaticResource MenuItemHeight}"
-                                Header="{x:Static resx:ResUI.menuMoveTop}"
-                                InputGestureText="T" />
-                            <MenuItem
-                                x:Name="menuMoveUp"
-                                Height="{StaticResource MenuItemHeight}"
-                                Header="{x:Static resx:ResUI.menuMoveUp}"
-                                InputGestureText="U" />
-                            <MenuItem
-                                x:Name="menuMoveDown"
-                                Height="{StaticResource MenuItemHeight}"
-                                Header="{x:Static resx:ResUI.menuMoveDown}"
-                                InputGestureText="D" />
-                            <MenuItem
-                                x:Name="menuMoveBottom"
-                                Height="{StaticResource MenuItemHeight}"
-                                Header="{x:Static resx:ResUI.menuMoveBottom}"
-                                InputGestureText="B" />
-                        </ContextMenu>
-                    </DataGrid.ContextMenu>
-                    <DataGrid.Columns>
-                        <DataGridTextColumn
-                            Width="150"
-                            Binding="{Binding ConfigType}"
-                            Header="{x:Static resx:ResUI.LvServiceType}" />
-                        <DataGridTextColumn
-                            Width="200"
-                            Binding="{Binding Remarks}"
-                            Header="{x:Static resx:ResUI.LvRemarks}" />
-                        <DataGridTextColumn
-                            Width="200"
-                            Binding="{Binding Address}"
-                            Header="{x:Static resx:ResUI.LvAddress}" />
-                        <DataGridTextColumn
-                            Width="100"
-                            Binding="{Binding Port}"
-                            Header="{x:Static resx:ResUI.LvPort}" />
-                        <DataGridTextColumn
-                            Width="100"
-                            Binding="{Binding Network}"
-                            Header="{x:Static resx:ResUI.LvTransportProtocol}" />
-                        <DataGridTextColumn
-                            Width="100"
-                            Binding="{Binding StreamSecurity}"
-                            Header="{x:Static resx:ResUI.LvTLS}" />
-                    </DataGrid.Columns>
-                </DataGrid>
+                <DockPanel Margin="{StaticResource Margin8}">
+                    <TextBlock
+                        x:Name="txtChildListTip"
+                        Margin="{StaticResource Margin4}"
+                        DockPanel.Dock="Top"
+                        Style="{StaticResource ToolbarTextBlock}"
+                        TextWrapping="Wrap" />
+                    <StackPanel
+                        Margin="{StaticResource Margin4}"
+                        DockPanel.Dock="Top"
+                        Orientation="Horizontal">
+                        <Button
+                            x:Name="btnAddChildServer"
+                            Margin="{StaticResource Margin4}"
+                            Click="MenuAddChild_Click"
+                            Content="{x:Static resx:ResUI.menuAddChildServer}"
+                            Style="{StaticResource DefButton}" />
+                        <Button
+                            x:Name="btnRemoveChildServer"
+                            Margin="{StaticResource Margin4}"
+                            Content="{x:Static resx:ResUI.menuRemoveChildServer}"
+                            Style="{StaticResource DefButton}" />
+                        <Button
+                            x:Name="btnMoveTop"
+                            Margin="{StaticResource Margin4}"
+                            Content="{x:Static resx:ResUI.menuMoveTop}"
+                            Style="{StaticResource DefButton}" />
+                        <Button
+                            x:Name="btnMoveUp"
+                            Margin="{StaticResource Margin4}"
+                            Content="{x:Static resx:ResUI.menuMoveUp}"
+                            Style="{StaticResource DefButton}" />
+                        <Button
+                            x:Name="btnMoveDown"
+                            Margin="{StaticResource Margin4}"
+                            Content="{x:Static resx:ResUI.menuMoveDown}"
+                            Style="{StaticResource DefButton}" />
+                        <Button
+                            x:Name="btnMoveBottom"
+                            Margin="{StaticResource Margin4}"
+                            Content="{x:Static resx:ResUI.menuMoveBottom}"
+                            Style="{StaticResource DefButton}" />
+                    </StackPanel>
+                    <DataGrid
+                        x:Name="lstChild"
+                        AutoGenerateColumns="False"
+                        BorderThickness="1"
+                        CanUserAddRows="False"
+                        CanUserResizeRows="False"
+                        CanUserSortColumns="False"
+                        EnableRowVirtualization="True"
+                        GridLinesVisibility="All"
+                        HeadersVisibility="All"
+                        IsReadOnly="True"
+                        Style="{StaticResource DefDataGrid}">
+                        <DataGrid.ContextMenu>
+                            <ContextMenu Style="{StaticResource DefContextMenu}">
+                                <MenuItem
+                                    x:Name="menuAddChildServer"
+                                    Height="{StaticResource MenuItemHeight}"
+                                    Click="MenuAddChild_Click"
+                                    Header="{x:Static resx:ResUI.menuAddChildServer}" />
+                                <MenuItem
+                                    x:Name="menuRemoveChildServer"
+                                    Height="{StaticResource MenuItemHeight}"
+                                    Header="{x:Static resx:ResUI.menuRemoveChildServer}" />
+                                <MenuItem
+                                    x:Name="menuSelectAllChild"
+                                    Height="{StaticResource MenuItemHeight}"
+                                    Header="{x:Static resx:ResUI.menuSelectAll}"
+                                    InputGestureText="Ctrl+A" />
+                                <Separator />
+                                <MenuItem
+                                    x:Name="menuMoveTop"
+                                    Height="{StaticResource MenuItemHeight}"
+                                    Header="{x:Static resx:ResUI.menuMoveTop}"
+                                    InputGestureText="T" />
+                                <MenuItem
+                                    x:Name="menuMoveUp"
+                                    Height="{StaticResource MenuItemHeight}"
+                                    Header="{x:Static resx:ResUI.menuMoveUp}"
+                                    InputGestureText="U" />
+                                <MenuItem
+                                    x:Name="menuMoveDown"
+                                    Height="{StaticResource MenuItemHeight}"
+                                    Header="{x:Static resx:ResUI.menuMoveDown}"
+                                    InputGestureText="D" />
+                                <MenuItem
+                                    x:Name="menuMoveBottom"
+                                    Height="{StaticResource MenuItemHeight}"
+                                    Header="{x:Static resx:ResUI.menuMoveBottom}"
+                                    InputGestureText="B" />
+                            </ContextMenu>
+                        </DataGrid.ContextMenu>
+                        <DataGrid.Columns>
+                            <DataGridTextColumn
+                                Width="150"
+                                Binding="{Binding ConfigType}"
+                                Header="{x:Static resx:ResUI.LvServiceType}" />
+                            <DataGridTextColumn
+                                Width="200"
+                                Binding="{Binding Remarks}"
+                                Header="{x:Static resx:ResUI.LvRemarks}" />
+                            <DataGridTextColumn
+                                Width="200"
+                                Binding="{Binding Address}"
+                                Header="{x:Static resx:ResUI.LvAddress}" />
+                            <DataGridTextColumn
+                                Width="100"
+                                Binding="{Binding Port}"
+                                Header="{x:Static resx:ResUI.LvPort}" />
+                            <DataGridTextColumn
+                                Width="100"
+                                Binding="{Binding Network}"
+                                Header="{x:Static resx:ResUI.LvTransportProtocol}" />
+                            <DataGridTextColumn
+                                Width="100"
+                                Binding="{Binding StreamSecurity}"
+                                Header="{x:Static resx:ResUI.LvTLS}" />
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </DockPanel>
             </TabItem>
             <TabItem HorizontalAlignment="Left" Header="{x:Static resx:ResUI.menuServerListPreview}">
                 <DataGrid

--- a/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddGroupServerWindow.xaml.cs
@@ -10,6 +10,7 @@ public partial class AddGroupServerWindow
         Loaded += Window_Loaded;
         PreviewKeyDown += AddGroupServerWindow_PreviewKeyDown;
         lstChild.SelectionChanged += LstChild_SelectionChanged;
+        lstChild.LoadingRow += LstChild_LoadingRow;
         menuSelectAllChild.Click += MenuSelectAllChild_Click;
         tabControl.SelectionChanged += TabControl_SelectionChanged;
 
@@ -38,6 +39,7 @@ public partial class AddGroupServerWindow
                 if (tabControl.Items.Count > 0)
                 {
                     tabControl.Items.RemoveAt(0);
+                    tabControl.SelectedIndex = 0;
                 }
                 break;
         }
@@ -51,16 +53,22 @@ public partial class AddGroupServerWindow
             this.Bind(ViewModel, vm => vm.SelectedSubItem, v => v.cmbSubChildItems.SelectedItem).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.Filter, v => v.cmbFilter.Text).DisposeWith(disposables);
 
+            this.OneWayBind(ViewModel, vm => vm.ChildListTip, v => v.txtChildListTip.Text).DisposeWith(disposables);
             this.OneWayBind(ViewModel, vm => vm.ChildItemsObs, v => v.lstChild.ItemsSource).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedChild, v => v.lstChild.SelectedItem).DisposeWith(disposables);
 
             this.OneWayBind(ViewModel, vm => vm.AllProfilePreviewItemsObs, v => v.lstPreviewChild.ItemsSource).DisposeWith(disposables);
 
             this.BindCommand(ViewModel, vm => vm.RemoveCmd, v => v.menuRemoveChildServer).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.RemoveCmd, v => v.btnRemoveChildServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.MoveTopCmd, v => v.menuMoveTop).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.MoveTopCmd, v => v.btnMoveTop).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.MoveUpCmd, v => v.menuMoveUp).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.MoveUpCmd, v => v.btnMoveUp).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.MoveDownCmd, v => v.menuMoveDown).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.MoveDownCmd, v => v.btnMoveDown).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.MoveBottomCmd, v => v.menuMoveBottom).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.MoveBottomCmd, v => v.btnMoveBottom).DisposeWith(disposables);
 
             this.BindCommand(ViewModel, vm => vm.SaveCmd, v => v.btnSave).DisposeWith(disposables);
         });
@@ -143,6 +151,11 @@ public partial class AddGroupServerWindow
         {
             ViewModel.SelectedChildren = lstChild.SelectedItems.Cast<ProfileItem>().ToList();
         }
+    }
+
+    private void LstChild_LoadingRow(object? sender, System.Windows.Controls.DataGridRowEventArgs e)
+    {
+        e.Row.Header = $" {e.Row.GetIndex() + 1}";
     }
 
     private void MenuSelectAllChild_Click(object sender, RoutedEventArgs e)

--- a/v2rayN/v2rayN/Views/RoutingRuleDetailsWindow.xaml
+++ b/v2rayN/v2rayN/Views/RoutingRuleDetailsWindow.xaml
@@ -93,7 +93,7 @@
                 Margin="{StaticResource Margin4}"
                 VerticalAlignment="Center"
                 Style="{StaticResource ToolbarTextBlock}"
-                Text="outboundTag" />
+                Text="{x:Static resx:ResUI.TbRuleOutbound}" />
             <ComboBox
                 x:Name="cmbOutboundTag"
                 Grid.Row="2"
@@ -119,7 +119,7 @@
                     Margin="{StaticResource Margin4}"
                     VerticalAlignment="Center"
                     Style="{StaticResource ToolbarTextBlock}"
-                    Text="{x:Static resx:ResUI.TbRuleOutboundTagTip}" />
+                    Text="{x:Static resx:ResUI.TbRuleOutboundProfileTip}" />
             </StackPanel>
 
             <TextBlock

--- a/v2rayN/v2rayN/Views/RoutingRuleDetailsWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/RoutingRuleDetailsWindow.xaml.cs
@@ -13,7 +13,6 @@ public partial class RoutingRuleDetailsWindow
 
         ViewModel = new RoutingRuleDetailsViewModel(rulesItem, UpdateViewHandler);
 
-        cmbOutboundTag.ItemsSource = Global.OutboundTags;
         clbProtocol.ItemsSource = Global.RuleProtocols;
         clbInboundTag.ItemsSource = Global.InboundTags;
         cmbNetwork.ItemsSource = Global.RuleNetworks;
@@ -34,6 +33,7 @@ public partial class RoutingRuleDetailsWindow
         this.WhenActivated(disposables =>
         {
             this.Bind(ViewModel, vm => vm.SelectedSource.Remarks, v => v.txtRemarks.Text).DisposeWith(disposables);
+            this.OneWayBind(ViewModel, vm => vm.OutboundTagItems, v => v.cmbOutboundTag.ItemsSource).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.OutboundTag, v => v.cmbOutboundTag.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Port, v => v.txtPort.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Network, v => v.cmbNetwork.Text).DisposeWith(disposables);
@@ -96,6 +96,7 @@ public partial class RoutingRuleDetailsWindow
             if (profile != null)
             {
                 cmbOutboundTag.Text = profile.Remarks;
+                await ViewModel.CheckOutboundProfileRemarkDuplicate(profile.Remarks);
             }
         }
     }


### PR DESCRIPTION
  ## Summary

  This PR improves the proxy chain routing workflow and makes the existing capability easier to discover and use.

  Changes included:

  - Add visible child node controls to policy group / proxy chain edit windows
    - Add child
    - Remove child
    - Move top / up / down / bottom
  - Add proxy chain order guidance in the edit window
  - Show row headers for child node order in the WPF edit window
  - Clarify routing rule outbound selection
    - `proxy/direct/block`
    - selected profile
    - policy group
    - proxy chain
  - Add duplicate profile remarks warning when selecting a routing outbound profile
  - Add tests for routing Claude/Anthropic domains to a proxy chain while keeping default traffic on the main proxy

  ## Manual verification

  I verified the proxy chain routing workflow with a real setup:

  - Created a `sing_box` proxy chain named `claude链式代理-日本`
  - Added two ordered child nodes:
    - `AnyTLS` Japan node
    - `SOCKS` residential IP node
  - Confirmed the new editor buttons make the chain configuration visible and editable
  - Used the proxy chain as the outbound target for Claude-related routing rules
  - Confirmed Claude traffic goes through the proxy chain, while unmatched traffic continues to use the currently
  selected main node
  
<img width="886" height="693" alt="image" src="https://github.com/user-attachments/assets/f9dd30e7-b225-45ce-9a49-a7c3748ff751" />
