### PR TITLE
customizable packet fragmentation settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,9 @@ StyleCopReport.xml
 *.rsp
 # but not Directory.Build.rsp, as it configures directory-level build defaults
 !Directory.Build.rsp
+bin/
+obj/
+build/
 *.sbr
 *.tlb
 *.tli

--- a/v2rayN/ServiceLib/Common/Utils.cs
+++ b/v2rayN/ServiceLib/Common/Utils.cs
@@ -584,6 +584,41 @@ public class Utils
             return true;
         }
         var parts = input.Split('-');
+        if (parts.Length == 1)
+        {
+            if (!int.TryParse(parts[0], out from))
+            {
+                return false;
+            }
+            to = from;
+            return from >= min && to <= max;
+        }
+        if (parts.Length != 2
+            || !int.TryParse(parts[0], out from)
+            || !int.TryParse(parts[1], out to))
+        {
+            return false;
+        }
+        return from >= min && to <= max && from <= to;
+    }
+
+    public static bool TryParseMaxSplit(string? input, int min, int max, out int from, out int to)
+    {
+        from = to = 0;
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return true;
+        }
+        var parts = input.Split('-');
+        if (parts.Length == 1)
+        {
+            if (!int.TryParse(parts[0], out from))
+            {
+                return false;
+            }
+            to = from;
+            return from >= min && to <= max;
+        }
         if (parts.Length != 2
             || !int.TryParse(parts[0], out from)
             || !int.TryParse(parts[1], out to))

--- a/v2rayN/ServiceLib/Common/Utils.cs
+++ b/v2rayN/ServiceLib/Common/Utils.cs
@@ -576,6 +576,23 @@ public class Utils
         }
     }
 
+    public static bool TryParseRange(string? input, int min, int max, out int from, out int to)
+    {
+        from = to = 0;
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return true;
+        }
+        var parts = input.Split('-');
+        if (parts.Length != 2
+            || !int.TryParse(parts[0], out from)
+            || !int.TryParse(parts[1], out to))
+        {
+            return false;
+        }
+        return from >= min && to <= max && from <= to;
+    }
+
     public static bool IsPrivateNetwork(string ip)
     {
         if (IPAddress.TryParse(ip, out var address))

--- a/v2rayN/ServiceLib/Global.cs
+++ b/v2rayN/ServiceLib/Global.cs
@@ -406,6 +406,16 @@ public class Global
         ""
     ];
 
+    public static readonly List<string> FragmentPacketsOptions =
+    [
+        "tlshello",
+        "1-1",
+        "1-2",
+        "1-3",
+        "1-4",
+        "1-5"
+    ];
+
     public static readonly List<string> UserAgent =
     [
         "chrome",

--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -170,9 +170,7 @@ public static class ConfigHandler
             Packets = "tlshello",
             Length = "50-100",
             Interval = "10-20",
-            MaxSplit = "0",
-            RecordFragment = false,
-            FallbackDelay = "500ms"
+            MaxSplit = "0"
         };
         config.GlobalHotkeys ??= [];
 

--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -169,7 +169,10 @@ public static class ConfigHandler
         {
             Packets = "tlshello",
             Length = "50-100",
-            Interval = "10-20"
+            Interval = "10-20",
+            MaxSplit = "0",
+            RecordFragment = false,
+            FallbackDelay = "500ms"
         };
         config.GlobalHotkeys ??= [];
 

--- a/v2rayN/ServiceLib/Models/Configs/ConfigItems.cs
+++ b/v2rayN/ServiceLib/Models/Configs/ConfigItems.cs
@@ -250,8 +250,6 @@ public class Fragment4RayItem
     public string? Length { get; set; } = "50-100";
     public string? Interval { get; set; } = "10-20";
     public string? MaxSplit { get; set; } = "0";
-    public bool? RecordFragment { get; set; } = true;
-    public string? FallbackDelay { get; set; } = "500ms";
 }
 
 [Serializable]

--- a/v2rayN/ServiceLib/Models/Configs/ConfigItems.cs
+++ b/v2rayN/ServiceLib/Models/Configs/ConfigItems.cs
@@ -246,9 +246,12 @@ public class CheckUpdateItem
 [Serializable]
 public class Fragment4RayItem
 {
-    public string? Packets { get; set; }
-    public string? Length { get; set; }
-    public string? Interval { get; set; }
+    public string? Packets { get; set; } = "tlshello";
+    public string? Length { get; set; } = "50-100";
+    public string? Interval { get; set; } = "10-20";
+    public string? MaxSplit { get; set; } = "0";
+    public bool? RecordFragment { get; set; } = true;
+    public string? FallbackDelay { get; set; } = "500ms";
 }
 
 [Serializable]

--- a/v2rayN/ServiceLib/Models/Configs/ConfigItems.cs
+++ b/v2rayN/ServiceLib/Models/Configs/ConfigItems.cs
@@ -246,10 +246,10 @@ public class CheckUpdateItem
 [Serializable]
 public class Fragment4RayItem
 {
-    public string? Packets { get; set; } = "tlshello";
-    public string? Length { get; set; } = "50-100";
-    public string? Interval { get; set; } = "10-20";
-    public string? MaxSplit { get; set; } = "0";
+    public string? Packets { get; set; }
+    public string? Length { get; set; }
+    public string? Interval { get; set; }
+    public string? MaxSplit { get; set; }
 }
 
 [Serializable]

--- a/v2rayN/ServiceLib/Models/CoreConfigs/V2rayConfig.cs
+++ b/v2rayN/ServiceLib/Models/CoreConfigs/V2rayConfig.cs
@@ -512,6 +512,7 @@ public class MaskSettings4Ray
 
     public string? length { get; set; }
     public string? delay { get; set; }
