### PR TITLE
Add IP geolocation display and direct subscription recovery

### DIFF
--- a/v2rayN/ServiceLib.Tests/Connection/ConnectionHandlerTests.cs
+++ b/v2rayN/ServiceLib.Tests/Connection/ConnectionHandlerTests.cs
@@ -68,4 +68,15 @@ public class ConnectionHandlerTests
 
         result.Should().BeNull();
     }
+
+    [Theory]
+    [InlineData(42, true)]
+    [InlineData(0, false)]
+    [InlineData(-1, false)]
+    public void AvailabilityCheckResult_IsAvailable_ShouldReflectPositiveResponseTime(int responseTime, bool expected)
+    {
+        var result = new AvailabilityCheckResult(responseTime, Global.None);
+
+        result.IsAvailable.Should().Be(expected);
+    }
 }

--- a/v2rayN/ServiceLib.Tests/Connection/ConnectionHandlerTests.cs
+++ b/v2rayN/ServiceLib.Tests/Connection/ConnectionHandlerTests.cs
@@ -1,0 +1,71 @@
+using AwesomeAssertions;
+using Xunit;
+
+namespace ServiceLib.Tests.Connection;
+
+public class ConnectionHandlerTests
+{
+    [Fact]
+    public void ParseIPInfo_IpWhoIsResponse_ShouldIncludeRegionAndCity()
+    {
+        const string json = """
+                            {
+                              "ip": "192.0.2.10",
+                              "country": "Example Country",
+                              "country_code": "ZZ",
+                              "region": "Example Region",
+                              "city": "Example City"
+                            }
+                            """;
+
+        var result = ConnectionHandler.ParseIPInfo(json);
+
+        result.Should().NotBeNull();
+        result!.Value.Country.Should().Be("ZZ");
+        result.Value.Region.Should().Be("Example Region");
+        result.Value.City.Should().Be("Example City");
+        result.Value.Ip.Should().Be("192.0.2.10");
+        result.Value.ToString().Should().Be("ZZ Example Region Example City 192.0.2.10");
+    }
+
+    [Fact]
+    public void ParseIPInfo_ApiIpapiIsLocationResponse_ShouldUseNestedLocation()
+    {
+        const string json = """
+                            {
+                              "ip": "198.51.100.20",
+                              "location": {
+                                "country": "Example Country",
+                                "country_code": "ZZ",
+                                "state": "Example State",
+                                "city": "Example City"
+                              }
+                            }
+                            """;
+
+        var result = ConnectionHandler.ParseIPInfo(json);
+
+        result.Should().NotBeNull();
+        result!.Value.Country.Should().Be("ZZ");
+        result.Value.Region.Should().Be("Example State");
+        result.Value.City.Should().Be("Example City");
+        result.Value.Ip.Should().Be("198.51.100.20");
+        result.Value.ToString().Should().Contain("Example State Example City 198.51.100.20");
+    }
+
+    [Fact]
+    public void IpInfoResult_ToString_ShouldSkipDuplicateLocationParts()
+    {
+        var result = new IpInfoResult("ZZ", "203.0.113.30", "Example City", "Example City");
+
+        result.ToString().Should().Be("ZZ Example City 203.0.113.30");
+    }
+
+    [Fact]
+    public void ParseIPInfo_InvalidJson_ShouldReturnNull()
+    {
+        var result = ConnectionHandler.ParseIPInfo("not-json");
+
+        result.Should().BeNull();
+    }
+}

--- a/v2rayN/ServiceLib.Tests/Connection/ConnectionHandlerTests.cs
+++ b/v2rayN/ServiceLib.Tests/Connection/ConnectionHandlerTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using System.Globalization;
 using Xunit;
 
 namespace ServiceLib.Tests.Connection;
@@ -70,6 +71,35 @@ public class ConnectionHandlerTests
     }
 
     [Theory]
+    [InlineData("https://ipwho.is/", "192.0.2.10", "https://ipwho.is/192.0.2.10")]
+    [InlineData("https://api.ip.sb/geoip", "192.0.2.10", "https://api.ip.sb/geoip/192.0.2.10")]
+    [InlineData("https://example.test/geo/{ip}", "192.0.2.10", "https://example.test/geo/192.0.2.10")]
+    [InlineData("https://example.test/geo/{0}", "192.0.2.10", "https://example.test/geo/192.0.2.10")]
+    [InlineData("https://api.ipapi.is", "192.0.2.10", "https://api.ipapi.is/?q=192.0.2.10")]
+    public void BuildIPInfoUrlForAddress_ShouldTargetSpecificIp(string apiUrl, string ip, string expected)
+    {
+        var result = ConnectionHandler.BuildIPInfoUrlForAddress(apiUrl, ip);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task ResolveAddressForIPInfo_PublicIp_ShouldReturnIp()
+    {
+        var result = await ConnectionHandler.ResolveAddressForIPInfo("192.0.2.10");
+
+        result.Should().Be("192.0.2.10");
+    }
+
+    [Fact]
+    public async Task ResolveAddressForIPInfo_PrivateIp_ShouldReturnNull()
+    {
+        var result = await ConnectionHandler.ResolveAddressForIPInfo("127.0.0.1");
+
+        result.Should().BeNull();
+    }
+
+    [Theory]
     [InlineData(42, true)]
     [InlineData(0, false)]
     [InlineData(-1, false)]
@@ -78,5 +108,24 @@ public class ConnectionHandlerTests
         var result = new AvailabilityCheckResult(responseTime, Global.None);
 
         result.IsAvailable.Should().Be(expected);
+    }
+
+    [Fact]
+    public void SubItem_FormatUpdateTimeAgo_ShouldShowChineseRelativeTime()
+    {
+        var oldCulture = CultureInfo.CurrentUICulture;
+        try
+        {
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("zh-Hans");
+            var now = DateTimeOffset.FromUnixTimeSeconds(1_700_000_000);
+            var updateTime = now.AddMinutes(-5).ToUnixTimeSeconds();
+
+            SubItem.FormatUpdateTimeAgo(updateTime, now).Should().Be("5 分钟前");
+            SubItem.FormatUpdateTimeAgo(0, now).Should().Be("未更新");
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = oldCulture;
+        }
     }
 }

