### PR TITLE
macOS TUN DNS 绕过修复

### DIFF
--- a/v2rayN/ServiceLib/Global.cs
+++ b/v2rayN/ServiceLib/Global.cs
@@ -41,6 +41,7 @@ public class Global
     public const string ProxySetLinuxShellFileName = NamespaceSample + "proxy_set_linux_sh";
     public const string KillAsSudoOSXShellFileName = NamespaceSample + "kill_as_sudo_osx_sh";
     public const string KillAsSudoLinuxShellFileName = NamespaceSample + "kill_as_sudo_linux_sh";
+    public const string TunDnsOSXShellFileName = NamespaceSample + "tun_dns_osx_sh";
     public const string SingboxFakeIPFilterFileName = NamespaceSample + "singbox_fakeip_filter";
 
     public const string DefaultSecurity = "auto";

--- a/v2rayN/ServiceLib/Manager/CoreAdminManager.cs
+++ b/v2rayN/ServiceLib/Manager/CoreAdminManager.cs
@@ -31,9 +31,14 @@ public class CoreAdminManager
 
     public async Task<ProcessService?> RunProcessAsLinuxSudo(string fileName, CoreInfo coreInfo, string configPath)
     {
+        var absoluteConfigPath = Utils.GetBinConfigPath(configPath);
+        var manageMacOSTunDns = Utils.IsMacOS()
+            && coreInfo.CoreType == ECoreType.sing_box
+            && HasDnsHijackAction(absoluteConfigPath);
+
         StringBuilder sb = new();
         sb.AppendLine("#!/bin/bash");
-        var cmdLine = $"{fileName.AppendQuotes()} {string.Format(coreInfo.Arguments, Utils.GetBinConfigPath(configPath).AppendQuotes())}";
+        var cmdLine = $"{fileName.AppendQuotes()} {string.Format(coreInfo.Arguments, absoluteConfigPath.AppendQuotes())}";
         sb.AppendLine($"exec sudo -S -- {cmdLine}");
         var shFilePath = await FileUtils.CreateLinuxShellFile("run_as_sudo.sh", sb.ToString(), true);
 
@@ -47,21 +52,41 @@ public class CoreAdminManager
             updateFunc: _updateFunc
         );
 
-        await procService.StartAsync(AppManager.Instance.LinuxSudoPwd);
-
-        if (procService is null or { HasExited: true })
+        try
         {
-            throw new Exception(ResUI.FailedToRunCore);
-        }
-        _linuxSudoPid = procService.Id;
+            await procService.StartAsync(AppManager.Instance.LinuxSudoPwd);
 
-        return procService;
+            if (procService is null or { HasExited: true })
+            {
+                throw new Exception(ResUI.FailedToRunCore);
+            }
+            _linuxSudoPid = procService.Id;
+
+            if (manageMacOSTunDns)
+            {
+                await RunMacOSTunDnsScript("set");
+            }
+
+            return procService;
+        }
+        catch
+        {
+            if (Utils.IsMacOS())
+            {
+                await RunMacOSTunDnsScript("restore");
+            }
+            throw;
+        }
     }
 
     public async Task KillProcessAsLinuxSudo()
     {
         if (_linuxSudoPid < 0)
         {
+            if (Utils.IsMacOS())
+            {
+                await RunMacOSTunDnsScript("restore");
+            }
             return;
         }
 
@@ -87,5 +112,49 @@ public class CoreAdminManager
         }
 
         _linuxSudoPid = -1;
