### PR TITLE
fix: 在窗口初始化前设置保存的尺寸，消除启动时偏右下偏移

### DIFF
--- a/v2rayN/v2rayN.Desktop/Base/WindowBase.cs
+++ b/v2rayN/v2rayN.Desktop/Base/WindowBase.cs
@@ -18,9 +18,18 @@ public class WindowBase<TViewModel> : ReactiveWindow<TViewModel> where TViewMode
         try
         {
             var sizeItem = ConfigHandler.GetWindowSizeItem(AppManager.Instance.Config, GetType().Name);
-            if (sizeItem != null)
+            if (sizeItem is null)
+            {
+                return;
+            }
+
+            if (sizeItem.Width > 0 && !Width.Equals(sizeItem.Width))
             {
                 Width = sizeItem.Width;
+            }
+
+            if (sizeItem.Height > 0 && !Height.Equals(sizeItem.Height))
+            {
                 Height = sizeItem.Height;
             }
         }

--- a/v2rayN/v2rayN.Desktop/Base/WindowBase.cs
+++ b/v2rayN/v2rayN.Desktop/Base/WindowBase.cs
@@ -4,6 +4,7 @@ public class WindowBase<TViewModel> : ReactiveWindow<TViewModel> where TViewMode
 {
     public WindowBase()
     {
+        Initialized += OnWindowInitialized;
         Loaded += OnLoaded;
     }
 
@@ -12,28 +13,22 @@ public class WindowBase<TViewModel> : ReactiveWindow<TViewModel> where TViewMode
         throw new NotImplementedException();
     }
 
-    protected virtual void OnLoaded(object? sender, RoutedEventArgs e)
+    private void OnWindowInitialized(object? sender, EventArgs e)
     {
         try
         {
             var sizeItem = ConfigHandler.GetWindowSizeItem(AppManager.Instance.Config, GetType().Name);
-            if (sizeItem == null)
+            if (sizeItem != null)
             {
-                return;
+                Width = sizeItem.Width;
+                Height = sizeItem.Height;
             }
-
-            Width = sizeItem.Width;
-            Height = sizeItem.Height;
-
-            var workingArea = (Screens.ScreenFromWindow(this) ?? Screens.Primary).WorkingArea;
-            var scaling = (Utils.IsMacOS() ? null : VisualRoot?.RenderScaling) ?? 1.0;
-
-            var x = workingArea.X + ((workingArea.Width - (Width * scaling)) / 2);
-            var y = workingArea.Y + ((workingArea.Height - (Height * scaling)) / 2);
-
-            Position = new PixelPoint((int)x, (int)y);
         }
         catch { }
+    }
+
+    protected virtual void OnLoaded(object? sender, RoutedEventArgs e)
+    {
     }
 
     protected override void OnClosed(EventArgs e)


### PR DESCRIPTION
 ### 问题
  Avalonia Desktop 版启动时，主窗口异常向右下偏移，未能正确居中。

  ### 原因
  `WindowBase.OnLoaded` 中有一段手工居中计算：

  ```csharp
  var x = workingArea.X + ((workingArea.Width - (Width * scaling)) / 2);
  var y = workingArea.Y + ((workingArea.Height - (Height * scaling)) / 2);
  Position = new PixelPoint((int)x, (int)y);
  ```
  
  Width * scaling 仅为客户区像素宽度，不包含窗口边框/标题栏（chrome）。而 Position 定位的是完整窗口（含
  chrome）的左上角，计算结果导致窗口偏右下。

  同时 XAML 已设置 WindowStartupLocation="CenterScreen"，它原本能正确居中（Avalonia 内部已处理 chrome），但被 OnLoaded
  中的手工 Position 覆盖，适得其反。

  修复

  在 Initialized 事件（Show() 过程中触发，早于 WindowStartupLocation 生效）中设置保存的 Width/Height。这样 CenterScreen
  从初始就能用正确的尺寸居中，不再需要手工计算 Position。

  改动

  仅一个文件 v2rayN.Desktop/Base/WindowBase.cs，+9/-14 行：

  - 构造函数增加 Initialized += OnWindowInitialized，在 Initialized 中设置保存的 Width/Height
  - OnLoaded 删除旧的手工 Position 计算和重复的 Width/Height 设置（Initialized 已提前处理）
  - 保留空虚方法 OnLoaded — MainWindow.OnLoaded 的 base.OnLoaded() 调用依赖它

  测试

  - 打开应用 → 调整窗口大小 → 关闭 → 重新打开 → 窗口正确居中，无偏移