--- a/v2rayN/ServiceLib/Global.cs
+++ b/v2rayN/ServiceLib/Global.cs
@@ -642,6 +642,7 @@ public class Global
 
     public static readonly List<string> IPAPIUrls =
     [
+        @"https://ipwho.is/",
         @"https://api.ip.sb/geoip",
         @"https://api-ipv4.ip.sb/geoip",
         @"https://api-ipv6.ip.sb/geoip",

--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -133,6 +133,10 @@ public static class ConfigHandler
         {
             config.SpeedTestItem.MixedConcurrencyCount = 5;
         }
+        if (config.SpeedTestItem.IPAPIUrl == null)
+        {
+            config.SpeedTestItem.IPAPIUrl = Global.IPAPIUrls.First();
+        }
         if (config.SpeedTestItem.UdpTestTarget.IsNullOrEmpty())
         {
             config.SpeedTestItem.UdpTestTarget = Global.UdpTestTargets.First();

--- a/v2rayN/ServiceLib/Handler/ConnectionHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConnectionHandler.cs
@@ -9,10 +9,18 @@ public static class ConnectionHandler
     /// </summary>
     public static async Task<string> RunAvailabilityCheck()
     {
+        return (await RunAvailabilityCheckResult()).ToString();
+    }
+
+    /// <summary>
+    /// Runs ping and IP checks and returns a structured result.
+    /// </summary>
+    public static async Task<AvailabilityCheckResult> RunAvailabilityCheckResult()
+    {
         var time = await GetRealPingTimeInfo();
         var ip = time > 0 ? await GetIPInfo() : Global.None;
 
-        return string.Format(ResUI.TestMeOutput, time, ip);
+        return new(time, ip);
     }
 
     /// <summary>

--- a/v2rayN/ServiceLib/Handler/ConnectionHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConnectionHandler.cs
@@ -134,6 +134,121 @@ public static class ConnectionHandler
     }
 
     /// <summary>
+    /// Gets IP and geolocation information for a server address.
+    /// </summary>
+    public static async Task<IpInfoResult?> GetIPInfoForAddress(string? address, bool blProxy)
+    {
+        try
+        {
+            var ip = await ResolveAddressForIPInfo(address);
+            if (ip.IsNullOrEmpty())
+            {
+                return null;
+            }
+
+            var url = BuildIPInfoUrlForAddress(AppManager.Instance.Config.SpeedTestItem.IPAPIUrl, ip);
+            if (url.IsNullOrEmpty())
+            {
+                return null;
+            }
+
+            var downloadHandle = new DownloadService();
+            var result = await downloadHandle.TryDownloadString(url, blProxy, Global.AppName);
+            if (result == null)
+            {
+                return null;
+            }
+
+            return ParseIPInfo(result);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Builds an IP API URL that targets a specific server IP.
+    /// </summary>
+    public static string? BuildIPInfoUrlForAddress(string? apiUrl, string? ip)
+    {
+        if (apiUrl.IsNullOrEmpty() || ip.IsNullOrEmpty())
+        {
+            return null;
+        }
+
+        var escapedIp = Uri.EscapeDataString(ip.TrimEx());
+        if (apiUrl.Contains("{0}", StringComparison.Ordinal))
+        {
+            return string.Format(apiUrl, escapedIp);
+        }
+        if (apiUrl.Contains("{ip}", StringComparison.OrdinalIgnoreCase))
+        {
+            return apiUrl.Replace("{ip}", escapedIp, StringComparison.OrdinalIgnoreCase);
+        }
+
+        var normalizedUrl = apiUrl.TrimEx().TrimEnd('/');
+        if (normalizedUrl.Contains("api.ipapi.is", StringComparison.OrdinalIgnoreCase))
+        {
+            return normalizedUrl.Contains('?', StringComparison.Ordinal)
+                ? $"{normalizedUrl}&q={escapedIp}"
+                : $"{normalizedUrl}/?q={escapedIp}";
+        }
+
+        return $"{normalizedUrl}/{escapedIp}";
+    }
+
+    /// <summary>
+    /// Resolves a server address to a public IP address for geolocation lookup.
+    /// </summary>
+    public static async Task<string?> ResolveAddressForIPInfo(string? address)
+    {
+        var host = NormalizeAddressForIPInfo(address);
+        if (host.IsNullOrEmpty())
+        {
+            return null;
+        }
+
+        if (IPAddress.TryParse(host, out var parsedAddress))
+        {
+            return Utils.IsPrivateNetwork(parsedAddress.ToString()) ? null : parsedAddress.ToString();
+        }
+
+        try
+        {
+            var addresses = await Dns.GetHostAddressesAsync(host);
+            return addresses
+                .Select(t => t.ToString())
+                .FirstOrDefault(t => !Utils.IsPrivateNetwork(t));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? NormalizeAddressForIPInfo(string? address)
+    {
+        var host = address?.Trim();
+        if (host.IsNullOrEmpty())
+        {
+            return null;
+        }
+
+        if (Uri.TryCreate(host, UriKind.Absolute, out var uri))
+        {
+            host = uri.Host;
+        }
+
+        if (host.StartsWith('[') && host.EndsWith(']'))
+        {
+            host = host[1..^1];
+        }
+
+        return host;
+    }
+
+    /// <summary>
     /// Parses IP API responses from supported providers.
     /// </summary>
     public static IpInfoResult? ParseIPInfo(string? result)

--- a/v2rayN/ServiceLib/Handler/ConnectionHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConnectionHandler.cs
@@ -98,7 +98,7 @@ public static class ConnectionHandler
     }
 
     /// <summary>
-    /// Gets IP and country information through specified proxy.
+    /// Gets IP and geolocation information through specified proxy.
     /// </summary>
     public static async Task<IpInfoResult?> GetIPInfo(IWebProxy? webProxy)
     {
@@ -117,20 +117,47 @@ public static class ConnectionHandler
                 return null;
             }
 
-            var ipInfo = JsonUtils.Deserialize<IPAPIInfo>(result);
-            if (ipInfo == null)
-            {
-                return null;
-            }
-
-            var ip = ipInfo.ip ?? ipInfo.clientIp ?? ipInfo.ip_addr ?? ipInfo.query;
-            var country = ipInfo.country_code ?? ipInfo.country ?? ipInfo.countryCode ?? ipInfo.location?.country_code ?? "unknown";
-
-            return new IpInfoResult(country, ip);
+            return ParseIPInfo(result);
         }
         catch
         {
             return null;
         }
+    }
+
+    /// <summary>
+    /// Parses IP API responses from supported providers.
+    /// </summary>
+    public static IpInfoResult? ParseIPInfo(string? result)
+    {
+        var ipInfo = JsonUtils.Deserialize<IPAPIInfo>(result);
+        if (ipInfo == null)
+        {
+            return null;
+        }
+
+        var ip = FirstNonEmpty(ipInfo.ip, ipInfo.clientIp, ipInfo.ip_addr, ipInfo.query);
+        var country = FirstNonEmpty(
+            ipInfo.country_code,
+            ipInfo.countryCode,
+            ipInfo.location?.country_code,
+            ipInfo.country,
+            ipInfo.country_name,
+            ipInfo.location?.country) ?? "unknown";
+        var region = FirstNonEmpty(
+            ipInfo.region,
+            ipInfo.regionName,
+            ipInfo.region_name,
+            ipInfo.location?.state,
+            ipInfo.location?.region,
+            ipInfo.location?.region_name);
+        var city = FirstNonEmpty(ipInfo.city, ipInfo.location?.city);
+
+        return new IpInfoResult(country, ip, region, city);
+    }
+
+    private static string? FirstNonEmpty(params string?[] values)
+    {
+        return values.Select(t => t?.Trim()).FirstOrDefault(t => t.IsNotEmpty());
     }
 }

--- a/v2rayN/ServiceLib/Handler/SubscriptionHandler.cs
+++ b/v2rayN/ServiceLib/Handler/SubscriptionHandler.cs
@@ -40,6 +40,8 @@ public static class SubscriptionHandler
                 // Process download result
                 if (await ProcessDownloadResult(config, item.Id, result, hashCode, updateFunc))
                 {
+                    item.UpdateTime = DateTimeOffset.Now.ToUnixTimeSeconds();
+                    await ConfigHandler.AddSubItem(config, item);
                     successCount++;
                 }
 
@@ -54,7 +56,60 @@ public static class SubscriptionHandler
             }
         }
 
