### PR TITLE
Disable .NET 9+ CET feature

### DIFF
--- a/v2rayN/v2rayN.Desktop/v2rayN.Desktop.csproj
+++ b/v2rayN/v2rayN.Desktop/v2rayN.Desktop.csproj
@@ -7,6 +7,7 @@
 		<AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
 		<AssemblyName>v2rayN</AssemblyName>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<CETCompat>false</CETCompat>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/v2rayN/v2rayN/v2rayN.csproj
+++ b/v2rayN/v2rayN/v2rayN.csproj
@@ -10,6 +10,7 @@
 		<ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
 		<SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<CETCompat>false</CETCompat>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
关闭CET验证，以解决win10 22h以前的版本，未更新微软补丁导致的闪退

<img width="797" height="668" alt="image" src="https://github.com/user-attachments/assets/8371d2af-9d18-462f-bb3c-09837b262595" />


[https://github.com/dotnet/runtime/issues/110920](url)
[https://github.com/dotnet/docs/issues/42600](url)