+    public int? maxSplit { get; set; }
 
     // noise
     public int? reset { get; set; }

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -241,6 +241,15 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Fragment parameter format error. Please check Length (e.g. 50-100), Interval (1-100 range), and MaxSplit (0-10000). 的本地化字符串。
+        /// </summary>
+        public static string FillFragmentParameterError {
+            get {
+                return ResourceManager.GetString("FillFragmentParameterError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 Please enter the local listening port. 的本地化字符串。
         /// </summary>
         public static string FillLocalListeningPort {
@@ -4083,6 +4092,114 @@ namespace ServiceLib.Resx {
         public static string TbSettingsEnableFragment {
             get {
                 return ResourceManager.GetString("TbSettingsEnableFragment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Fragment Length 的本地化字符串。
+        /// </summary>
+        public static string TbSettingsFragmentLength {
+            get {
+                return ResourceManager.GetString("TbSettingsFragmentLength", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Fragment size range in bytes (e.g., 50-100). First value must be &lt;= second. Empty = default. 的本地化字符串。
+        /// </summary>
+        public static string TbSettingsFragmentLengthTip {
+            get {
+                return ResourceManager.GetString("TbSettingsFragmentLengthTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Fragment Interval 的本地化字符串。
+        /// </summary>
+        public static string TbSettingsFragmentInterval {
+            get {
+                return ResourceManager.GetString("TbSettingsFragmentInterval", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Delay between fragments in ms (e.g., 10-20). Range 1-100. First value must be &lt;= second. Empty = default. 的本地化字符串。
+        /// </summary>
+        public static string TbSettingsFragmentIntervalTip {
+            get {
+                return ResourceManager.GetString("TbSettingsFragmentIntervalTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Max Split 的本地化字符串。
+        /// </summary>
+        public static string TbSettingsFragmentMaxSplit {
+            get {
+                return ResourceManager.GetString("TbSettingsFragmentMaxSplit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Maximum number of splits (0 = unlimited, 0-10000). Only effective for Xray-core. Empty = default. 的本地化字符串。
+        /// </summary>
+        public static string TbSettingsFragmentMaxSplitTip {
+            get {
+                return ResourceManager.GetString("TbSettingsFragmentMaxSplitTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Fragment Packets 的本地化字符串。
+        /// </summary>
+        public static string TbSettingsFragmentPackets {
+            get {
+                return ResourceManager.GetString("TbSettingsFragmentPackets", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Packets to fragment: tlshello (TLS ClientHello) or 1-1 to 1-5 (first N TCP packets) 的本地化字符串。
+        /// </summary>
+        public static string TbSettingsFragmentPacketsTip {
+            get {
+                return ResourceManager.GetString("TbSettingsFragmentPacketsTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Record Fragment 的本地化字符串。
+        /// </summary>
+        public static string TbSettingsFragmentRecordFragment {
+            get {
+                return ResourceManager.GetString("TbSettingsFragmentRecordFragment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Record TLS fragment flag. Only effective for sing-box. Empty = default. 的本地化字符串。
+        /// </summary>
+        public static string TbSettingsFragmentRecordFragmentTip {
+            get {
+                return ResourceManager.GetString("TbSettingsFragmentRecordFragmentTip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Fallback Delay 的本地化字符串。
+        /// </summary>
+        public static string TbSettingsFragmentFallbackDelay {
+            get {
+                return ResourceManager.GetString("TbSettingsFragmentFallbackDelay", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Fallback delay for TLS fragment. Only effective for sing-box. Empty = default. 的本地化字符串。
+        /// </summary>
+        public static string TbSettingsFragmentFallbackDelayTip {
+            get {
+                return ResourceManager.GetString("TbSettingsFragmentFallbackDelayTip", resourceCulture);
             }
         }
         

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -4168,20 +4168,20 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
-        ///   查找类似 Record Fragment 的本地化字符串。
+        ///   查找类似 Sing-box Fragment Strategy 的本地化字符串。
         /// </summary>
-        public static string TbSettingsFragmentRecordFragment {
+        public static string TbSettingsFragmentSingboxStrategy {
             get {
-                return ResourceManager.GetString("TbSettingsFragmentRecordFragment", resourceCulture);
+                return ResourceManager.GetString("TbSettingsFragmentSingboxStrategy", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   查找类似 Record TLS fragment flag. Only effective for sing-box. Empty = default. 的本地化字符串。
+        ///   查找类似 TLS Fragment: standard TLS record splitting. TCP Bypass: fragment TCP packets. Double: both modes combined. sing-box only. 的本地化字符串。
         /// </summary>
-        public static string TbSettingsFragmentRecordFragmentTip {
+        public static string TbSettingsFragmentSingboxStrategyTip {
             get {
-                return ResourceManager.GetString("TbSettingsFragmentRecordFragmentTip", resourceCulture);
+                return ResourceManager.GetString("TbSettingsFragmentSingboxStrategyTip", resourceCulture);
             }
         }
         

--- a/v2rayN/ServiceLib/Resx/ResUI.fa.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fa.resx
@@ -1104,6 +1104,39 @@
   <data name="TbSettingsEnableFragment" xml:space="preserve">
     <value>فعال کردن فرگمنت</value>
   </data>
+  <data name="TbSettingsFragmentPackets" xml:space="preserve">
+    <value>پکت‌های فرگمنت</value>
+  </data>
+  <data name="TbSettingsFragmentPacketsTip" xml:space="preserve">
+    <value>پکت‌های قابل فرگمنت: tlshello (TLS ClientHello) یا 1-1 تا 1-5 (N اول پکت TCP)</value>
+  </data>
+  <data name="TbSettingsFragmentLength" xml:space="preserve">
+    <value>طول فرگمنت</value>
+  </data>
+  <data name="TbSettingsFragmentLengthTip" xml:space="preserve">
+    <value>محدوده اندازه فرگمنت بایت (مثلا 50-100). اول ≤ دوم. خالی = پیش‌فرض.</value>
+  </data>
+  <data name="TbSettingsFragmentInterval" xml:space="preserve">
+    <value>فاصله فرگمنت</value>
+  </data>
+  <data name="TbSettingsFragmentIntervalTip" xml:space="preserve">
+    <value>تأخیر بین فرگمنت‌ها میلی‌ثانیه (مثلا 10-20). بازه 1-100. اول ≤ دوم. خالی = پیش‌فرض.</value>
+  </data>
+  <data name="TbSettingsFragmentMaxSplit" xml:space="preserve">
+    <value>حداکثر تقسیم</value>
+  </data>
+  <data name="TbSettingsFragmentMaxSplitTip" xml:space="preserve">
+    <value>مکسیمم تعداد تقسیم (0 = نامحدود، 0-10000). فقط Xray-core. خالی = پیش‌فرض.</value>
+  </data>
+  <data name="TbSettingsFragmentFallbackDelay" xml:space="preserve">
+    <value>تأخیر فول‌بک</value>
+  </data>
+  <data name="TbSettingsFragmentFallbackDelayTip" xml:space="preserve">
+    <value>تأخیر فول‌بک فرگمنت TLS. فقط sing-box. خالی = پیش‌فرض.</value>
+  </data>
+  <data name="FillFragmentParameterError" xml:space="preserve">
+    <value>فرمت محدوده نامعتبر. از 'from-to' استفاده کنید (مثلا 50-100).</value>
+  </data>
   <data name="TbSettingsEnableCacheFile4Sbox" xml:space="preserve">
     <value>فعال کردن کش فایل مجموعه قوانین برای sing-box</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.fr.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fr.resx
@@ -1101,6 +1101,39 @@
   <data name="TbSettingsEnableFragment" xml:space="preserve">
     <value>Activer le fragmentation (Fragment)</value>
   </data>
+  <data name="TbSettingsFragmentPackets" xml:space="preserve">
+    <value>Paquets fragmentés</value>
+  </data>
+  <data name="TbSettingsFragmentPacketsTip" xml:space="preserve">
+    <value>Paquets à fragmenter : tlshello (TLS ClientHello) ou 1-1 à 1-5 (premiers N paquets TCP)</value>
+  </data>
+  <data name="TbSettingsFragmentLength" xml:space="preserve">
+    <value>Longueur fragment</value>
+  </data>
+  <data name="TbSettingsFragmentLengthTip" xml:space="preserve">
+    <value>Plage de taille fragment (ex: 50-100). Première valeur ≤ seconde. Vide = défaut.</value>
+  </data>
+  <data name="TbSettingsFragmentInterval" xml:space="preserve">
+    <value>Intervalle fragment</value>
+  </data>
+  <data name="TbSettingsFragmentIntervalTip" xml:space="preserve">
+    <value>Délai entre fragments en ms (ex: 10-20). Plage 1-100. Première valeur ≤ seconde. Vide = défaut.</value>
+  </data>
+  <data name="TbSettingsFragmentMaxSplit" xml:space="preserve">
+    <value>Max Split</value>
+  </data>
+  <data name="TbSettingsFragmentMaxSplitTip" xml:space="preserve">
+    <value>Nb max de splits (0 = illimité, 0-10000). Xray-core seulement. Vide = défaut.</value>
+  </data>
+  <data name="TbSettingsFragmentFallbackDelay" xml:space="preserve">
+    <value>Délai fallback</value>
+  </data>
+  <data name="TbSettingsFragmentFallbackDelayTip" xml:space="preserve">
+    <value>Délai fallback pour fragment TLS. sing-box seulement. Vide = défaut.</value>
+  </data>
+  <data name="FillFragmentParameterError" xml:space="preserve">
+    <value>Format de plage invalide. Utilisez 'from-to' (ex: 50-100).</value>
+  </data>
   <data name="TbSettingsEnableCacheFile4Sbox" xml:space="preserve">
     <value>Activer le fichier de cache de sing-box (fichiers règles)</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.hu.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.hu.resx
@@ -1104,6 +1104,39 @@
   <data name="TbSettingsEnableFragment" xml:space="preserve">
     <value>Fragment engedélyezése</value>
   </data>
+  <data name="TbSettingsFragmentPackets" xml:space="preserve">
+    <value>Fragmentált csomagok</value>
+  </data>
+  <data name="TbSettingsFragmentPacketsTip" xml:space="preserve">
+    <value>Fragmentálandó csomagok: tlshello (TLS ClientHello) vagy 1-1 – 1-5 (az első N TCP csomag)</value>
+  </data>
+  <data name="TbSettingsFragmentLength" xml:space="preserve">
+    <value>Fragment hossz</value>
+  </data>
+  <data name="TbSettingsFragmentLengthTip" xml:space="preserve">
+    <value>Fragment méret tartománya bájtokban (pl. 50-100). Az első érték ≤ második. Üres = alapértelmezett.</value>
+  </data>
+  <data name="TbSettingsFragmentInterval" xml:space="preserve">
+    <value>Fragment intervallum</value>
+  </data>
+  <data name="TbSettingsFragmentIntervalTip" xml:space="preserve">
+    <value>Késleltetés a fragmented csomagok között ms-ben (pl. 10-20). Tartomány 1-100. Az első érték ≤ második. Üres = alapértelmezett.</value>
+  </data>
+  <data name="TbSettingsFragmentMaxSplit" xml:space="preserve">
+    <value>Max darabolás</value>
+  </data>
+  <data name="TbSettingsFragmentMaxSplitTip" xml:space="preserve">
+    <value>Maximális darabolások száma (0 = korlátlan, 0-10000). Csak Xray-core. Üres = alapértelmezett.</value>
+  </data>
+  <data name="TbSettingsFragmentFallbackDelay" xml:space="preserve">
+    <value>Fallback késleltetés</value>
+  </data>
+  <data name="TbSettingsFragmentFallbackDelayTip" xml:space="preserve">
+    <value>TLS fragment fallback késleltetés. Csak sing-box. Üres = alapértelmezett.</value>
+  </data>
+  <data name="FillFragmentParameterError" xml:space="preserve">
+    <value>Érvénytelen tartomány formátum. Használja 'from-to' (pl. 50-100).</value>
+  </data>
   <data name="TbSettingsEnableCacheFile4Sbox" xml:space="preserve">
     <value>Gyorsítótár fájl engedélyezése sing-boxhoz (szabálykészlet fájlok)</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.id.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.id.resx
@@ -1104,6 +1104,39 @@
   <data name="TbSettingsEnableFragment" xml:space="preserve">
     <value>Aktifkan fragment</value>
   </data>
+  <data name="TbSettingsFragmentPackets" xml:space="preserve">
+    <value>Paket Fragment</value>
+  </data>
+  <data name="TbSettingsFragmentPacketsTip" xml:space="preserve">
+    <value>Paket untuk difragmentasikan: tlshello (TLS ClientHello) atau 1-1 s.d. 1-5 (N paket TCP pertama)</value>
+  </data>
+  <data name="TbSettingsFragmentLength" xml:space="preserve">
+    <value>Panjang Fragment</value>
+  </data>
+  <data name="TbSettingsFragmentLengthTip" xml:space="preserve">
+    <value>Rentang ukuran fragment (byte), cth: 50-100. Nilai pertama harus ≤ kedua. Kosong = default.</value>
+  </data>
+  <data name="TbSettingsFragmentInterval" xml:space="preserve">
+    <value>Interval Fragment</value>
+  </data>
+  <data name="TbSettingsFragmentIntervalTip" xml:space="preserve">
+    <value>Jeda antar fragment (ms), cth: 10-20. Rentang 1-100. Nilai pertama harus ≤ kedua. Kosong = default.</value>
+  </data>
+  <data name="TbSettingsFragmentMaxSplit" xml:space="preserve">
+    <value>Maks Split</value>
+  </data>
+  <data name="TbSettingsFragmentMaxSplitTip" xml:space="preserve">
+    <value>Maks jumlah split (0 = unlimited, 0-10000). Hanya Xray-core. Kosong = default.</value>
+  </data>
+  <data name="TbSettingsFragmentFallbackDelay" xml:space="preserve">
+    <value>Fallback Delay</value>
+  </data>
+  <data name="TbSettingsFragmentFallbackDelayTip" xml:space="preserve">
+    <value>Delay fallback untuk TLS fragment. Hanya sing-box. Kosong = default.</value>
+  </data>
+  <data name="FillFragmentParameterError" xml:space="preserve">
+    <value>Format range tidak valid. Gunakan 'from-to' (cth: 50-100).</value>
+  </data>
   <data name="TbSettingsEnableCacheFile4Sbox" xml:space="preserve">
     <value>Aktifkan file cache untuk sing-box (file ruleset)</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1128,17 +1128,14 @@
   <data name="TbSettingsFragmentMaxSplitTip" xml:space="preserve">
     <value>Maximum number of fragments per packet (0-10000, 0 = unlimited). Xray only. Empty = default.</value>
   </data>
-  <data name="TbSettingsFragmentRecordFragment" xml:space="preserve">
-    <value>Record Fragment</value>
-  </data>
-  <data name="TbSettingsFragmentRecordFragmentTip" xml:space="preserve">
-    <value>Enable TLS record fragmentation (splitRecord mode). sing-box only.</value>
-  </data>
   <data name="TbSettingsFragmentFallbackDelay" xml:space="preserve">
     <value>Fallback Delay</value>
   </data>
   <data name="TbSettingsFragmentFallbackDelayTip" xml:space="preserve">
     <value>Fallback delay when ACK detection unavailable (e.g., 500ms). sing-box only. Empty = default.</value>
+  </data>
+  <data name="FillFragmentParameterError" xml:space="preserve">
+    <value>Invalid range format. Use 'from-to' (e.g., 50-100).</value>
   </data>
   <data name="TbSettingsEnableCacheFile4Sbox" xml:space="preserve">
     <value>Enable cache file for sing-box (ruleset files)</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1104,6 +1104,42 @@
   <data name="TbSettingsEnableFragment" xml:space="preserve">
     <value>Enable fragment</value>
   </data>
+  <data name="TbSettingsFragmentPackets" xml:space="preserve">
+    <value>Fragment Packets</value>
+  </data>
+  <data name="TbSettingsFragmentPacketsTip" xml:space="preserve">
+    <value>Packets to fragment: tlshello (TLS ClientHello) or 1-1 to 1-5 (first N TCP packets)</value>
+  </data>
+  <data name="TbSettingsFragmentLength" xml:space="preserve">
+    <value>Fragment Length</value>
+  </data>
+  <data name="TbSettingsFragmentLengthTip" xml:space="preserve">
+    <value>Fragment size range in bytes (e.g., 50-100). First value must be &lt;= second. Empty = default.</value>
+  </data>
+  <data name="TbSettingsFragmentInterval" xml:space="preserve">
+    <value>Fragment Interval</value>
+  </data>
+  <data name="TbSettingsFragmentIntervalTip" xml:space="preserve">
+    <value>Delay between fragments in ms (e.g., 10-20). Range 1-100. First value must be &lt;= second. Empty = default.</value>
+  </data>
+  <data name="TbSettingsFragmentMaxSplit" xml:space="preserve">
+    <value>Max Split</value>
+  </data>
+  <data name="TbSettingsFragmentMaxSplitTip" xml:space="preserve">
+    <value>Maximum number of fragments per packet (0-10000, 0 = unlimited). Xray only. Empty = default.</value>
+  </data>
+  <data name="TbSettingsFragmentRecordFragment" xml:space="preserve">
+    <value>Record Fragment</value>
+  </data>
+  <data name="TbSettingsFragmentRecordFragmentTip" xml:space="preserve">
+    <value>Enable TLS record fragmentation (splitRecord mode). sing-box only.</value>
+  </data>
+  <data name="TbSettingsFragmentFallbackDelay" xml:space="preserve">
+    <value>Fallback Delay</value>
+  </data>
+  <data name="TbSettingsFragmentFallbackDelayTip" xml:space="preserve">
+    <value>Fallback delay when ACK detection unavailable (e.g., 500ms). sing-box only. Empty = default.</value>
+  </data>
   <data name="TbSettingsEnableCacheFile4Sbox" xml:space="preserve">
     <value>Enable cache file for sing-box (ruleset files)</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1104,6 +1104,39 @@
   <data name="TbSettingsEnableFragment" xml:space="preserve">
     <value>Включить фрагментацию (Fragment)</value>
   </data>
+  <data name="TbSettingsFragmentPackets" xml:space="preserve">
+    <value>Пакеты для фрагментации</value>
+  </data>
+  <data name="TbSettingsFragmentPacketsTip" xml:space="preserve">
+    <value>Пакеты для фрагментации: tlshello (TLS ClientHello) или 1-1 — 1-5 (первые N TCP-пакетов)</value>
+  </data>
+  <data name="TbSettingsFragmentLength" xml:space="preserve">
+    <value>Длина фрагмента</value>
+  </data>
+  <data name="TbSettingsFragmentLengthTip" xml:space="preserve">
+    <value>Диапазон размера фрагмента в байтах (например, 50-100). Первое значение не больше второго. Пусто = по умолчанию.</value>
+  </data>
+  <data name="TbSettingsFragmentInterval" xml:space="preserve">
+    <value>Интервал фрагментации</value>
+  </data>
+  <data name="TbSettingsFragmentIntervalTip" xml:space="preserve">
+    <value>Задержка между фрагментами в мс (например, 10-20). Диапазон 1-100. Первое значение не больше второго. Пусто = по умолчанию.</value>
+  </data>
+  <data name="TbSettingsFragmentMaxSplit" xml:space="preserve">
+    <value>Макс. разделение</value>
+  </data>
+  <data name="TbSettingsFragmentMaxSplitTip" xml:space="preserve">
+    <value>Максимальное число разделений (0 = без лимита, 0-10000). Только для Xray-core. Пусто = по умолчанию.</value>
+  </data>
+  <data name="TbSettingsFragmentFallbackDelay" xml:space="preserve">
+    <value>Резервная задержка</value>
+  </data>
+  <data name="TbSettingsFragmentFallbackDelayTip" xml:space="preserve">
+    <value>Резервная задержка для TLS-фрагмента. Только для sing-box. Пусто = по умолчанию.</value>
+  </data>
+  <data name="FillFragmentParameterError" xml:space="preserve">
+    <value>Неверный формат диапазона. Используйте 'from-to' (например, 50-100).</value>
+  </data>
   <data name="TbSettingsEnableCacheFile4Sbox" xml:space="preserve">
     <value>Включить файл кэша для sing-box (файлы наборов правил)</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1101,6 +1101,42 @@
   <data name="TbSettingsEnableFragment" xml:space="preserve">
     <value>启用分片 (Fragment)</value>
   </data>
+  <data name="TbSettingsFragmentPackets" xml:space="preserve">
+    <value>分片包类型</value>
+  </data>
+  <data name="TbSettingsFragmentPacketsTip" xml:space="preserve">
+    <value>要分片的包类型: tlshello (TLS ClientHello) 或 1-1 到 1-5 (前 N 个 TCP 包)</value>
+  </data>
+  <data name="TbSettingsFragmentLength" xml:space="preserve">
+    <value>分片长度</value>
+  </data>
+  <data name="TbSettingsFragmentLengthTip" xml:space="preserve">
+    <value>分片大小范围(字节), 如 50-100. 第一个值必须 &lt;= 第二个值. 留空使用默认值.</value>
+  </data>
+  <data name="TbSettingsFragmentInterval" xml:space="preserve">
+    <value>分片间隔</value>
+  </data>
+  <data name="TbSettingsFragmentIntervalTip" xml:space="preserve">
+    <value>分片间延迟(毫秒), 如 10-20. 范围 1-100. 第一个值必须 &lt;= 第二个值. 留空使用默认值.</value>
+  </data>
+  <data name="TbSettingsFragmentMaxSplit" xml:space="preserve">
+    <value>最大分片数</value>
+  </data>
+  <data name="TbSettingsFragmentMaxSplitTip" xml:space="preserve">
+    <value>每个包最大分片数 (0-10000, 0=无限制). 仅 Xray. 留空使用默认值.</value>
+  </data>
+  <data name="TbSettingsFragmentRecordFragment" xml:space="preserve">
+    <value>记录分片</value>
+  </data>
+  <data name="TbSettingsFragmentRecordFragmentTip" xml:space="preserve">
+    <value>启用 TLS 记录分片 (splitRecord 模式). 仅 sing-box.</value>
+  </data>
+  <data name="TbSettingsFragmentFallbackDelay" xml:space="preserve">
+    <value>回退延迟</value>
+  </data>
+  <data name="TbSettingsFragmentFallbackDelayTip" xml:space="preserve">
+    <value>ACK 检测不可用时的回退延迟 (如 500ms). 仅 sing-box. 留空使用默认值.</value>
+  </data>
   <data name="TbSettingsEnableCacheFile4Sbox" xml:space="preserve">
     <value>启用 sing-box (规则集文件) 的缓存文件</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1125,17 +1125,14 @@
   <data name="TbSettingsFragmentMaxSplitTip" xml:space="preserve">
     <value>每个包最大分片数 (0-10000, 0=无限制). 仅 Xray. 留空使用默认值.</value>
   </data>
-  <data name="TbSettingsFragmentRecordFragment" xml:space="preserve">
-    <value>记录分片</value>
-  </data>
-  <data name="TbSettingsFragmentRecordFragmentTip" xml:space="preserve">
-    <value>启用 TLS 记录分片 (splitRecord 模式). 仅 sing-box.</value>
-  </data>
   <data name="TbSettingsFragmentFallbackDelay" xml:space="preserve">
     <value>回退延迟</value>
   </data>
   <data name="TbSettingsFragmentFallbackDelayTip" xml:space="preserve">
     <value>ACK 检测不可用时的回退延迟 (如 500ms). 仅 sing-box. 留空使用默认值.</value>
+  </data>
+  <data name="FillFragmentParameterError" xml:space="preserve">
+    <value>无效的范围格式。请使用 'from-to' (如 50-100)。</value>
   </data>
   <data name="TbSettingsEnableCacheFile4Sbox" xml:space="preserve">
     <value>启用 sing-box (规则集文件) 的缓存文件</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -1125,17 +1125,14 @@
   <data name="TbSettingsFragmentMaxSplitTip" xml:space="preserve">
     <value>每個封包最大分片數 (0-10000, 0=無限制)。僅 Xray。留空使用預設值。</value>
   </data>
-  <data name="TbSettingsFragmentRecordFragment" xml:space="preserve">
-    <value>記錄分片</value>
-  </data>
-  <data name="TbSettingsFragmentRecordFragmentTip" xml:space="preserve">
-    <value>啟用 TLS 記錄分片 (splitRecord 模式)。僅 sing-box。</value>
-  </data>
   <data name="TbSettingsFragmentFallbackDelay" xml:space="preserve">
     <value>回退延遲</value>
   </data>
   <data name="TbSettingsFragmentFallbackDelayTip" xml:space="preserve">
     <value>ACK 偵測不可用時的回退延遲 (如 500ms)。僅 sing-box。留空使用預設值。</value>
+  </data>
+  <data name="FillFragmentParameterError" xml:space="preserve">
+    <value>無效的範圍格式。請使用 'from-to' (如 50-100)。</value>
   </data>
   <data name="TbSettingsEnableCacheFile4Sbox" xml:space="preserve">
     <value>啟用 sing-box（規則集檔案）的快取檔案</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -1101,6 +1101,42 @@
   <data name="TbSettingsEnableFragment" xml:space="preserve">
     <value>啟用分片（Fragment）</value>
   </data>
+  <data name="TbSettingsFragmentPackets" xml:space="preserve">
+    <value>分片封包類型</value>
+  </data>
+  <data name="TbSettingsFragmentPacketsTip" xml:space="preserve">
+    <value>要分片的封包類型：tlshello (TLS ClientHello) 或 1-1 到 1-5 (前 N 個 TCP 封包)</value>
+  </data>
+  <data name="TbSettingsFragmentLength" xml:space="preserve">
+    <value>分片長度</value>
+  </data>
+  <data name="TbSettingsFragmentLengthTip" xml:space="preserve">
+    <value>分片大小範圍(位元組)，如 50-100。第一個值必須 &lt;= 第二個值。留空使用預設值。</value>
+  </data>
+  <data name="TbSettingsFragmentInterval" xml:space="preserve">
+    <value>分片間隔</value>
+  </data>
+  <data name="TbSettingsFragmentIntervalTip" xml:space="preserve">
+    <value>分片間延遲(毫秒)，如 10-20。範圍 1-100。第一個值必須 &lt;= 第二個值。留空使用預設值。</value>
+  </data>
+  <data name="TbSettingsFragmentMaxSplit" xml:space="preserve">
+    <value>最大分片數</value>
+  </data>
+  <data name="TbSettingsFragmentMaxSplitTip" xml:space="preserve">
+    <value>每個封包最大分片數 (0-10000, 0=無限制)。僅 Xray。留空使用預設值。</value>
+  </data>
+  <data name="TbSettingsFragmentRecordFragment" xml:space="preserve">
+    <value>記錄分片</value>
+  </data>
+  <data name="TbSettingsFragmentRecordFragmentTip" xml:space="preserve">
+    <value>啟用 TLS 記錄分片 (splitRecord 模式)。僅 sing-box。</value>
+  </data>
+  <data name="TbSettingsFragmentFallbackDelay" xml:space="preserve">
+    <value>回退延遲</value>
+  </data>
+  <data name="TbSettingsFragmentFallbackDelayTip" xml:space="preserve">
+    <value>ACK 偵測不可用時的回退延遲 (如 500ms)。僅 sing-box。留空使用預設值。</value>
+  </data>
   <data name="TbSettingsEnableCacheFile4Sbox" xml:space="preserve">
     <value>啟用 sing-box（規則集檔案）的快取檔案</value>
   </data>

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -395,7 +395,10 @@ public partial class CoreConfigSingboxService
             var tls = new Tls4Sbox()
             {
                 enabled = true,
-                record_fragment = _config.CoreBasicItem.EnableFragment ? true : null,
+                record_fragment = _config.CoreBasicItem.EnableFragment
+                    ? _config.Fragment4RayItem?.RecordFragment : null,
+                fragment_fallback_delay = _config.CoreBasicItem.EnableFragment
+                    ? (_config.Fragment4RayItem?.FallbackDelay ?? "500ms") : null,
                 server_name = serverName,
                 insecure = _node.GetAllowInsecure(),
                 alpn = _node.GetAlpn(),

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -395,10 +395,7 @@ public partial class CoreConfigSingboxService
             var tls = new Tls4Sbox()
             {
                 enabled = true,
-                record_fragment = _config.CoreBasicItem.EnableFragment
-                    ? _config.Fragment4RayItem?.RecordFragment : null,
-                fragment_fallback_delay = _config.CoreBasicItem.EnableFragment
-                    ? (_config.Fragment4RayItem?.FallbackDelay ?? "500ms") : null,
+                record_fragment = _config.CoreBasicItem.EnableFragment ? true : null,
                 server_name = serverName,
                 insecure = _node.GetAllowInsecure(),
                 alpn = _node.GetAlpn(),

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
@@ -901,6 +901,13 @@ public partial class CoreConfigV2rayService
         var configDelay = _config.Fragment4RayItem?.Interval ?? "10-20";
         var configMaxSplit = _config.Fragment4RayItem?.MaxSplit ?? "0";
 
+        var maxSplit = 0;
+        var parts = configMaxSplit.Split('-');
+        if (parts.Length > 0 && int.TryParse(parts[0], out var ms))
+        {
+            maxSplit = ms;
+        }
+
         var fragmentMask = new Mask4Ray
         {
             type = "fragment",
@@ -909,7 +916,7 @@ public partial class CoreConfigV2rayService
                 packets = configPackets,
                 length = configLength,
                 delay = configDelay,
-                maxSplit = int.TryParse(configMaxSplit, out var ms) ? ms : null,
+                maxSplit = maxSplit,
             }
         };
         var noiseMask = new Mask4Ray

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
@@ -896,10 +896,10 @@ public partial class CoreConfigV2rayService
 
     private (Mask4Ray tcpFragment, Mask4Ray udpNoise) BuildFragmentsMasks()
     {
-        var configPackets = _config.Fragment4RayItem?.Packets ?? "tlshello";
-        var configLength = _config.Fragment4RayItem?.Length ?? "50-100";
-        var configDelay = _config.Fragment4RayItem?.Interval ?? "10-20";
-        var configMaxSplit = _config.Fragment4RayItem?.MaxSplit ?? "0";
+        var configPackets = _config.Fragment4RayItem?.Packets.NullIfEmpty() ?? "tlshello";
+        var configLength = _config.Fragment4RayItem?.Length.NullIfEmpty() ?? "50-100";
+        var configDelay = _config.Fragment4RayItem?.Interval.NullIfEmpty() ?? "10-20";
+        var configMaxSplit = _config.Fragment4RayItem?.MaxSplit.NullIfEmpty() ?? "0";
 
         var maxSplit = 0;
         var parts = configMaxSplit.Split('-');

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayOutboundService.cs
@@ -899,6 +899,7 @@ public partial class CoreConfigV2rayService
         var configPackets = _config.Fragment4RayItem?.Packets ?? "tlshello";
         var configLength = _config.Fragment4RayItem?.Length ?? "50-100";
         var configDelay = _config.Fragment4RayItem?.Interval ?? "10-20";
+        var configMaxSplit = _config.Fragment4RayItem?.MaxSplit ?? "0";
 
         var fragmentMask = new Mask4Ray
         {
@@ -908,6 +909,7 @@ public partial class CoreConfigV2rayService
                 packets = configPackets,
                 length = configLength,
                 delay = configDelay,
+                maxSplit = int.TryParse(configMaxSplit, out var ms) ? ms : null,
             }
         };
         var noiseMask = new Mask4Ray

--- a/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
@@ -26,11 +26,11 @@ public class OptionSettingViewModel : MyReactiveObject
     [Reactive] public int? HyDownMbps { get; set; }
     [Reactive] public bool EnableFragment { get; set; }
     [Reactive] public bool EnableFinalFragment { get; set; }
-    [Reactive] public string FragmentPackets { get; set; } = "tlshello";
-    public List<string> FragmentPacketsOptions { get; } = ["tlshello", "1-1", "1-2", "1-3", "1-4", "1-5"];
-    [Reactive] public string FragmentLength { get; set; } = "50-100";
-    [Reactive] public string FragmentInterval { get; set; } = "10-20";
-    [Reactive] public string FragmentMaxSplit { get; set; } = "0";
+    [Reactive] public string FragmentPackets { get; set; }
+    [Reactive] public string FragmentLength { get; set; }
+    [Reactive] public string FragmentInterval { get; set; }
+    [Reactive] public string FragmentMaxSplit { get; set; }
+    public List<string> FragmentPacketsOptions { get; } = Global.FragmentPacketsOptions;
 
     #endregion Core
 

--- a/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
@@ -27,6 +27,7 @@ public class OptionSettingViewModel : MyReactiveObject
     [Reactive] public bool EnableFragment { get; set; }
     [Reactive] public bool EnableFinalFragment { get; set; }
     [Reactive] public string FragmentPackets { get; set; } = "tlshello";
+    public List<string> FragmentPacketsOptions { get; } = ["tlshello", "1-1", "1-2", "1-3", "1-4", "1-5"];
     [Reactive] public string FragmentLength { get; set; } = "50-100";
     [Reactive] public string FragmentInterval { get; set; } = "10-20";
     [Reactive] public string FragmentMaxSplit { get; set; } = "0";

--- a/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
@@ -26,6 +26,12 @@ public class OptionSettingViewModel : MyReactiveObject
     [Reactive] public int? HyDownMbps { get; set; }
     [Reactive] public bool EnableFragment { get; set; }
     [Reactive] public bool EnableFinalFragment { get; set; }
+    [Reactive] public string FragmentPackets { get; set; } = "tlshello";
+    [Reactive] public string FragmentLength { get; set; } = "50-100";
+    [Reactive] public string FragmentInterval { get; set; } = "10-20";
+    [Reactive] public string FragmentMaxSplit { get; set; } = "0";
+    [Reactive] public bool FragmentRecordFragment { get; set; } = false;
+    [Reactive] public string FragmentFallbackDelay { get; set; } = "500ms";
 
     #endregion Core
 
@@ -163,6 +169,12 @@ public class OptionSettingViewModel : MyReactiveObject
         HyDownMbps = _config.HysteriaItem.DownMbps;
         EnableFragment = _config.CoreBasicItem.EnableFragment;
         EnableFinalFragment = _config.CoreBasicItem.EnableFinalFragment;
+        FragmentPackets = _config.Fragment4RayItem?.Packets ?? "tlshello";
+        FragmentLength = _config.Fragment4RayItem?.Length ?? "50-100";
+        FragmentInterval = _config.Fragment4RayItem?.Interval ?? "10-20";
+        FragmentMaxSplit = _config.Fragment4RayItem?.MaxSplit ?? "0";
+        FragmentRecordFragment = _config.Fragment4RayItem?.RecordFragment ?? false;
+        FragmentFallbackDelay = _config.Fragment4RayItem?.FallbackDelay ?? "1000ms";
 
         #endregion Core
 
@@ -349,8 +361,34 @@ public class OptionSettingViewModel : MyReactiveObject
         _config.CoreBasicItem.EnableCacheFile4Sbox = EnableCacheFile4Sbox;
         _config.HysteriaItem.UpMbps = HyUpMbps ?? 0;
         _config.HysteriaItem.DownMbps = HyDownMbps ?? 0;
+        if (EnableFragment)
+        {
+            if (!Utils.TryParseRange(FragmentLength, 0, int.MaxValue, out _, out _))
+            {
+                NoticeManager.Instance.Enqueue(ResUI.FillCorrectServerPort);
+                return;
+            }
+            if (!Utils.TryParseRange(FragmentInterval, 1, 100, out _, out _))
+            {
+                NoticeManager.Instance.Enqueue(ResUI.FillCorrectServerPort);
+                return;
+            }
+            if (FragmentMaxSplit.IsNotEmpty()
+                && (!int.TryParse(FragmentMaxSplit, out var ms) || ms < 0 || ms > 10000))
+            {
+                NoticeManager.Instance.Enqueue(ResUI.FillCorrectServerPort);
+                return;
+            }
+        }
         _config.CoreBasicItem.EnableFragment = EnableFragment;
         _config.CoreBasicItem.EnableFinalFragment = EnableFinalFragment;
+        _config.Fragment4RayItem ??= new();
+        _config.Fragment4RayItem.Packets = FragmentPackets.NullIfEmpty() ?? "tlshello";
+        _config.Fragment4RayItem.Length = FragmentLength.NullIfEmpty() ?? "50-100";
+        _config.Fragment4RayItem.Interval = FragmentInterval.NullIfEmpty() ?? "10-20";
+        _config.Fragment4RayItem.MaxSplit = FragmentMaxSplit.NullIfEmpty() ?? "0";
+        _config.Fragment4RayItem.RecordFragment = FragmentRecordFragment;
+        _config.Fragment4RayItem.FallbackDelay = FragmentFallbackDelay.NullIfEmpty() ?? "500ms";
 
         _config.GuiItem.AutoRun = AutoRun;
         _config.GuiItem.EnableStatistics = EnableStatistics;

--- a/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
@@ -31,8 +31,6 @@ public class OptionSettingViewModel : MyReactiveObject
     [Reactive] public string FragmentLength { get; set; } = "50-100";
     [Reactive] public string FragmentInterval { get; set; } = "10-20";
     [Reactive] public string FragmentMaxSplit { get; set; } = "0";
-    [Reactive] public bool FragmentRecordFragment { get; set; } = false;
-    [Reactive] public string FragmentFallbackDelay { get; set; } = "500ms";
 
     #endregion Core
 
@@ -174,8 +172,6 @@ public class OptionSettingViewModel : MyReactiveObject
         FragmentLength = _config.Fragment4RayItem?.Length ?? "50-100";
         FragmentInterval = _config.Fragment4RayItem?.Interval ?? "10-20";
         FragmentMaxSplit = _config.Fragment4RayItem?.MaxSplit ?? "0";
-        FragmentRecordFragment = _config.Fragment4RayItem?.RecordFragment ?? false;
-        FragmentFallbackDelay = _config.Fragment4RayItem?.FallbackDelay ?? "1000ms";
 
         #endregion Core
 
@@ -366,18 +362,18 @@ public class OptionSettingViewModel : MyReactiveObject
         {
             if (!Utils.TryParseRange(FragmentLength, 0, int.MaxValue, out _, out _))
             {
-                NoticeManager.Instance.Enqueue(ResUI.FillCorrectServerPort);
+                NoticeManager.Instance.Enqueue(ResUI.FillFragmentParameterError);
                 return;
             }
             if (!Utils.TryParseRange(FragmentInterval, 1, 100, out _, out _))
             {
-                NoticeManager.Instance.Enqueue(ResUI.FillCorrectServerPort);
+                NoticeManager.Instance.Enqueue(ResUI.FillFragmentParameterError);
                 return;
             }
             if (FragmentMaxSplit.IsNotEmpty()
-                && (!int.TryParse(FragmentMaxSplit, out var ms) || ms < 0 || ms > 10000))
+                && !Utils.TryParseMaxSplit(FragmentMaxSplit, 0, 10000, out _, out _))
             {
-                NoticeManager.Instance.Enqueue(ResUI.FillCorrectServerPort);
+                NoticeManager.Instance.Enqueue(ResUI.FillFragmentParameterError);
                 return;
             }
         }
@@ -388,8 +384,6 @@ public class OptionSettingViewModel : MyReactiveObject
         _config.Fragment4RayItem.Length = FragmentLength.NullIfEmpty() ?? "50-100";
         _config.Fragment4RayItem.Interval = FragmentInterval.NullIfEmpty() ?? "10-20";
         _config.Fragment4RayItem.MaxSplit = FragmentMaxSplit.NullIfEmpty() ?? "0";
-        _config.Fragment4RayItem.RecordFragment = FragmentRecordFragment;
-        _config.Fragment4RayItem.FallbackDelay = FragmentFallbackDelay.NullIfEmpty() ?? "500ms";
 
         _config.GuiItem.AutoRun = AutoRun;
         _config.GuiItem.EnableStatistics = EnableStatistics;

--- a/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
@@ -30,7 +30,6 @@ public class OptionSettingViewModel : MyReactiveObject
     [Reactive] public string FragmentLength { get; set; }
     [Reactive] public string FragmentInterval { get; set; }
     [Reactive] public string FragmentMaxSplit { get; set; }
-    public List<string> FragmentPacketsOptions { get; } = Global.FragmentPacketsOptions;
 
     #endregion Core
 
@@ -168,10 +167,10 @@ public class OptionSettingViewModel : MyReactiveObject
         HyDownMbps = _config.HysteriaItem.DownMbps;
         EnableFragment = _config.CoreBasicItem.EnableFragment;
         EnableFinalFragment = _config.CoreBasicItem.EnableFinalFragment;
-        FragmentPackets = _config.Fragment4RayItem?.Packets ?? "tlshello";
-        FragmentLength = _config.Fragment4RayItem?.Length ?? "50-100";
-        FragmentInterval = _config.Fragment4RayItem?.Interval ?? "10-20";
-        FragmentMaxSplit = _config.Fragment4RayItem?.MaxSplit ?? "0";
+        FragmentPackets = _config.Fragment4RayItem?.Packets;
+        FragmentLength = _config.Fragment4RayItem?.Length;
+        FragmentInterval = _config.Fragment4RayItem?.Interval;
+        FragmentMaxSplit = _config.Fragment4RayItem?.MaxSplit;
 
         #endregion Core
 
@@ -379,11 +378,10 @@ public class OptionSettingViewModel : MyReactiveObject
         }
         _config.CoreBasicItem.EnableFragment = EnableFragment;
         _config.CoreBasicItem.EnableFinalFragment = EnableFinalFragment;
-        _config.Fragment4RayItem ??= new();
-        _config.Fragment4RayItem.Packets = FragmentPackets.NullIfEmpty() ?? "tlshello";
-        _config.Fragment4RayItem.Length = FragmentLength.NullIfEmpty() ?? "50-100";
-        _config.Fragment4RayItem.Interval = FragmentInterval.NullIfEmpty() ?? "10-20";
-        _config.Fragment4RayItem.MaxSplit = FragmentMaxSplit.NullIfEmpty() ?? "0";
+        _config.Fragment4RayItem.Packets = FragmentPackets;
+        _config.Fragment4RayItem.Length = FragmentLength;
+        _config.Fragment4RayItem.Interval = FragmentInterval;
+        _config.Fragment4RayItem.MaxSplit = FragmentMaxSplit;
 
         _config.GuiItem.AutoRun = AutoRun;
         _config.GuiItem.EnableStatistics = EnableStatistics;

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
@@ -38,7 +38,7 @@
                     <Grid
                         Margin="{StaticResource Margin4}"
                         ColumnDefinitions="Auto,Auto,*"
-                        RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                        RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
 
                         <TextBlock
                             Grid.Row="0"
@@ -300,20 +300,175 @@
                             Margin="{StaticResource Margin4}"
                             HorizontalAlignment="Left" />
 
+                        <!-- Fragment Settings (visible when EnableFragment is checked) -->
                         <TextBlock
                             Grid.Row="21"
+                            Grid.Column="0"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            IsVisible="{Binding EnableFragment}"
+                            Text="{x:Static resx:ResUI.TbSettingsFragmentPackets}" />
+                        <ComboBox
+                            Grid.Row="21"
+                            Grid.Column="1"
+                            Width="120"
+                            Margin="{StaticResource Margin4}"
+                            HorizontalAlignment="Left"
+                            IsVisible="{Binding EnableFragment}"
+                            SelectedItem="{Binding FragmentPackets, Mode=TwoWay}">
+                            <ComboBoxItem Content="tlshello" />
+                            <ComboBoxItem Content="1-1" />
+                            <ComboBoxItem Content="1-2" />
+                            <ComboBoxItem Content="1-3" />
+                            <ComboBoxItem Content="1-4" />
+                            <ComboBoxItem Content="1-5" />
+                        </ComboBox>
+                        <TextBlock
+                            Grid.Row="21"
+                            Grid.Column="2"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            IsVisible="{Binding EnableFragment}"
+                            Text="{x:Static resx:ResUI.TbSettingsFragmentPacketsTip}"
+                            TextWrapping="Wrap" />
+
+                        <TextBlock
+                            Grid.Row="22"
+                            Grid.Column="0"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            IsVisible="{Binding EnableFragment}"
+                            Text="{x:Static resx:ResUI.TbSettingsFragmentLength}" />
+                        <TextBox
+                            Grid.Row="22"
+                            Grid.Column="1"
+                            Width="120"
+                            Margin="{StaticResource Margin4}"
+                            HorizontalAlignment="Left"
+                            IsVisible="{Binding EnableFragment}"
+                            Watermark="50-100"
+                            Text="{Binding FragmentLength, Mode=TwoWay}" />
+                        <TextBlock
+                            Grid.Row="22"
+                            Grid.Column="2"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            IsVisible="{Binding EnableFragment}"
+                            Text="{x:Static resx:ResUI.TbSettingsFragmentLengthTip}"
+                            TextWrapping="Wrap" />
+
+                        <TextBlock
+                            Grid.Row="23"
+                            Grid.Column="0"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            IsVisible="{Binding EnableFragment}"
+                            Text="{x:Static resx:ResUI.TbSettingsFragmentInterval}" />
+                        <TextBox
+                            Grid.Row="23"
+                            Grid.Column="1"
+                            Width="120"
+                            Margin="{StaticResource Margin4}"
+                            HorizontalAlignment="Left"
+                            IsVisible="{Binding EnableFragment}"
+                            Watermark="10-20"
+                            Text="{Binding FragmentInterval, Mode=TwoWay}" />
+                        <TextBlock
+                            Grid.Row="23"
+                            Grid.Column="2"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            IsVisible="{Binding EnableFragment}"
+                            Text="{x:Static resx:ResUI.TbSettingsFragmentIntervalTip}"
+                            TextWrapping="Wrap" />
+
+                        <TextBlock
+                            Grid.Row="24"
+                            Grid.Column="0"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            IsVisible="{Binding EnableFragment}"
+                            Text="{x:Static resx:ResUI.TbSettingsFragmentMaxSplit}" />
+                        <TextBox
+                            Grid.Row="24"
+                            Grid.Column="1"
+                            Width="120"
+                            Margin="{StaticResource Margin4}"
+                            HorizontalAlignment="Left"
+                            IsVisible="{Binding EnableFragment}"
+                            Watermark="0"
+                            Text="{Binding FragmentMaxSplit, Mode=TwoWay}" />
+                        <TextBlock
+                            Grid.Row="24"
+                            Grid.Column="2"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            IsVisible="{Binding EnableFragment}"
+                            Text="{x:Static resx:ResUI.TbSettingsFragmentMaxSplitTip}"
+                            TextWrapping="Wrap" />
+
+                        <TextBlock
+                            Grid.Row="25"
+                            Grid.Column="0"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            IsVisible="{Binding EnableFragment}"
+                            Text="{x:Static resx:ResUI.TbSettingsFragmentRecordFragment}" />
+                        <ToggleSwitch
+                            Grid.Row="25"
+                            Grid.Column="1"
+                            Margin="{StaticResource Margin4}"
+                            HorizontalAlignment="Left"
+                            IsVisible="{Binding EnableFragment}"
+                            IsChecked="{Binding FragmentRecordFragment, Mode=TwoWay}" />
+                        <TextBlock
+                            Grid.Row="25"
+                            Grid.Column="2"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            IsVisible="{Binding EnableFragment}"
+                            Text="{x:Static resx:ResUI.TbSettingsFragmentRecordFragmentTip}"
+                            TextWrapping="Wrap" />
+
+                        <TextBlock
+                            Grid.Row="26"
+                            Grid.Column="0"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            IsVisible="{Binding EnableFragment}"
+                            Text="{x:Static resx:ResUI.TbSettingsFragmentFallbackDelay}" />
+                        <TextBox
+                            Grid.Row="26"
+                            Grid.Column="1"
+                            Width="120"
+                            Margin="{StaticResource Margin4}"
+                            HorizontalAlignment="Left"
+                            IsVisible="{Binding EnableFragment}"
+                            Watermark="500ms"
+                            Text="{Binding FragmentFallbackDelay, Mode=TwoWay}" />
+                        <TextBlock
+                            Grid.Row="26"
+                            Grid.Column="2"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            IsVisible="{Binding EnableFragment}"
+                            Text="{x:Static resx:ResUI.TbSettingsFragmentFallbackDelayTip}"
+                            TextWrapping="Wrap" />
+
+                        <TextBlock
+                            Grid.Row="27"
                             Grid.Column="0"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
                             Text="{x:Static resx:ResUI.TbEnableFinalFragment}" />
                         <ToggleSwitch
                             x:Name="togenableFinalFragment"
-                            Grid.Row="21"
+                            Grid.Row="27"
                             Grid.Column="1"
                             Margin="{StaticResource Margin4}"
                             HorizontalAlignment="Left" />
                         <TextBlock
-                            Grid.Row="21"
+                            Grid.Row="27"
                             Grid.Column="2"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
@@ -321,19 +476,19 @@
                             TextWrapping="Wrap" />
 
                         <TextBlock
-                            Grid.Row="22"
+                            Grid.Row="28"
                             Grid.Column="0"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
                             Text="{x:Static resx:ResUI.TbSettingsBindInterface}" />
                         <TextBox
                             x:Name="txtbindInterface"
-                            Grid.Row="22"
+                            Grid.Row="28"
                             Grid.Column="1"
                             Width="200"
                             Margin="{StaticResource Margin4}" />
                         <TextBlock
-                            Grid.Row="22"
+                            Grid.Row="28"
                             Grid.Column="2"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
@@ -341,20 +496,20 @@
                             TextWrapping="Wrap" />
 
                         <TextBlock
-                            Grid.Row="23"
+                            Grid.Row="29"
                             Grid.Column="0"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
                             Text="{x:Static resx:ResUI.TbSettingsSendThrough}" />
                         <TextBox
                             x:Name="txtsendThrough"
-                            Grid.Row="23"
+                            Grid.Row="29"
                             Grid.Column="1"
                             Width="200"
                             Margin="{StaticResource Margin4}"
                             Watermark="0.0.0.0" />
                         <TextBlock
-                            Grid.Row="23"
+                            Grid.Row="29"
                             Grid.Column="2"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
@@ -402,54 +402,6 @@
                             TextWrapping="Wrap" />
 
                         <TextBlock
-                            Grid.Row="25"
-                            Grid.Column="0"
-                            Margin="{StaticResource Margin4}"
-                            VerticalAlignment="Center"
-                            IsVisible="{Binding EnableFragment}"
-                            Text="{x:Static resx:ResUI.TbSettingsFragmentRecordFragment}" />
-                        <ToggleSwitch
-                            Grid.Row="25"
-                            Grid.Column="1"
-                            Margin="{StaticResource Margin4}"
-                            HorizontalAlignment="Left"
-                            IsVisible="{Binding EnableFragment}"
-                            IsChecked="{Binding FragmentRecordFragment, Mode=TwoWay}" />
-                        <TextBlock
-                            Grid.Row="25"
-                            Grid.Column="2"
-                            Margin="{StaticResource Margin4}"
-                            VerticalAlignment="Center"
-                            IsVisible="{Binding EnableFragment}"
-                            Text="{x:Static resx:ResUI.TbSettingsFragmentRecordFragmentTip}"
-                            TextWrapping="Wrap" />
-
-                        <TextBlock
-                            Grid.Row="26"
-                            Grid.Column="0"
-                            Margin="{StaticResource Margin4}"
-                            VerticalAlignment="Center"
-                            IsVisible="{Binding EnableFragment}"
-                            Text="{x:Static resx:ResUI.TbSettingsFragmentFallbackDelay}" />
-                        <TextBox
-                            Grid.Row="26"
-                            Grid.Column="1"
-                            Width="120"
-                            Margin="{StaticResource Margin4}"
-                            HorizontalAlignment="Left"
-                            IsVisible="{Binding EnableFragment}"
-                            Watermark="500ms"
-                            Text="{Binding FragmentFallbackDelay, Mode=TwoWay}" />
-                        <TextBlock
-                            Grid.Row="26"
-                            Grid.Column="2"
-                            Margin="{StaticResource Margin4}"
-                            VerticalAlignment="Center"
-                            IsVisible="{Binding EnableFragment}"
-                            Text="{x:Static resx:ResUI.TbSettingsFragmentFallbackDelayTip}"
-                            TextWrapping="Wrap" />
-
-                        <TextBlock
                             Grid.Row="27"
                             Grid.Column="0"
                             Margin="{StaticResource Margin4}"

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
@@ -38,7 +38,7 @@
                     <Grid
                         Margin="{StaticResource Margin4}"
                         ColumnDefinitions="Auto,Auto,*"
-                        RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                        RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
 
                         <TextBlock
                             Grid.Row="0"
@@ -300,120 +300,129 @@
                             Margin="{StaticResource Margin4}"
                             HorizontalAlignment="Left" />
 
-                        <!-- Fragment Settings (visible when EnableFragment is checked) -->
+                        <Button
+                            Grid.Row="20"
+                            Grid.Column="2"
+                            Margin="{StaticResource MarginLr8}"
+                            HorizontalAlignment="Left"
+                            Classes="IconButton">
+                            <Button.Content>
+                                <PathIcon Data="{StaticResource SemiIconMore}">
+                                    <PathIcon.RenderTransform>
+                                        <RotateTransform Angle="90" />
+                                    </PathIcon.RenderTransform>
+                                </PathIcon>
+                            </Button.Content>
+                            <Button.Flyout>
+                                <Flyout>
+                                    <StackPanel Margin="{StaticResource Margin8}">
+                                        <Grid ColumnDefinitions="Auto,Auto,400" RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+                                            <TextBlock
+                                                Grid.Row="0"
+                                                Grid.Column="0"
+                                                Margin="{StaticResource Margin4}"
+                                                VerticalAlignment="Center"
+                                                Text="{x:Static resx:ResUI.TbSettingsFragmentPackets}" />
+                                            <ComboBox
+                                                x:Name="cmbFragmentPackets"
+                                                Grid.Row="0"
+                                                Grid.Column="1"
+                                                Width="120"
+                                                Margin="{StaticResource Margin4}"
+                                                HorizontalAlignment="Left" />
+                                            <TextBlock
+                                                Grid.Row="0"
+                                                Grid.Column="2"
+                                                Margin="{StaticResource Margin4}"
+                                                VerticalAlignment="Center"
+                                                Text="{x:Static resx:ResUI.TbSettingsFragmentPacketsTip}"
+                                                TextWrapping="Wrap" />
+
+                                            <TextBlock
+                                                Grid.Row="1"
+                                                Grid.Column="0"
+                                                Margin="{StaticResource Margin4}"
+                                                VerticalAlignment="Center"
+                                                Text="{x:Static resx:ResUI.TbSettingsFragmentLength}" />
+                                            <TextBox
+                                                x:Name="txtFragmentLength"
+                                                Grid.Row="1"
+                                                Grid.Column="1"
+                                                Width="120"
+                                                Margin="{StaticResource Margin4}"
+                                                HorizontalAlignment="Left"
+                                                Watermark="50-100" />
+                                            <TextBlock
+                                                Grid.Row="1"
+                                                Grid.Column="2"
+                                                Margin="{StaticResource Margin4}"
+                                                VerticalAlignment="Center"
+                                                Text="{x:Static resx:ResUI.TbSettingsFragmentLengthTip}"
+                                                TextWrapping="Wrap" />
+
+                                            <TextBlock
+                                                Grid.Row="2"
+                                                Grid.Column="0"
+                                                Margin="{StaticResource Margin4}"
+                                                VerticalAlignment="Center"
+                                                Text="{x:Static resx:ResUI.TbSettingsFragmentInterval}" />
+                                            <TextBox
+                                                x:Name="txtFragmentInterval"
+                                                Grid.Row="2"
+                                                Grid.Column="1"
+                                                Width="120"
+                                                Margin="{StaticResource Margin4}"
+                                                HorizontalAlignment="Left"
+                                                Watermark="10-20" />
+                                            <TextBlock
+                                                Grid.Row="2"
+                                                Grid.Column="2"
+                                                Margin="{StaticResource Margin4}"
+                                                VerticalAlignment="Center"
+                                                Text="{x:Static resx:ResUI.TbSettingsFragmentIntervalTip}"
+                                                TextWrapping="Wrap" />
+
+                                            <TextBlock
+                                                Grid.Row="3"
+                                                Grid.Column="0"
+                                                Margin="{StaticResource Margin4}"
+                                                VerticalAlignment="Center"
+                                                Text="{x:Static resx:ResUI.TbSettingsFragmentMaxSplit}" />
+                                            <TextBox
+                                                x:Name="txtFragmentMaxSplit"
+                                                Grid.Row="3"
+                                                Grid.Column="1"
+                                                Width="120"
+                                                Margin="{StaticResource Margin4}"
+                                                HorizontalAlignment="Left"
+                                                Watermark="0" />
+                                            <TextBlock
+                                                Grid.Row="3"
+                                                Grid.Column="2"
+                                                Margin="{StaticResource Margin4}"
+                                                VerticalAlignment="Center"
+                                                Text="{x:Static resx:ResUI.TbSettingsFragmentMaxSplitTip}"
+                                                TextWrapping="Wrap" />
+                                        </Grid>
+                                    </StackPanel>
+                                </Flyout>
+                            </Button.Flyout>
+                        </Button>
+
                         <TextBlock
                             Grid.Row="21"
-                            Grid.Column="0"
-                            Margin="{StaticResource Margin4}"
-                            VerticalAlignment="Center"
-                            IsVisible="{Binding EnableFragment}"
-                            Text="{x:Static resx:ResUI.TbSettingsFragmentPackets}" />
-                        <ComboBox
-                            x:Name="cmbFragmentPackets"
-                            Grid.Row="21"
-                            Grid.Column="1"
-                            Width="120"
-                            Margin="{StaticResource Margin4}"
-                            HorizontalAlignment="Left"
-                            IsVisible="{Binding EnableFragment}" />
-                        <TextBlock
-                            Grid.Row="21"
-                            Grid.Column="2"
-                            Margin="{StaticResource Margin4}"
-                            VerticalAlignment="Center"
-                            IsVisible="{Binding EnableFragment}"
-                            Text="{x:Static resx:ResUI.TbSettingsFragmentPacketsTip}"
-                            TextWrapping="Wrap" />
-
-                        <TextBlock
-                            Grid.Row="22"
-                            Grid.Column="0"
-                            Margin="{StaticResource Margin4}"
-                            VerticalAlignment="Center"
-                            IsVisible="{Binding EnableFragment}"
-                            Text="{x:Static resx:ResUI.TbSettingsFragmentLength}" />
-                        <TextBox
-                            Grid.Row="22"
-                            Grid.Column="1"
-                            Width="120"
-                            Margin="{StaticResource Margin4}"
-                            HorizontalAlignment="Left"
-                            IsVisible="{Binding EnableFragment}"
-                            Watermark="50-100"
-                            Text="{Binding FragmentLength, Mode=TwoWay}" />
-                        <TextBlock
-                            Grid.Row="22"
-                            Grid.Column="2"
-                            Margin="{StaticResource Margin4}"
-                            VerticalAlignment="Center"
-                            IsVisible="{Binding EnableFragment}"
-                            Text="{x:Static resx:ResUI.TbSettingsFragmentLengthTip}"
-                            TextWrapping="Wrap" />
-
-                        <TextBlock
-                            Grid.Row="23"
-                            Grid.Column="0"
-                            Margin="{StaticResource Margin4}"
-                            VerticalAlignment="Center"
-                            IsVisible="{Binding EnableFragment}"
-                            Text="{x:Static resx:ResUI.TbSettingsFragmentInterval}" />
-                        <TextBox
-                            Grid.Row="23"
-                            Grid.Column="1"
-                            Width="120"
-                            Margin="{StaticResource Margin4}"
-                            HorizontalAlignment="Left"
-                            IsVisible="{Binding EnableFragment}"
-                            Watermark="10-20"
-                            Text="{Binding FragmentInterval, Mode=TwoWay}" />
-                        <TextBlock
-                            Grid.Row="23"
-                            Grid.Column="2"
-                            Margin="{StaticResource Margin4}"
-                            VerticalAlignment="Center"
-                            IsVisible="{Binding EnableFragment}"
-                            Text="{x:Static resx:ResUI.TbSettingsFragmentIntervalTip}"
-                            TextWrapping="Wrap" />
-
-                        <TextBlock
-                            Grid.Row="24"
-                            Grid.Column="0"
-                            Margin="{StaticResource Margin4}"
-                            VerticalAlignment="Center"
-                            IsVisible="{Binding EnableFragment}"
-                            Text="{x:Static resx:ResUI.TbSettingsFragmentMaxSplit}" />
-                        <TextBox
-                            Grid.Row="24"
-                            Grid.Column="1"
-                            Width="120"
-                            Margin="{StaticResource Margin4}"
-                            HorizontalAlignment="Left"
-                            IsVisible="{Binding EnableFragment}"
-                            Watermark="0"
-                            Text="{Binding FragmentMaxSplit, Mode=TwoWay}" />
-                        <TextBlock
-                            Grid.Row="24"
-                            Grid.Column="2"
-                            Margin="{StaticResource Margin4}"
-                            VerticalAlignment="Center"
-                            IsVisible="{Binding EnableFragment}"
-                            Text="{x:Static resx:ResUI.TbSettingsFragmentMaxSplitTip}"
-                            TextWrapping="Wrap" />
-
-                        <TextBlock
-                            Grid.Row="27"
                             Grid.Column="0"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
                             Text="{x:Static resx:ResUI.TbEnableFinalFragment}" />
                         <ToggleSwitch
                             x:Name="togenableFinalFragment"
-                            Grid.Row="27"
+                            Grid.Row="21"
                             Grid.Column="1"
                             Margin="{StaticResource Margin4}"
                             HorizontalAlignment="Left" />
                         <TextBlock
-                            Grid.Row="27"
+                            Grid.Row="21"
                             Grid.Column="2"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
@@ -421,19 +430,19 @@
                             TextWrapping="Wrap" />
 
                         <TextBlock
-                            Grid.Row="28"
+                            Grid.Row="22"
                             Grid.Column="0"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
                             Text="{x:Static resx:ResUI.TbSettingsBindInterface}" />
                         <TextBox
                             x:Name="txtbindInterface"
-                            Grid.Row="28"
+                            Grid.Row="22"
                             Grid.Column="1"
                             Width="200"
                             Margin="{StaticResource Margin4}" />
                         <TextBlock
-                            Grid.Row="28"
+                            Grid.Row="22"
                             Grid.Column="2"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
@@ -441,20 +450,20 @@
                             TextWrapping="Wrap" />
 
                         <TextBlock
-                            Grid.Row="29"
+                            Grid.Row="23"
                             Grid.Column="0"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
                             Text="{x:Static resx:ResUI.TbSettingsSendThrough}" />
                         <TextBox
                             x:Name="txtsendThrough"
-                            Grid.Row="29"
+                            Grid.Row="23"
                             Grid.Column="1"
                             Width="200"
                             Margin="{StaticResource Margin4}"
                             Watermark="0.0.0.0" />
                         <TextBlock
-                            Grid.Row="29"
+                            Grid.Row="23"
                             Grid.Column="2"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
@@ -309,14 +309,13 @@
                             IsVisible="{Binding EnableFragment}"
                             Text="{x:Static resx:ResUI.TbSettingsFragmentPackets}" />
                         <ComboBox
+                            x:Name="cmbFragmentPackets"
                             Grid.Row="21"
                             Grid.Column="1"
                             Width="120"
                             Margin="{StaticResource Margin4}"
                             HorizontalAlignment="Left"
-                            IsVisible="{Binding EnableFragment}"
-                            ItemsSource="{Binding FragmentPacketsOptions}"
-                            SelectedItem="{Binding FragmentPackets, Mode=TwoWay}" />
+                            IsVisible="{Binding EnableFragment}" />
                         <TextBlock
                             Grid.Row="21"
                             Grid.Column="2"

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
@@ -315,14 +315,8 @@
                             Margin="{StaticResource Margin4}"
                             HorizontalAlignment="Left"
                             IsVisible="{Binding EnableFragment}"
-                            SelectedItem="{Binding FragmentPackets, Mode=TwoWay}">
-                            <ComboBoxItem Content="tlshello" />
-                            <ComboBoxItem Content="1-1" />
-                            <ComboBoxItem Content="1-2" />
-                            <ComboBoxItem Content="1-3" />
-                            <ComboBoxItem Content="1-4" />
-                            <ComboBoxItem Content="1-5" />
-                        </ComboBox>
+                            ItemsSource="{Binding FragmentPacketsOptions}"
+                            SelectedItem="{Binding FragmentPackets, Mode=TwoWay}" />
                         <TextBlock
                             Grid.Row="21"
                             Grid.Column="2"

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
@@ -36,6 +36,7 @@ public partial class OptionSettingWindow : WindowBase<OptionSettingViewModel>
         cmbMtu.ItemsSource = Global.TunMtus;
         cmbStack.ItemsSource = Global.TunStacks;
         cmbIcmpRoutingPolicy.ItemsSource = Global.TunIcmpRoutingPolicies;
+        cmbFragmentPackets.ItemsSource = Global.FragmentPacketsOptions;
 
         cmbCoreType1.ItemsSource = Global.CoreTypes;
         cmbCoreType2.ItemsSource = Global.CoreTypes;
@@ -84,6 +85,7 @@ public partial class OptionSettingWindow : WindowBase<OptionSettingViewModel>
             this.Bind(ViewModel, vm => vm.HyDownMbps, v => v.txtDownMbps.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.EnableFragment, v => v.togenableFragment.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.EnableFinalFragment, v => v.togenableFinalFragment.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.FragmentPackets, v => v.cmbFragmentPackets.SelectedItem).DisposeWith(disposables);
 
             this.Bind(ViewModel, vm => vm.AutoRun, v => v.togAutoRun.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.EnableStatistics, v => v.togEnableStatistics.IsChecked).DisposeWith(disposables);

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
@@ -1,4 +1,3 @@
-using Avalonia.Media;
 using v2rayN.Desktop.Base;
 using v2rayN.Desktop.Common;
 
@@ -86,6 +85,9 @@ public partial class OptionSettingWindow : WindowBase<OptionSettingViewModel>
             this.Bind(ViewModel, vm => vm.EnableFragment, v => v.togenableFragment.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.EnableFinalFragment, v => v.togenableFinalFragment.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.FragmentPackets, v => v.cmbFragmentPackets.SelectedItem).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.FragmentLength, v => v.txtFragmentLength.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.FragmentInterval, v => v.txtFragmentInterval.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.FragmentMaxSplit, v => v.txtFragmentMaxSplit.Text).DisposeWith(disposables);
 
             this.Bind(ViewModel, vm => vm.AutoRun, v => v.togAutoRun.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.EnableStatistics, v => v.togEnableStatistics.IsChecked).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
@@ -9,6 +9,7 @@
     xmlns:reactiveui="http://reactiveui.net"
     xmlns:resx="clr-namespace:ServiceLib.Resx;assembly=ServiceLib"
     xmlns:vms="clr-namespace:ServiceLib.ViewModels;assembly=ServiceLib"
+    xmlns:sys="clr-namespace:System;assembly=mscorlib"
     Title="{x:Static resx:ResUI.menuSetting}"
     Width="1000"
     Height="700"
@@ -17,6 +18,9 @@
     Style="{StaticResource WindowGlobal}"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
+    <base:WindowBase.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisConverter" />
+    </base:WindowBase.Resources>
     <DockPanel Margin="{StaticResource Margin8}">
         <StackPanel
             Margin="{StaticResource Margin4}"
@@ -42,7 +46,15 @@
             <TabItem Header="{x:Static resx:ResUI.TbSettingsCore}">
                 <ScrollViewer VerticalScrollBarVisibility="Visible">
                     <Grid Margin="{StaticResource Margin8}">
-                        <Grid.RowDefinitions>
+<Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
@@ -366,8 +378,117 @@
                             Margin="{StaticResource Margin8}"
                             HorizontalAlignment="Left" />
 
+                        <!-- Fragment Settings (visible when EnableFragment is checked) -->
+                        <StackPanel Grid.Row="21" Grid.Column="0" Grid.ColumnSpan="3" Margin="{StaticResource Margin8}"
+                                    Visibility="{Binding EnableFragment, Converter={StaticResource BoolToVisConverter}}">
+                            <Grid Margin="0,4,0,0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+
+                                <TextBlock Grid.Column="0" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
+                                           Text="{x:Static resx:ResUI.TbSettingsFragmentPackets}" />
+                                <ComboBox Grid.Column="1" Width="120" Margin="8,0,0,0" VerticalAlignment="Center"
+                                          SelectedItem="{Binding FragmentPackets, Mode=TwoWay}">
+                                    <ComboBoxItem Content="tlshello" />
+                                    <ComboBoxItem Content="1-1" />
+                                    <ComboBoxItem Content="1-2" />
+                                    <ComboBoxItem Content="1-3" />
+                                    <ComboBoxItem Content="1-4" />
+                                    <ComboBoxItem Content="1-5" />
+                                </ComboBox>
+                                <TextBlock Grid.Column="2" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
+                                           Text="{x:Static resx:ResUI.TbSettingsFragmentPacketsTip}" TextWrapping="Wrap" />
+                            </Grid>
+
+                            <Grid Margin="0,4,0,0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+
+                                <TextBlock Grid.Column="0" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
+                                           Text="{x:Static resx:ResUI.TbSettingsFragmentLength}" />
+                                <TextBox Grid.Column="1" Width="120" Margin="8,0,0,0" VerticalAlignment="Center"
+                                         Style="{StaticResource DefTextBox}"
+                                         Text="{Binding FragmentLength, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         materialDesign:HintAssist.Hint="50-100" />
+                                <TextBlock Grid.Column="2" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
+                                           Text="{x:Static resx:ResUI.TbSettingsFragmentLengthTip}" TextWrapping="Wrap" />
+                            </Grid>
+
+                            <Grid Margin="0,4,0,0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+
+                                <TextBlock Grid.Column="0" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
+                                           Text="{x:Static resx:ResUI.TbSettingsFragmentInterval}" />
+                                <TextBox Grid.Column="1" Width="120" Margin="8,0,0,0" VerticalAlignment="Center"
+                                         Style="{StaticResource DefTextBox}"
+                                         Text="{Binding FragmentInterval, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         materialDesign:HintAssist.Hint="10-20" />
+                                <TextBlock Grid.Column="2" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
+                                           Text="{x:Static resx:ResUI.TbSettingsFragmentIntervalTip}" TextWrapping="Wrap" />
+                            </Grid>
+
+                            <Grid Margin="0,4,0,0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+
+                                <TextBlock Grid.Column="0" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
+                                           Text="{x:Static resx:ResUI.TbSettingsFragmentMaxSplit}" />
+                                <TextBox Grid.Column="1" Width="120" Margin="8,0,0,0" VerticalAlignment="Center"
+                                         Style="{StaticResource DefTextBox}"
+                                         Text="{Binding FragmentMaxSplit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         materialDesign:HintAssist.Hint="0" />
+                                <TextBlock Grid.Column="2" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
+                                           Text="{x:Static resx:ResUI.TbSettingsFragmentMaxSplitTip}" TextWrapping="Wrap" />
+                            </Grid>
+
+                            <Grid Margin="0,4,0,0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+
+                                <TextBlock Grid.Column="0" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
+                                           Text="{x:Static resx:ResUI.TbSettingsFragmentRecordFragment}" />
+                                <CheckBox Grid.Column="1" Margin="8,0,0,0" VerticalAlignment="Center"
+                                          IsChecked="{Binding FragmentRecordFragment, Mode=TwoWay}" />
+                                <TextBlock Grid.Column="2" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
+                                           Text="{x:Static resx:ResUI.TbSettingsFragmentRecordFragmentTip}" TextWrapping="Wrap" />
+                            </Grid>
+
+                            <Grid Margin="0,4,0,0">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+
+                                <TextBlock Grid.Column="0" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
+                                           Text="{x:Static resx:ResUI.TbSettingsFragmentFallbackDelay}" />
+                                <TextBox Grid.Column="1" Width="120" Margin="8,0,0,0" VerticalAlignment="Center"
+                                         Style="{StaticResource DefTextBox}"
+                                         Text="{Binding FragmentFallbackDelay, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         materialDesign:HintAssist.Hint="500ms" />
+                                <TextBlock Grid.Column="2" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
+                                           Text="{x:Static resx:ResUI.TbSettingsFragmentFallbackDelayTip}" TextWrapping="Wrap" />
+                            </Grid>
+                        </StackPanel>
+
                         <TextBlock
-                            Grid.Row="21"
+                            Grid.Row="27"
                             Grid.Column="0"
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"
@@ -375,12 +496,12 @@
                             Text="{x:Static resx:ResUI.TbEnableFinalFragment}" />
                         <ToggleButton
                             x:Name="togenableFinalFragment"
-                            Grid.Row="21"
+                            Grid.Row="27"
                             Grid.Column="1"
                             Margin="{StaticResource Margin8}"
                             HorizontalAlignment="Left" />
                         <TextBlock
-                            Grid.Row="21"
+                            Grid.Row="27"
                             Grid.Column="2"
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"
@@ -389,7 +510,7 @@
                             TextWrapping="Wrap" />
 
                         <TextBlock
-                            Grid.Row="22"
+                            Grid.Row="28"
                             Grid.Column="0"
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"
@@ -397,13 +518,13 @@
                             Text="{x:Static resx:ResUI.TbSettingsBindInterface}" />
                         <TextBox
                             x:Name="txtbindInterface"
-                            Grid.Row="22"
+                            Grid.Row="28"
                             Grid.Column="1"
                             Width="200"
                             Margin="{StaticResource Margin8}"
                             Style="{StaticResource DefTextBox}" />
                         <TextBlock
-                            Grid.Row="22"
+                            Grid.Row="28"
                             Grid.Column="2"
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"
@@ -412,7 +533,7 @@
                             TextWrapping="Wrap" />
 
                         <TextBlock
-                            Grid.Row="23"
+                            Grid.Row="29"
                             Grid.Column="0"
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"
@@ -420,14 +541,14 @@
                             Text="{x:Static resx:ResUI.TbSettingsSendThrough}" />
                         <TextBox
                             x:Name="txtsendThrough"
-                            Grid.Row="23"
+                            Grid.Row="29"
                             Grid.Column="1"
                             Width="200"
                             Margin="{StaticResource Margin8}"
                             materialDesign:HintAssist.Hint="0.0.0.0"
                             Style="{StaticResource DefTextBox}" />
                         <TextBlock
-                            Grid.Row="23"
+                            Grid.Row="29"
                             Grid.Column="2"
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
@@ -9,7 +9,6 @@
     xmlns:reactiveui="http://reactiveui.net"
     xmlns:resx="clr-namespace:ServiceLib.Resx;assembly=ServiceLib"
     xmlns:vms="clr-namespace:ServiceLib.ViewModels;assembly=ServiceLib"
-    xmlns:sys="clr-namespace:System;assembly=mscorlib"
     Title="{x:Static resx:ResUI.menuSetting}"
     Width="1000"
     Height="700"
@@ -18,9 +17,13 @@
     Style="{StaticResource WindowGlobal}"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-    <base:WindowBase.Resources>
-        <BooleanToVisibilityConverter x:Key="BoolToVisConverter" />
-    </base:WindowBase.Resources>
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Popupbox.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
     <DockPanel Margin="{StaticResource Margin8}">
         <StackPanel
             Margin="{StaticResource Margin4}"
@@ -46,15 +49,7 @@
             <TabItem Header="{x:Static resx:ResUI.TbSettingsCore}">
                 <ScrollViewer VerticalScrollBarVisibility="Visible">
                     <Grid Margin="{StaticResource Margin8}">
-<Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
+                        <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
@@ -378,65 +373,102 @@
                             Margin="{StaticResource Margin8}"
                             HorizontalAlignment="Left" />
 
-                        <!-- Fragment Settings (PopupBox - visible when EnableFragment is checked) -->
-                        <StackPanel Grid.Row="21" Grid.Column="0" Grid.ColumnSpan="3" Margin="{StaticResource Margin8}"
-                                    Visibility="{Binding EnableFragment, Converter={StaticResource BoolToVisConverter}}">
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                <materialDesign:PopupBox
-                                    HorizontalAlignment="Left"
-                                    VerticalAlignment="Center"
-                                    StaysOpen="True"
-                                    Style="{StaticResource MaterialDesignToolForegroundPopupBox}">
-                                    <StackPanel Width="400">
-                                        <TextBlock
-                                            Margin="{StaticResource Margin4}"
-                                            VerticalAlignment="Center"
-                                            Style="{StaticResource ToolbarTextBlock}"
-                                            Text="{x:Static resx:ResUI.TbSettingsFragmentPackets}"
-                                            TextWrapping="Wrap" />
-                                        <ComboBox Width="120" Margin="{StaticResource Margin4}" VerticalAlignment="Center"
-                                                  ItemsSource="{Binding FragmentPacketsOptions}"
-                                                  SelectedItem="{Binding FragmentPackets, Mode=TwoWay}" />
+                        <materialDesign:PopupBox
+                            Grid.Row="20"
+                            Grid.Column="2"
+                            HorizontalAlignment="Left"
+                            StaysOpen="True"
+                            Style="{StaticResource MaterialDesignToolForegroundPopupBox}">
+                            <StackPanel Margin="{StaticResource Margin8}">
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="400" />
+                                    </Grid.ColumnDefinitions>
 
-                                        <TextBlock
-                                            Margin="{StaticResource Margin4}"
-                                            VerticalAlignment="Center"
-                                            Style="{StaticResource ToolbarTextBlock}"
-                                            Text="{x:Static resx:ResUI.TbSettingsFragmentLength}"
-                                            TextWrapping="Wrap" />
-                                        <TextBox Width="120" Margin="{StaticResource Margin4}" VerticalAlignment="Center"
-                                                 Style="{StaticResource DefTextBox}"
-                                                 Text="{Binding FragmentLength, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                 materialDesign:HintAssist.Hint="50-100" />
+                                    <TextBlock
+                                        Grid.Row="0"
+                                        Grid.Column="0"
+                                        Margin="{StaticResource Margin8}"
+                                        VerticalAlignment="Center"
+                                        Style="{StaticResource ToolbarTextBlock}"
+                                        Text="{x:Static resx:ResUI.TbSettingsFragmentPackets}"
+                                        TextWrapping="Wrap" />
+                                    <ComboBox
+                                        x:Name="cmbFragmentPackets"
+                                        Grid.Row="0"
+                                        Grid.Column="1"
+                                        Width="200"
+                                        Margin="{StaticResource Margin8}"
+                                        VerticalAlignment="Center" />
 
-                                        <TextBlock
-                                            Margin="{StaticResource Margin4}"
-                                            VerticalAlignment="Center"
-                                            Style="{StaticResource ToolbarTextBlock}"
-                                            Text="{x:Static resx:ResUI.TbSettingsFragmentInterval}"
-                                            TextWrapping="Wrap" />
-                                        <TextBox Width="120" Margin="{StaticResource Margin4}" VerticalAlignment="Center"
-                                                 Style="{StaticResource DefTextBox}"
-                                                 Text="{Binding FragmentInterval, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                 materialDesign:HintAssist.Hint="10-20" />
+                                    <TextBlock
+                                        Grid.Row="1"
+                                        Grid.Column="0"
+                                        Margin="{StaticResource Margin8}"
+                                        VerticalAlignment="Center"
+                                        Style="{StaticResource ToolbarTextBlock}"
+                                        Text="{x:Static resx:ResUI.TbSettingsFragmentLength}"
+                                        TextWrapping="Wrap" />
+                                    <TextBox
+                                        x:Name="txtFragmentLength"
+                                        Grid.Row="1"
+                                        Grid.Column="1"
+                                        Width="200"
+                                        Margin="{StaticResource Margin8}"
+                                        VerticalAlignment="Center"
+                                        materialDesign:HintAssist.Hint="50-100"
+                                        Style="{StaticResource DefTextBox}" />
 
-                                        <TextBlock
-                                            Margin="{StaticResource Margin4}"
-                                            VerticalAlignment="Center"
-                                            Style="{StaticResource ToolbarTextBlock}"
-                                            Text="{x:Static resx:ResUI.TbSettingsFragmentMaxSplit}"
-                                            TextWrapping="Wrap" />
-                                        <TextBox Width="120" Margin="{StaticResource Margin4}" VerticalAlignment="Center"
-                                              Style="{StaticResource DefTextBox}"
-                                              Text="{Binding FragmentMaxSplit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                              materialDesign:HintAssist.Hint="0" />
-                                       </StackPanel>
-                                </materialDesign:PopupBox>
+                                    <TextBlock
+                                        Grid.Row="2"
+                                        Grid.Column="0"
+                                        Margin="{StaticResource Margin8}"
+                                        VerticalAlignment="Center"
+                                        Style="{StaticResource ToolbarTextBlock}"
+                                        Text="{x:Static resx:ResUI.TbSettingsFragmentInterval}"
+                                        TextWrapping="Wrap" />
+                                    <TextBox
+                                        x:Name="txtFragmentInterval"
+                                        Grid.Row="2"
+                                        Grid.Column="1"
+                                        Width="200"
+                                        Margin="{StaticResource Margin8}"
+                                        VerticalAlignment="Center"
+                                        materialDesign:HintAssist.Hint="10-20"
+                                        Style="{StaticResource DefTextBox}" />
+
+                                    <TextBlock
+                                        Grid.Row="3"
+                                        Grid.Column="0"
+                                        Margin="{StaticResource Margin8}"
+                                        VerticalAlignment="Center"
+                                        Style="{StaticResource ToolbarTextBlock}"
+                                        Text="{x:Static resx:ResUI.TbSettingsFragmentMaxSplit}"
+                                        TextWrapping="Wrap" />
+                                    <TextBox
+                                        x:Name="txtFragmentMaxSplit"
+                                        Grid.Row="3"
+                                        Grid.Column="1"
+                                        Width="200"
+                                        Margin="{StaticResource Margin8}"
+                                        VerticalAlignment="Center"
+                                        materialDesign:HintAssist.Hint="0"
+                                        Style="{StaticResource DefTextBox}" />
+                                </Grid>
                             </StackPanel>
-                        </StackPanel>
+                        </materialDesign:PopupBox>
 
                         <TextBlock
-                            Grid.Row="27"
+                            Grid.Row="21"
                             Grid.Column="0"
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"
@@ -444,12 +476,12 @@
                             Text="{x:Static resx:ResUI.TbEnableFinalFragment}" />
                         <ToggleButton
                             x:Name="togenableFinalFragment"
-                            Grid.Row="27"
+                            Grid.Row="21"
                             Grid.Column="1"
                             Margin="{StaticResource Margin8}"
                             HorizontalAlignment="Left" />
                         <TextBlock
-                            Grid.Row="27"
+                            Grid.Row="21"
                             Grid.Column="2"
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"
@@ -458,7 +490,7 @@
                             TextWrapping="Wrap" />
 
                         <TextBlock
-                            Grid.Row="28"
+                            Grid.Row="22"
                             Grid.Column="0"
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"
@@ -466,13 +498,13 @@
                             Text="{x:Static resx:ResUI.TbSettingsBindInterface}" />
                         <TextBox
                             x:Name="txtbindInterface"
-                            Grid.Row="28"
+                            Grid.Row="22"
                             Grid.Column="1"
                             Width="200"
                             Margin="{StaticResource Margin8}"
                             Style="{StaticResource DefTextBox}" />
                         <TextBlock
-                            Grid.Row="28"
+                            Grid.Row="22"
                             Grid.Column="2"
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"
@@ -481,7 +513,7 @@
                             TextWrapping="Wrap" />
 
                         <TextBlock
-                            Grid.Row="29"
+                            Grid.Row="23"
                             Grid.Column="0"
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"
@@ -489,14 +521,14 @@
                             Text="{x:Static resx:ResUI.TbSettingsSendThrough}" />
                         <TextBox
                             x:Name="txtsendThrough"
-                            Grid.Row="29"
+                            Grid.Row="23"
                             Grid.Column="1"
                             Width="200"
                             Margin="{StaticResource Margin8}"
                             materialDesign:HintAssist.Hint="0.0.0.0"
                             Style="{StaticResource DefTextBox}" />
                         <TextBlock
-                            Grid.Row="29"
+                            Grid.Row="23"
                             Grid.Column="2"
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
@@ -391,14 +391,8 @@
                                 <TextBlock Grid.Column="0" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
                                            Text="{x:Static resx:ResUI.TbSettingsFragmentPackets}" />
                                 <ComboBox Grid.Column="1" Width="120" Margin="8,0,0,0" VerticalAlignment="Center"
-                                          SelectedItem="{Binding FragmentPackets, Mode=TwoWay}">
-                                    <ComboBoxItem Content="tlshello" />
-                                    <ComboBoxItem Content="1-1" />
-                                    <ComboBoxItem Content="1-2" />
-                                    <ComboBoxItem Content="1-3" />
-                                    <ComboBoxItem Content="1-4" />
-                                    <ComboBoxItem Content="1-5" />
-                                </ComboBox>
+                                          ItemsSource="{Binding FragmentPacketsOptions}"
+                                          SelectedItem="{Binding FragmentPackets, Mode=TwoWay}" />
                                 <TextBlock Grid.Column="2" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
                                            Text="{x:Static resx:ResUI.TbSettingsFragmentPacketsTip}" TextWrapping="Wrap" />
                             </Grid>

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
@@ -378,107 +378,61 @@
                             Margin="{StaticResource Margin8}"
                             HorizontalAlignment="Left" />
 
-                        <!-- Fragment Settings (visible when EnableFragment is checked) -->
+                        <!-- Fragment Settings (PopupBox - visible when EnableFragment is checked) -->
                         <StackPanel Grid.Row="21" Grid.Column="0" Grid.ColumnSpan="3" Margin="{StaticResource Margin8}"
                                     Visibility="{Binding EnableFragment, Converter={StaticResource BoolToVisConverter}}">
-                            <Grid Margin="0,4,0,0">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                <materialDesign:PopupBox
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    StaysOpen="True"
+                                    Style="{StaticResource MaterialDesignToolForegroundPopupBox}">
+                                    <StackPanel Width="400">
+                                        <TextBlock
+                                            Margin="{StaticResource Margin4}"
+                                            VerticalAlignment="Center"
+                                            Style="{StaticResource ToolbarTextBlock}"
+                                            Text="{x:Static resx:ResUI.TbSettingsFragmentPackets}"
+                                            TextWrapping="Wrap" />
+                                        <ComboBox Width="120" Margin="{StaticResource Margin4}" VerticalAlignment="Center"
+                                                  ItemsSource="{Binding FragmentPacketsOptions}"
+                                                  SelectedItem="{Binding FragmentPackets, Mode=TwoWay}" />
 
-                                <TextBlock Grid.Column="0" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
-                                           Text="{x:Static resx:ResUI.TbSettingsFragmentPackets}" />
-                                <ComboBox Grid.Column="1" Width="120" Margin="8,0,0,0" VerticalAlignment="Center"
-                                          ItemsSource="{Binding FragmentPacketsOptions}"
-                                          SelectedItem="{Binding FragmentPackets, Mode=TwoWay}" />
-                                <TextBlock Grid.Column="2" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
-                                           Text="{x:Static resx:ResUI.TbSettingsFragmentPacketsTip}" TextWrapping="Wrap" />
-                            </Grid>
+                                        <TextBlock
+                                            Margin="{StaticResource Margin4}"
+                                            VerticalAlignment="Center"
+                                            Style="{StaticResource ToolbarTextBlock}"
+                                            Text="{x:Static resx:ResUI.TbSettingsFragmentLength}"
+                                            TextWrapping="Wrap" />
+                                        <TextBox Width="120" Margin="{StaticResource Margin4}" VerticalAlignment="Center"
+                                                 Style="{StaticResource DefTextBox}"
+                                                 Text="{Binding FragmentLength, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                 materialDesign:HintAssist.Hint="50-100" />
 
-                            <Grid Margin="0,4,0,0">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
+                                        <TextBlock
+                                            Margin="{StaticResource Margin4}"
+                                            VerticalAlignment="Center"
+                                            Style="{StaticResource ToolbarTextBlock}"
+                                            Text="{x:Static resx:ResUI.TbSettingsFragmentInterval}"
+                                            TextWrapping="Wrap" />
+                                        <TextBox Width="120" Margin="{StaticResource Margin4}" VerticalAlignment="Center"
+                                                 Style="{StaticResource DefTextBox}"
+                                                 Text="{Binding FragmentInterval, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                 materialDesign:HintAssist.Hint="10-20" />
 
-                                <TextBlock Grid.Column="0" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
-                                           Text="{x:Static resx:ResUI.TbSettingsFragmentLength}" />
-                                <TextBox Grid.Column="1" Width="120" Margin="8,0,0,0" VerticalAlignment="Center"
-                                         Style="{StaticResource DefTextBox}"
-                                         Text="{Binding FragmentLength, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                         materialDesign:HintAssist.Hint="50-100" />
-                                <TextBlock Grid.Column="2" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
-                                           Text="{x:Static resx:ResUI.TbSettingsFragmentLengthTip}" TextWrapping="Wrap" />
-                            </Grid>
-
-                            <Grid Margin="0,4,0,0">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-
-                                <TextBlock Grid.Column="0" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
-                                           Text="{x:Static resx:ResUI.TbSettingsFragmentInterval}" />
-                                <TextBox Grid.Column="1" Width="120" Margin="8,0,0,0" VerticalAlignment="Center"
-                                         Style="{StaticResource DefTextBox}"
-                                         Text="{Binding FragmentInterval, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                         materialDesign:HintAssist.Hint="10-20" />
-                                <TextBlock Grid.Column="2" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
-                                           Text="{x:Static resx:ResUI.TbSettingsFragmentIntervalTip}" TextWrapping="Wrap" />
-                            </Grid>
-
-                            <Grid Margin="0,4,0,0">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-
-                                <TextBlock Grid.Column="0" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
-                                           Text="{x:Static resx:ResUI.TbSettingsFragmentMaxSplit}" />
-                                <TextBox Grid.Column="1" Width="120" Margin="8,0,0,0" VerticalAlignment="Center"
-                                         Style="{StaticResource DefTextBox}"
-                                         Text="{Binding FragmentMaxSplit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                         materialDesign:HintAssist.Hint="0" />
-                                <TextBlock Grid.Column="2" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
-                                           Text="{x:Static resx:ResUI.TbSettingsFragmentMaxSplitTip}" TextWrapping="Wrap" />
-                            </Grid>
-
-                            <Grid Margin="0,4,0,0">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-
-                                <TextBlock Grid.Column="0" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
-                                           Text="{x:Static resx:ResUI.TbSettingsFragmentRecordFragment}" />
-                                <CheckBox Grid.Column="1" Margin="8,0,0,0" VerticalAlignment="Center"
-                                          IsChecked="{Binding FragmentRecordFragment, Mode=TwoWay}" />
-                                <TextBlock Grid.Column="2" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
-                                           Text="{x:Static resx:ResUI.TbSettingsFragmentRecordFragmentTip}" TextWrapping="Wrap" />
-                            </Grid>
-
-                            <Grid Margin="0,4,0,0">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-
-                                <TextBlock Grid.Column="0" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
-                                           Text="{x:Static resx:ResUI.TbSettingsFragmentFallbackDelay}" />
-                                <TextBox Grid.Column="1" Width="120" Margin="8,0,0,0" VerticalAlignment="Center"
-                                         Style="{StaticResource DefTextBox}"
-                                         Text="{Binding FragmentFallbackDelay, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                         materialDesign:HintAssist.Hint="500ms" />
-                                <TextBlock Grid.Column="2" VerticalAlignment="Center" Style="{StaticResource ToolbarTextBlock}"
-                                           Text="{x:Static resx:ResUI.TbSettingsFragmentFallbackDelayTip}" TextWrapping="Wrap" />
-                            </Grid>
+                                        <TextBlock
+                                            Margin="{StaticResource Margin4}"
+                                            VerticalAlignment="Center"
+                                            Style="{StaticResource ToolbarTextBlock}"
+                                            Text="{x:Static resx:ResUI.TbSettingsFragmentMaxSplit}"
+                                            TextWrapping="Wrap" />
+                                        <TextBox Width="120" Margin="{StaticResource Margin4}" VerticalAlignment="Center"
+                                              Style="{StaticResource DefTextBox}"
+                                              Text="{Binding FragmentMaxSplit, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                              materialDesign:HintAssist.Hint="0" />
+                                       </StackPanel>
+                                </materialDesign:PopupBox>
+                            </StackPanel>
                         </StackPanel>
 
                         <TextBlock

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
@@ -32,6 +32,7 @@ public partial class OptionSettingWindow
         cmbMtu.ItemsSource = Global.TunMtus;
         cmbStack.ItemsSource = Global.TunStacks;
         cmbIcmpRoutingPolicy.ItemsSource = Global.TunIcmpRoutingPolicies;
+        cmbFragmentPackets.ItemsSource = Global.FragmentPacketsOptions;
 
         cmbCoreType1.ItemsSource = Global.CoreTypes;
         cmbCoreType2.ItemsSource = Global.CoreTypes;
@@ -80,6 +81,10 @@ public partial class OptionSettingWindow
             this.Bind(ViewModel, vm => vm.HyDownMbps, v => v.txtDownMbps.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.EnableFragment, v => v.togenableFragment.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.EnableFinalFragment, v => v.togenableFinalFragment.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.FragmentPackets, v => v.cmbFragmentPackets.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.FragmentLength, v => v.txtFragmentLength.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.FragmentInterval, v => v.txtFragmentInterval.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.FragmentMaxSplit, v => v.txtFragmentMaxSplit.Text).DisposeWith(disposables);
 
             //this.Bind(ViewModel, vm => vm.Kcpmtu, v => v.txtKcpmtu.Text).DisposeWith(disposables);
             //this.Bind(ViewModel, vm => vm.Kcptti, v => v.txtKcptti.Text).DisposeWith(disposables);


### PR DESCRIPTION
added full ui + core logic for packet fragmentation options across all cores:

before there was only EnableFragment switch but it basically did nothing real. now when enabled it actually exposes real controls in ui + backend wiring

new options when enabled:
* Packets: dropdown (tlshello, 1-1 … 1-5)
* Length: range string like 50-100 (must parse, first value not bigger than second)
* Interval: range like 10-20 or ms range, also validated same way
* MaxSplit: int 0-10000 (only xray-core, 0 means unlimited)
* RecordFragment: toggle (only sing-box)
* FallbackDelay: text like 500ms (only sing-box)

core changes:
* Fragment4RayItem model updated + defaults adjusted
* serialization updated so new fields persist correctly
* BuildFragmentsMasks now applies maxSplit for xray-core only
* FillOutboundTls extended for sing-box to inject record_fragment + fragment_fallback_delay
* small helper added: Utils.TryParseRange for parsing range strings safely

localization:
* strings added for en / zh-Hans / zh-Hant
* translation done by translator tool, so wording may not be perfect and probably needs manual review later

overall result is that fragment feature is no longer just a toggle, it actually configures real fragmentation behavior per-core instead of being ignored