+        if (successCount > 0)
+        {
+            await updateFunc?.Invoke(false, "正在刷新节点 IP 信息...");
+            var ipInfoCount = await RefreshServerIPInfoAfterSubscriptionUpdate(config, blProxy);
+            await updateFunc?.Invoke(false, $"已刷新节点 IP 信息: {ipInfoCount}");
+        }
+
         await updateFunc?.Invoke(successCount > 0, $"{ResUI.MsgUpdateSubscriptionEnd}");
+    }
+
+    private static async Task<int> RefreshServerIPInfoAfterSubscriptionUpdate(Config config, bool blProxy)
+    {
+        var profileItems = await AppManager.Instance.ProfileItems(string.Empty);
+        if (profileItems is not { Count: > 0 })
+        {
+            return 0;
+        }
+
+        var candidates = profileItems
+            .Where(t => !t.ConfigType.IsComplexType() && t.IsValid() && t.Address.IsNotEmpty())
+            .ToList();
+        if (candidates.Count == 0)
+        {
+            return 0;
+        }
+
+        var ipInfoTasks = new ConcurrentDictionary<string, Task<string>>();
+        using var semaphore = new SemaphoreSlim(Math.Max(1, config.SpeedTestItem.MixedConcurrencyCount));
+        var refreshedCount = 0;
+
+        var tasks = candidates.Select(async item =>
+        {
+            await semaphore.WaitAsync();
+            try
+            {
+                var ipInfo = await ipInfoTasks.GetOrAdd(item.Address.TrimEx(), address => GetServerIPInfoString(address, blProxy));
+                ProfileExManager.Instance.SetTestIpInfo(item.IndexId, ipInfo);
+                Interlocked.Increment(ref refreshedCount);
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        });
+
+        await Task.WhenAll(tasks);
+        await ProfileExManager.Instance.SaveTo();
+        return refreshedCount;
+    }
+
+    private static async Task<string> GetServerIPInfoString(string address, bool blProxy)
+    {
+        var ipInfo = await ConnectionHandler.GetIPInfoForAddress(address, blProxy);
+        return ipInfo?.ToString() ?? Global.None;
     }
 
     private static bool IsValidSubscription(SubItem item, string subId)

--- a/v2rayN/ServiceLib/Models/Dto/IPAPIInfo.cs
+++ b/v2rayN/ServiceLib/Models/Dto/IPAPIInfo.cs
@@ -10,19 +10,50 @@ internal class IPAPIInfo
     public string? country_name { get; set; }
     public string? country_code { get; set; }
     public string? countryCode { get; set; }
+    public string? region { get; set; }
+    public string? region_name { get; set; }
+    public string? regionName { get; set; }
+    public string? city { get; set; }
     public LocationInfo? location { get; set; }
 }
 
 public class LocationInfo
 {
+    public string? country { get; set; }
     public string? country_code { get; set; }
+    public string? region { get; set; }
+    public string? region_name { get; set; }
+    public string? state { get; set; }
+    public string? city { get; set; }
 }
 
