### PR TITLE
fix: Desktop(Avalonia) 移除子对话框最小化按钮，仅禁 CanMinimize

### DIFF
--- a/v2rayN/v2rayN.Desktop/Base/WindowBase.cs
+++ b/v2rayN/v2rayN.Desktop/Base/WindowBase.cs
@@ -6,6 +6,13 @@ public class WindowBase<TViewModel> : ReactiveWindow<TViewModel> where TViewMode
     {
         Initialized += OnWindowInitialized;
         Loaded += OnLoaded;
+        Loaded += (s, e) =>
+        {
+            if (Owner != null && !ShowInTaskbar)
+            {
+                CanMinimize = false;
+            }
+        };
     }
 
     private void ReactiveWindowBase_Closed(object? sender, EventArgs e)

--- a/v2rayN/v2rayN.Desktop/Views/MessageBoxDialog.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MessageBoxDialog.axaml.cs
@@ -18,6 +18,8 @@ public partial class MessageBoxDialog : Window
 
         btnYes.Click += BtnYes_Click;
         btnNo.Click += BtnNo_Click;
+
+        CanMinimize = false;
     }
 
     private void BtnYes_Click(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
closes #9525 