+        if (Utils.IsMacOS())
+        {
+            await RunMacOSTunDnsScript("restore");
+        }
+    }
+
+    private static bool HasDnsHijackAction(string configPath)
+    {
+        try
+        {
+            var rules = JsonNode.Parse(File.ReadAllText(configPath))?["route"]?["rules"]?.AsArray();
+            return rules?.Any(rule =>
+                string.Equals(rule?["action"]?.GetValue<string>(), "hijack-dns", StringComparison.Ordinal)) == true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static async Task RunMacOSTunDnsScript(string action)
+    {
+        try
+        {
+            var scriptPath = await FileUtils.CreateLinuxShellFile(
+                "tun_dns_osx.sh",
+                EmbedUtils.GetEmbedText(Global.TunDnsOSXShellFileName),
+                false);
+            var statePath = Utils.GetConfigPath("macos_tun_dns_state");
+            var result = await Cli.Wrap("/usr/bin/sudo")
+                .WithArguments(["-S", "--", scriptPath, action, statePath])
+                .WithStandardInputPipe(PipeSource.FromString(AppManager.Instance.LinuxSudoPwd + Environment.NewLine))
+                .WithValidation(CommandResultValidation.None)
+                .ExecuteBufferedAsync();
+
+            if (result.ExitCode != 0)
+            {
+                Logging.SaveLog($"macOS TUN DNS script failed: {result.StandardError}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logging.SaveLog(_tag, ex);
+        }
     }
 }

--- a/v2rayN/ServiceLib/Sample/tun_dns_osx_sh
+++ b/v2rayN/ServiceLib/Sample/tun_dns_osx_sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+ACTION=$1
+STATE_FILE=$2
+TEMP_DNS="1.1.1.1 1.0.0.1"
+
+[ -n "$STATE_FILE" ] || {
+    echo "Usage: $0 {set|restore} <state-file>" >&2
+    exit 1
+}
+
+configured_dns() {
+    /usr/sbin/networksetup -getdnsservers "$1" | \
+        /usr/bin/awk '/^[0-9a-fA-F:.%]+$/ { print }'
+}
+
+restore_dns() {
+    [ -f "$STATE_FILE" ] || return 0
+
+    SERVICE=$(/usr/bin/sed -n '1p' "$STATE_FILE")
+    CURRENT_DNS=$(configured_dns "$SERVICE" | /usr/bin/paste -sd ' ' -)
+
+    # Do not overwrite DNS changed by the user or another application.
+    if [ "$CURRENT_DNS" != "$TEMP_DNS" ]; then
+        /bin/rm -f "$STATE_FILE"
+        return 0
+    fi
+
+    ORIGINAL_DNS=$(/usr/bin/sed -n '2,$p' "$STATE_FILE")
+    if [ -z "$ORIGINAL_DNS" ]; then
+        /usr/sbin/networksetup -setdnsservers "$SERVICE" Empty
+    else
+        # DNS server values cannot contain shell whitespace.
+        # shellcheck disable=SC2086
+        /usr/sbin/networksetup -setdnsservers "$SERVICE" $ORIGINAL_DNS
+    fi
+    /bin/rm -f "$STATE_FILE"
+}
+
+is_private_dns() {
+    case "$1" in
+        10.*|192.168.*|169.254.*|fe80:*|FE80:*|fc*|FC*|fd*|FD*)
+            return 0
+            ;;
+        172.*)
+            SECOND=$(printf '%s' "$1" | /usr/bin/cut -d. -f2)
+            [ "$SECOND" -ge 16 ] 2>/dev/null && [ "$SECOND" -le 31 ] 2>/dev/null
+            return
+            ;;
+    esac
+    return 1
+}
+
+service_for_interface() {
+    # networksetup changes a network service (for example, Wi-Fi), not a BSD
+    # interface name (for example, en0).
+    /usr/sbin/networksetup -listnetworkserviceorder | \
+        /usr/bin/awk -v device="$1" '
+            /^\([0-9*]+\) / {
+                service=$0
+                sub(/^\([0-9*]+\) /, "", service)
+                next
+            }
+            index($0, "Device: " device ")") {
+                print service
+                exit
+            }
+        '
+}
+
+find_bypassing_service() {
+    # Keep each resolver's nameservers paired with its scoped interface.
+    # scutil prints nameservers before the corresponding if_index line.
+    RESOLVERS=$(/usr/sbin/scutil --dns | /usr/bin/awk '
+        function emit(i) {
+            if (interface != "" && supplemental == 0) {
+                for (i = 1; i <= count; i++) {
+                    print servers[i], interface
+                }
+            }
+        }
+        /^resolver #[0-9]+$/ {
+            emit()
+            for (i = 1; i <= count; i++) {
+                delete servers[i]
+            }
+            count = 0
+            interface = ""
+            supplemental = 0
+            next
+        }
+        /^[[:space:]]*domain[[:space:]]*:/ {
+            supplemental = 1
+            next
+        }
+        /nameserver\[[0-9]+\]/ {
+            servers[++count] = $3
+            next
+        }
+        /if_index/ && match($0, /\([^()]+\)/) {
+            interface = substr($0, RSTART + 1, RLENGTH - 2)
+        }
+        END {
+            emit()
+        }
+    ')
+
+    while read -r DNS_SERVER RESOLVER_INTERFACE; do
+        [ -n "$DNS_SERVER" ] && [ -n "$RESOLVER_INTERFACE" ] || continue
+        is_private_dns "$DNS_SERVER" || continue
+
+        DNS_INTERFACE=$(/sbin/route -n get "$DNS_SERVER" 2>/dev/null | \
+            /usr/bin/awk '/interface:/ { print $2; exit }')
+        # A private DNS bypasses TUN only when its resolver scope and actual
+        # route both point to the same configurable physical network service.
+        [ "$DNS_INTERFACE" = "$RESOLVER_INTERFACE" ] || continue
+
+        SERVICE=$(service_for_interface "$RESOLVER_INTERFACE")
+        [ -n "$SERVICE" ] || continue
+        return 0
+    done <<EOF
+$RESOLVERS
+EOF
+    return 1
+}
+
+case "$ACTION" in
+    set)
+        restore_dns
+        find_bypassing_service || exit 0
+
+        {
+            printf '%s\n' "$SERVICE"
+            configured_dns "$SERVICE"
+        } > "$STATE_FILE"
+        /bin/chmod 600 "$STATE_FILE"
+
+        if ! /usr/sbin/networksetup -setdnsservers "$SERVICE" $TEMP_DNS; then
+            /bin/rm -f "$STATE_FILE"
+            exit 1
+        fi
+        ;;
+    restore)
+        restore_dns
+        ;;
+    *)
+        echo "Usage: $0 {set|restore} <state-file>" >&2
+        exit 1
+        ;;
+esac