-public readonly record struct IpInfoResult(string Country, string? Ip)
+public readonly record struct IpInfoResult(string Country, string? Ip, string? Region = null, string? City = null)
 {
     public override string ToString()
     {
         var emoji = Utils.IsWindows() ? null : Country.CountryToEmoji();
-        return $"{emoji}({Country}) {Ip}";
+        var country = emoji.IsNotEmpty() ? $"{emoji}({Country})" : Country;
+        var location = string.Join(" ", DistinctNonEmpty(country, Region, City));
+
+        return string.Join(" ", DistinctNonEmpty(location, Ip));
+    }
+
+    private static IEnumerable<string> DistinctNonEmpty(params string?[] values)
+    {
+        HashSet<string> seen = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var value in values)
+        {
+            var trimmed = value?.Trim();
+            if (trimmed.IsNullOrEmpty())
+            {
+                continue;
+            }
+
+            if (seen.Add(trimmed))
+            {
+                yield return trimmed;
+            }
+        }
     }
 }

--- a/v2rayN/ServiceLib/Models/Dto/IPAPIInfo.cs
+++ b/v2rayN/ServiceLib/Models/Dto/IPAPIInfo.cs
@@ -57,3 +57,13 @@ public readonly record struct IpInfoResult(string Country, string? Ip, string? R
         }
     }
 }
+
+public readonly record struct AvailabilityCheckResult(int ResponseTime, string? IpInfo)
+{
+    public bool IsAvailable => ResponseTime > 0;
+
+    public override string ToString()
+    {
+        return string.Format(ResUI.TestMeOutput, ResponseTime, IpInfo);
+    }
+}

--- a/v2rayN/ServiceLib/Models/Entities/SubItem.cs
+++ b/v2rayN/ServiceLib/Models/Entities/SubItem.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace ServiceLib.Models.Entities;
 
 [Serializable]
@@ -33,4 +35,60 @@ public class SubItem
     public int? PreSocksPort { get; set; }
 
     public string? Memo { get; set; }
