### PR TITLE
fix: 移除子对话框的最小化/最大化按钮

### DIFF
--- a/v2rayN/v2rayN.Desktop/Base/WindowBase.cs
+++ b/v2rayN/v2rayN.Desktop/Base/WindowBase.cs
@@ -6,6 +6,14 @@ public class WindowBase<TViewModel> : ReactiveWindow<TViewModel> where TViewMode
     {
         Initialized += OnWindowInitialized;
         Loaded += OnLoaded;
+        Loaded += (s, e) =>
+        {
+            if (Owner != null && !ShowInTaskbar)
+            {
+                CanMinimize = false;
+                CanMaximize = false;
+            }
+        };
     }
 
     private void ReactiveWindowBase_Closed(object? sender, EventArgs e)

--- a/v2rayN/v2rayN.Desktop/Views/MessageBoxDialog.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MessageBoxDialog.axaml.cs
@@ -18,6 +18,9 @@ public partial class MessageBoxDialog : Window
 
         btnYes.Click += BtnYes_Click;
         btnNo.Click += BtnNo_Click;
+
+        CanMinimize = false;
+        CanMaximize = false;
     }
 
     private void BtnYes_Click(object? sender, RoutedEventArgs e)

--- a/v2rayN/v2rayN/Base/WindowBase.cs
+++ b/v2rayN/v2rayN/Base/WindowBase.cs
@@ -4,7 +4,16 @@ public class WindowBase<TViewModel> : ReactiveWindow<TViewModel> where TViewMode
 {
     public WindowBase()
     {
+        SourceInitialized += OnSourceInitialized;
         Loaded += OnLoaded;
+    }
+
+    private void OnSourceInitialized(object? sender, EventArgs e)
+    {
+        if (Owner != null && !ShowInTaskbar)
+        {
+            WindowsUtils.RemoveMinMaxButtons(this);
+        }
     }
 
     protected virtual void OnLoaded(object? sender, RoutedEventArgs e)

--- a/v2rayN/v2rayN/Common/WindowsUtils.cs
+++ b/v2rayN/v2rayN/Common/WindowsUtils.cs
@@ -80,7 +80,36 @@ internal static partial class WindowsUtils
         return value == 0;
     }
 
+    [LibraryImport("user32.dll")]
+    private static partial int GetWindowLongW(nint hWnd, int nIndex);
+
+    [LibraryImport("user32.dll")]
+    private static partial int SetWindowLongW(nint hWnd, int nIndex, int dwNewLong);
+
+    [LibraryImport("user32.dll")]
+    private static partial int SetWindowPos(nint hWnd, nint hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
+
+    public static void RemoveMinMaxButtons(Window window)
+    {
+        var hWnd = new WindowInteropHelper(window).EnsureHandle();
+        var style = GetWindowLongW(hWnd, GWL_STYLE);
+        if ((style & (WS_MINIMIZEBOX | WS_MAXIMIZEBOX)) != 0)
+        {
+            SetWindowLongW(hWnd, GWL_STYLE, style & ~(WS_MINIMIZEBOX | WS_MAXIMIZEBOX));
+            SetWindowPos(hWnd, 0, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+        }
+    }
+
     #region Windows API
+
+    private const int GWL_STYLE = -16;
+    private const int WS_MINIMIZEBOX = 0x00020000;
+    private const int WS_MAXIMIZEBOX = 0x00010000;
+    private const int SWP_NOSIZE = 0x0001;
+    private const int SWP_NOMOVE = 0x0002;
+    private const int SWP_NOZORDER = 0x0004;
+    private const int SWP_NOACTIVATE = 0x0010;
+    private const int SWP_FRAMECHANGED = 0x0020;
 
     [Flags]
     public enum DWMWINDOWATTRIBUTE : uint


### PR DESCRIPTION
  ## 问题

  在 Windows 上，打开任意子对话框后最小化窗口时，屏幕左下角会出现浮动标题栏。根因是窗口同时设置了
  `ResizeMode="CanResize"`（启用最小化按钮）和 `ShowInTaskbar="False"`（不在任务栏显示），最小化后 Windows
  无法将窗口停靠到任务栏，只能渲染一个脱离的浮动栏。

  ## 修复

  移除所有子对话框的最小化/最大化按钮，保留窗口可调整大小的能力，从根源消除浮动栏。

  | 平台 | 机制 | 条件 |
  |------|------|------|
  | Desktop (Avalonia) | 原生 `CanMinimize = false; CanMaximize = false` | `Owner != null && !ShowInTaskbar` |
  | WPF | Win32 API 移除 `WS_MINIMIZEBOX` / `WS_MAXIMIZEBOX` | `Owner != null && !ShowInTaskbar` |

  ## 影响范围

  主窗口不受影响（`Owner` 为 null 且 `ShowInTaskbar` 为 true）。以下子对话框去除最小化/最大化按钮：

  **WPF** (12)
  `AddServerWindow` `AddServer2Window` `AddGroupServerWindow` `DNSSettingWindow` `FullConfigTemplateWindow`
  `GlobalHotkeySettingWindow` `OptionSettingWindow` `RoutingRuleDetailsWindow` `RoutingRuleSettingWindow`
  `RoutingSettingWindow` `SubEditWindow` `SubSettingWindow`

  **Desktop** (13)
  `AddServerWindow` `AddServer2Window` `AddGroupServerWindow` `DNSSettingWindow` `FullConfigTemplateWindow`
  `GlobalHotkeySettingWindow` `MessageBoxDialog` `OptionSettingWindow` `RoutingRuleDetailsWindow`
  `RoutingRuleSettingWindow` `RoutingSettingWindow` `SubEditWindow` `SubSettingWindow`

  ## 变更

  | 文件 | 新增 |
  |------|------|
  | `v2rayN.Desktop/Base/WindowBase.cs` | `OnLoaded_DisableMinMax` private handler |
  | `v2rayN.Desktop/Views/MessageBoxDialog.axaml.cs` | 构造函数设 CanMinimize/CanMaximize |
  | `v2rayN/Base/WindowBase.cs` | `OnSourceInitialized` → RemoveMinMaxButtons |
  | `v2rayN/Common/WindowsUtils.cs` | P/Invoke + RemoveMinMaxButtons|