--- a/v2rayN/ServiceLib/ServiceLib.csproj
+++ b/v2rayN/ServiceLib/ServiceLib.csproj
@@ -32,6 +32,7 @@
 		<EmbeddedResource Include="Sample\dns_v2ray_normal" />
 		<EmbeddedResource Include="Sample\kill_as_sudo_linux_sh" />
 		<EmbeddedResource Include="Sample\kill_as_sudo_osx_sh" />
+		<EmbeddedResource Include="Sample\tun_dns_osx_sh" />
 		<EmbeddedResource Include="Sample\pac" />
 		<EmbeddedResource Include="Sample\proxy_set_linux_sh" /> 
 		<EmbeddedResource Include="Sample\proxy_set_osx_sh" />


### PR DESCRIPTION
## 1. 问题原因

macOS 开启 TUN 后，由于最长前缀匹配，DNS 请求直接走物理网卡，绕过 `hijack-dns`，造成真实 DNS 泄漏。

Mac 通过 DHCP 获得 DNS `192.168.1.1`，系统同时生成 `192.168.1.0/24 -> en0` 的局域网直连路由。该路由比 TUN 的分段默认路由更具体，因此 macOS 仍会把 DNS 查询交给 `en0`：

```text
macOS 发出 DNS 请求 -> 192.168.1.1
-> 命中更具体的 192.168.1.0/24 路由
-> 通过 en0 发送
-> 没有 WFP 阻止
-> 绕过 TUN 和 hijack-dns
```

Windows 没有复现该问题，是因为启用 `strict_route` 后，sing-box 会使用 Windows WFP 阻止 53 端口流量从非 TUN 网卡发出。macOS 没有这层 Windows 专用拦截。

```text
Windows 应用发出 DNS 请求 -> 私有 DNS:53
-> 即使路由表准备通过物理网卡发送
-> WFP 阻止非 TUN 接口上的 53 端口流量
-> DNS 只能进入 TUN
-> 由 hijack-dns 接管
```

## 2. 解决办法

`CoreAdminManager` 启动 sing-box 后，程序先检查当前配置是否包含 `hijack-dns`。只有同时满足 macOS、sing-box 和已启用 DNS 劫持三个条件时，才执行修复脚本。

脚本通过 `scutil --dns` 读取每个 DNS 及其绑定接口，并过滤企业 VPN 等分域 DNS；随后使用 `route -n get` 判断私有 DNS 是否仍从对应的物理网卡直连。

确认发生绕过后，脚本先把网络服务名称和原 DNS 写入状态文件，再通过 `networksetup` 临时设置 Cloudflare DNS：

```text
1.1.1.1
1.0.0.1
```

关闭 TUN 或核心启动失败时，程序会读取状态文件并恢复原设置：

- 原来使用 DHCP：恢复为自动获取 DNS；
- 原来使用手动 DNS：恢复原来的 DNS；
- 用户在运行期间修改过 DNS：保留用户的新设置，不进行覆盖。

## 3. 测试结果

测试时关闭系统代理，并直接使用 DHCP。开启修复版 TUN 后，macOS DNS 变为 1.1.1.1 和 1.0.0.1，两者经 route -n get 确认都走 utun43，不再通过 en0 访问 192.168.1.1。关闭TUN 后恢复原有DNS状态。