+
+    [Ignore]
+    public string RemarksWithUpdateTime
+    {
+        get
+        {
+            if (Id.IsNullOrEmpty())
+            {
+                return Remarks;
+            }
+
+            return $"{Remarks} · {UpdateTimeAgo}";
+        }
+    }
+
+    [Ignore]
+    public string UpdateTimeAgo => FormatUpdateTimeAgo(UpdateTime);
+
+    public static string FormatUpdateTimeAgo(long updateTime, DateTimeOffset? now = null)
+    {
+        var isChinese = CultureInfo.CurrentUICulture.Name.StartsWith("zh", StringComparison.OrdinalIgnoreCase);
+        if (updateTime <= 0)
+        {
+            return isChinese ? "未更新" : "Never";
+        }
+
+        var currentTime = now ?? DateTimeOffset.Now;
+        var updatedTime = DateTimeOffset.FromUnixTimeSeconds(updateTime).ToLocalTime();
+        var elapsed = currentTime - updatedTime;
+        if (elapsed.TotalSeconds < 0)
+        {
+            elapsed = TimeSpan.Zero;
+        }
+
+        if (elapsed.TotalMinutes < 1)
+        {
+            return isChinese ? "刚刚" : "Just now";
+        }
+        if (elapsed.TotalHours < 1)
+        {
+            var minutes = Math.Max(1, (int)elapsed.TotalMinutes);
+            return isChinese ? $"{minutes} 分钟前" : $"{minutes} min ago";
+        }
+        if (elapsed.TotalDays < 1)
+        {
+            var hours = Math.Max(1, (int)elapsed.TotalHours);
+            return isChinese ? $"{hours} 小时前" : $"{hours} h ago";
+        }
+        if (elapsed.TotalDays < 7)
+        {
+            var days = Math.Max(1, (int)elapsed.TotalDays);
+            return isChinese ? $"{days} 天前" : $"{days} d ago";
+        }
+
+        return updatedTime.ToString("yyyy/MM/dd HH:mm");
+    }
 }

--- a/v2rayN/ServiceLib/Models/Entities/SubItem.cs
+++ b/v2rayN/ServiceLib/Models/Entities/SubItem.cs
@@ -3,8 +3,11 @@ using System.Globalization;
 namespace ServiceLib.Models.Entities;
 
 [Serializable]
-public class SubItem
+public class SubItem : System.ComponentModel.INotifyPropertyChanged
 {
+    [field: NonSerialized]
+    public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
+
     [PrimaryKey]
     public string Id { get; set; }
 
@@ -52,6 +55,17 @@ public class SubItem
 
     [Ignore]
     public string UpdateTimeAgo => FormatUpdateTimeAgo(UpdateTime);
+
+    public void RefreshUpdateTimeAgo()
+    {
+        OnPropertyChanged(nameof(UpdateTimeAgo));
+        OnPropertyChanged(nameof(RemarksWithUpdateTime));
+    }
+
+    private void OnPropertyChanged(string propertyName)
+    {
+        PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+    }
 
     public static string FormatUpdateTimeAgo(long updateTime, DateTimeOffset? now = null)
     {

--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -303,6 +303,7 @@ public class MainWindowViewModel : MyReactiveObject
         if (success)
         {
             var indexIdOld = _config.IndexId;
+            RefreshSubscriptions();
             await RefreshServers();
 
             // If indexId changed or subIndexId is empty, directly reload.

--- a/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
@@ -256,6 +256,10 @@ public class ProfilesViewModel : MyReactiveObject
             .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(async indexId => await SetDefaultServer(indexId));
 
+        Observable.Interval(TimeSpan.FromMinutes(1))
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(_ => RefreshSubscriptionUpdateTimeText());
+
         #endregion AppEvents
 
         _ = Init();
@@ -408,6 +412,14 @@ public class ProfilesViewModel : MyReactiveObject
         SelectedSub = (_config.SubIndexId.IsNotEmpty()
                         ? SubItems.FirstOrDefault(t => t.Id == _config.SubIndexId)
                         : null) ?? SubItems.FirstOrDefault();
+    }
+
+    private void RefreshSubscriptionUpdateTimeText()
+    {
+        foreach (var item in SubItems)
+        {
+            item.RefreshUpdateTimeAgo();
+        }
     }
 
     private async Task<List<ProfileItemModel>?> GetProfileItemsEx(string subid, string filter)

--- a/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
@@ -4,6 +4,9 @@ public class StatusBarViewModel : MyReactiveObject
 {
     private static readonly Lazy<StatusBarViewModel> _instance = new(() => new(null));
     public static StatusBarViewModel Instance => _instance.Value;
+    private static readonly TimeSpan _autoSubscriptionRecoveryCooldown = TimeSpan.FromMinutes(10);
+    private readonly SemaphoreSlim _autoSubscriptionRecoverySemaphore = new(1, 1);
+    private DateTimeOffset _lastAutoSubscriptionRecoveryTime = DateTimeOffset.MinValue;
 
     #region ObservableCollection
 
@@ -353,10 +356,59 @@ public class StatusBarViewModel : MyReactiveObject
 
         await TestServerAvailabilitySub(ResUI.Speedtesting);
 
-        var msg = await Task.Run(ConnectionHandler.RunAvailabilityCheck);
+        var result = await Task.Run(ConnectionHandler.RunAvailabilityCheckResult);
+        var msg = result.ToString();
 
         NoticeManager.Instance.SendMessageEx(msg);
         await TestServerAvailabilitySub(msg);
+        await TryUpdateSubscriptionsDirectlyAfterProxyFailure(result);
+    }
+
+    private async Task TryUpdateSubscriptionsDirectlyAfterProxyFailure(AvailabilityCheckResult result)
+    {
+        if (result.IsAvailable)
+        {
+            return;
+        }
+
+        if (!await _autoSubscriptionRecoverySemaphore.WaitAsync(0))
+        {
+            return;
+        }
+
+        try
+        {
+            var now = DateTimeOffset.UtcNow;
+            if (now - _lastAutoSubscriptionRecoveryTime < _autoSubscriptionRecoveryCooldown)
+            {
+                return;
+            }
+
+            var subItems = await AppManager.Instance.SubItems();
+            if (subItems?.Any(IsAutoRecoverySubscription) != true)
+            {
+                return;
+            }
+
+            _lastAutoSubscriptionRecoveryTime = now;
+            Logging.SaveLog("Proxy availability check failed; updating all subscriptions without proxy.");
+            NoticeManager.Instance.SendMessageEx($"{ResUI.MsgUpdateSubscriptionStart} ({Global.DirectTag})");
+            AppEvents.SubscriptionsUpdateRequested.Publish(false);
+        }
+        finally
+        {
+            _autoSubscriptionRecoverySemaphore.Release();
+        }
+    }
+
+    private static bool IsAutoRecoverySubscription(SubItem item)
+    {
+        var id = item.Id.TrimEx();
+        var url = item.Url.TrimEx();
+
+        return item.Enabled
+            && id.IsNotEmpty()
+            && (url.StartsWith(Global.HttpsProtocol) || url.StartsWith(Global.HttpProtocol));
     }
 
     private async Task TestServerAvailabilitySub(string msg)

--- a/v2rayN/ServiceLib/ViewModels/SubSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/SubSettingViewModel.cs
@@ -41,6 +41,10 @@ public class SubSettingViewModel : MyReactiveObject
             await _updateView?.Invoke(EViewAction.ShareSub, SelectedSource?.Url);
         }, canEditRemove);
 
+        Observable.Interval(TimeSpan.FromMinutes(1))
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(_ => RefreshSubscriptionUpdateTimeText());
+
         _ = Init();
     }
 
@@ -93,5 +97,13 @@ public class SubSettingViewModel : MyReactiveObject
         await RefreshSubItems();
         NoticeManager.Instance.Enqueue(ResUI.OperationSuccess);
         IsModified = true;
+    }
+
+    private void RefreshSubscriptionUpdateTimeText()
+    {
+        foreach (var item in SubItems)
+        {
+            item.RefreshUpdateTimeAgo();
+        }
     }
 }

--- a/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml
@@ -203,6 +203,20 @@
                 </DataGrid.ContextMenu>
 
                 <DataGrid.Columns>
+                    <DataGridTemplateColumn SortMemberPath="IpInfo" Tag="IpInfo">
+                        <DataGridTemplateColumn.Header>
+                            <TextBlock Text="{x:Static resx:ResUI.LvTestIpInfo}" />
+                        </DataGridTemplateColumn.Header>
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <SelectableTextBlock
+                                    Margin="{StaticResource MarginLr8}"
+                                    VerticalAlignment="Center"
+                                    Text="{Binding Path=IpInfo, Mode=OneWay}" />
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+
                     <DataGridTextColumn
                         Width="80"
                         Binding="{Binding ConfigType}"
@@ -276,20 +290,6 @@
                         Binding="{Binding SpeedVal}"
                         Header="{x:Static resx:ResUI.LvTestSpeed}"
                         Tag="SpeedVal" />
-
-                    <DataGridTemplateColumn SortMemberPath="IpInfo" Tag="IpInfo">
-                        <DataGridTemplateColumn.Header>
-                            <TextBlock Text="{x:Static resx:ResUI.LvTestIpInfo}" />
-                        </DataGridTemplateColumn.Header>
-                        <DataGridTemplateColumn.CellTemplate>
-                            <DataTemplate>
-                                <SelectableTextBlock
-                                    Margin="{StaticResource MarginLr8}"
-                                    VerticalAlignment="Center"
-                                    Text="{Binding Path=IpInfo, Mode=OneWay}" />
-                            </DataTemplate>
-                        </DataGridTemplateColumn.CellTemplate>
-                    </DataGridTemplateColumn>
 
                     <DataGridTextColumn
                         Width="100"

--- a/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml
@@ -21,7 +21,7 @@
                 <ListBox
                     x:Name="lstGroup"
                     Margin="{StaticResource MarginLr4}"
-                    DisplayMemberBinding="{Binding Remarks}"
+                    DisplayMemberBinding="{Binding RemarksWithUpdateTime}"
                     ItemsSource="{Binding SubItems}"
                     Theme="{DynamicResource PureCardRadioGroupListBox}">
                     <ListBox.ItemsPanel>

--- a/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml.cs
@@ -404,7 +404,7 @@ public partial class ProfilesView : ReactiveUserControl<ProfilesViewModel>
     {
         try
         {
-            var lvColumnItem = _config.UiItem.MainColumnItem.OrderBy(t => t.Index).ToList();
+            var lvColumnItem = GetMainColumnItemsForRestore();
             var displayIndex = 0;
             foreach (var item in lvColumnItem)
             {
@@ -441,6 +441,46 @@ public partial class ProfilesView : ReactiveUserControl<ProfilesViewModel>
         {
             Logging.SaveLog(_tag, ex);
         }
+    }
+
+    private static List<ColumnItem> GetMainColumnItemsForRestore()
+    {
+        var lvColumnItem = _config.UiItem.MainColumnItem.OrderBy(t => t.Index).ToList();
+        if (lvColumnItem.Count == 0)
+        {
+            return lvColumnItem;
+        }
+
+        var ipInfoIndex = FindColumnIndex(lvColumnItem, "IpInfo");
+        if (ipInfoIndex < 0)
+        {
+            lvColumnItem.Insert(0, new() { Name = "IpInfo", Width = 100, Index = 0 });
+            return lvColumnItem;
+        }
+
+        if (ShouldPromoteIpInfoColumn(lvColumnItem, ipInfoIndex))
+        {
+            var ipInfoItem = lvColumnItem[ipInfoIndex];
+            lvColumnItem.RemoveAt(ipInfoIndex);
+            lvColumnItem.Insert(0, ipInfoItem);
+        }
+
+        return lvColumnItem;
+    }
+
+    private static bool ShouldPromoteIpInfoColumn(List<ColumnItem> lvColumnItem, int ipInfoIndex)
+    {
+        var speedValIndex = FindColumnIndex(lvColumnItem, "SpeedVal");
+        var todayUpIndex = FindColumnIndex(lvColumnItem, "TodayUp");
+
+        return ipInfoIndex > 0
+               && ((speedValIndex >= 0 && ipInfoIndex == speedValIndex + 1)
+                   || (todayUpIndex >= 0 && ipInfoIndex == todayUpIndex + 1));
+    }
+
+    private static int FindColumnIndex(List<ColumnItem> lvColumnItem, string name)
+    {
+        return lvColumnItem.FindIndex(t => t.Name.Equals(name, StringComparison.CurrentCultureIgnoreCase));
     }
 
     private void StorageUI()

--- a/v2rayN/v2rayN.Desktop/Views/SubSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/SubSettingWindow.axaml
@@ -62,6 +62,10 @@
                         Binding="{Binding Enabled}"
                         Header="{x:Static resx:ResUI.LvEnabled}" />
                     <DataGridTextColumn
+                        Width="120"
+                        Binding="{Binding UpdateTimeAgo}"
+                        Header="上次更新" />
+                    <DataGridTextColumn
                         Width="150"
                         Binding="{Binding AutoUpdateInterval}"
                         Header="{x:Static resx:ResUI.LvAutoUpdateInterval}" />

--- a/v2rayN/v2rayN/Views/ProfilesView.xaml
+++ b/v2rayN/v2rayN/Views/ProfilesView.xaml
@@ -280,6 +280,13 @@
                 </DataGrid.Resources>
                 <DataGrid.Columns>
                     <base:MyDGTextColumn
+                        x:Name="colIpInfo"
+                        Width="100"
+                        Binding="{Binding IpInfo}"
+                        ExName="IpInfo"
+                        Header="{x:Static resx:ResUI.LvTestIpInfo}" />
+
+                    <base:MyDGTextColumn
                         Width="80"
                         Binding="{Binding ConfigType}"
                         ExName="ConfigType"
@@ -345,13 +352,6 @@
                         Binding="{Binding TodayUp}"
                         ExName="TodayUp"
                         Header="{x:Static resx:ResUI.LvTodayUploadDataAmount}" />
-
-                    <base:MyDGTextColumn
-                        x:Name="colIpInfo"
-                        Width="100"
-                        Binding="{Binding IpInfo}"
-                        ExName="IpInfo"
-                        Header="{x:Static resx:ResUI.LvTestIpInfo}" />
 
                     <base:MyDGTextColumn
                         x:Name="colTodayDown"

--- a/v2rayN/v2rayN/Views/ProfilesView.xaml.cs
+++ b/v2rayN/v2rayN/Views/ProfilesView.xaml.cs
@@ -361,7 +361,7 @@ public partial class ProfilesView
     {
         try
         {
-            var lvColumnItem = _config.UiItem.MainColumnItem.OrderBy(t => t.Index).ToList();
+            var lvColumnItem = GetMainColumnItemsForRestore();
             var displayIndex = 0;
             foreach (var item in lvColumnItem)
             {
@@ -394,6 +394,46 @@ public partial class ProfilesView
         {
             Logging.SaveLog(_tag, ex);
         }
+    }
+
+    private static List<ColumnItem> GetMainColumnItemsForRestore()
+    {
+        var lvColumnItem = _config.UiItem.MainColumnItem.OrderBy(t => t.Index).ToList();
+        if (lvColumnItem.Count == 0)
+        {
+            return lvColumnItem;
+        }
+
+        var ipInfoIndex = FindColumnIndex(lvColumnItem, "IpInfo");
+        if (ipInfoIndex < 0)
+        {
+            lvColumnItem.Insert(0, new() { Name = "IpInfo", Width = 100, Index = 0 });
+            return lvColumnItem;
+        }
+
+        if (ShouldPromoteIpInfoColumn(lvColumnItem, ipInfoIndex))
+        {
+            var ipInfoItem = lvColumnItem[ipInfoIndex];
+            lvColumnItem.RemoveAt(ipInfoIndex);
+            lvColumnItem.Insert(0, ipInfoItem);
+        }
+
+        return lvColumnItem;
+    }
+
+    private static bool ShouldPromoteIpInfoColumn(List<ColumnItem> lvColumnItem, int ipInfoIndex)
+    {
+        var speedValIndex = FindColumnIndex(lvColumnItem, "SpeedVal");
+        var todayUpIndex = FindColumnIndex(lvColumnItem, "TodayUp");
+
+        return ipInfoIndex > 0
+               && ((speedValIndex >= 0 && ipInfoIndex == speedValIndex + 1)
+                   || (todayUpIndex >= 0 && ipInfoIndex == todayUpIndex + 1));
+    }
+
+    private static int FindColumnIndex(List<ColumnItem> lvColumnItem, string name)
+    {
+        return lvColumnItem.FindIndex(t => t.Name.Equals(name, StringComparison.CurrentCultureIgnoreCase));
     }
 
     private void StorageUI()


### PR DESCRIPTION
English summary:
- Parse region and city fields from supported IP API responses.
- Support nested `location` fields returned by providers such as `api.ipapi.is`.
- Include country/region/city/IP in the existing `IpInfo` server-list column.
- Move the `IpInfo` column to the front of the server list so location appears before the profile name.
- Migrate old default column layouts so the location column appears first while preserving later user-customized column order.
- Add `https://ipwho.is/` to the selectable IP API providers.
- Default old configs with `IPAPIUrl: null` to the first provider while preserving an explicit empty string as disabled.
- When the proxy availability check cannot reach the configured Google-style ping URL, automatically update all valid subscriptions without proxy.
- Add a 10-minute cooldown and a semaphore guard so failed checks do not trigger repeated direct subscription updates.
- After successful subscription updates, refresh server-list IP geolocation for all current non-complex nodes.
- Show each subscription group's last successful update time as relative text, such as "Just now" or "5 min ago", and refresh those labels every minute.
- Test data uses RFC 5737 documentation IP ranges only; no real server, subscription, password, or user config is included.

中文说明:
- 从支持的 IP API 响应中解析地区和城市字段。
- 支持 `api.ipapi.is` 等服务返回的嵌套 `location` 字段。
- 在现有服务器列表 `IpInfo` 列中显示国家/地区/城市/IP。
- 将 `IpInfo` 列移动到服务器列表最前面，让地理位置显示在节点名称前面。
- 对旧的默认列布局做兼容迁移，让位置列首次显示在最前，同时保留之后用户手动调整的列顺序。
- 将 `https://ipwho.is/` 加入可选 IP API 服务列表。
- 对旧配置中的 `IPAPIUrl: null` 默认启用第一个服务，同时保留显式空字符串表示禁用。
- 当代理可用性检测无法访问默认 Google 风格测速地址时，自动执行“订阅全部更新”，并且不通过代理。
- 增加 10 分钟冷却和并发保护，避免失败检测反复触发直连订阅更新。
- 订阅成功更新后，自动刷新当前所有普通节点的 IP 地理位置信息。
- 显示每个订阅分组上次成功更新时间，例如“刚刚”“5 分钟前”，并每分钟刷新一次显示文本。
- 测试数据只使用 RFC 5737 文档保留 IP 段，不包含真实节点、订阅、密码或用户配置。

Tests / 测试:
- `dotnet test v2rayN/ServiceLib.Tests/ServiceLib.Tests.csproj --configuration Release -m:1`
- `dotnet build v2rayN/v2rayN.Desktop/v2rayN.Desktop.csproj --configuration Release -m:1`
- `dotnet build v2rayN/v2rayN/v2rayN.csproj --configuration Release -m:1 -p:EnableWindowsTargeting=true -r win-x64`

Base / 基线:
- Rebased on `2dust/v2rayN@1a681695a2ed0be942d9961c9902dfd3274260af`

Branch / 分支:
- `feature/ip-geolocation-column`

Commits / 提交:
- `30cc3a4d858ada860e260aeb73cedfa147c28e24` - Add region and city to IP info results
- `a46d373ac6e6f26dbef75650d4c4a7698c655c1e` - Auto update subscriptions directly when proxy check fails
- `cdc1ef2cd55cfc66b03eef81070f8c6c12783106` - Refresh IP info after subscription updates
- `d3d2bd3d8ec4baabce54d25bb18deefcd6152770` - Refresh subscription update age labels
- `f79a4b40b545df549de7722f6e0ee7cf73f82688` - Move IP info column before profile name

Privacy note / 隐私说明:
- This branch modifies source code only.
- It does not include local v2rayN profiles, node addresses, subscriptions, passwords, generated config files, or user-specific paths.
- 本分支只修改源码，不包含本地 V2rayN 节点、订阅、密码、生成配置文件或用户路径。