### PR TITLE
Fix process rule

### DIFF
--- a/v2rayN/ServiceLib/Common/Utils.cs
+++ b/v2rayN/ServiceLib/Common/Utils.cs
@@ -324,6 +324,29 @@ public class Utils
                     .ReplaceLineBreaks(",");
     }
 
+    public static string ParseProcess(string text)
+    {
+        if (text.IsNullOrEmpty())
+        {
+            return string.Empty;
+        }
+        if (text.StartsWith('"'))
+        {
+            text = text[1..];
+        }
+        if (text.EndsWith('"'))
+        {
+            text = text[..^1];
+        }
+        return List2String(text.Replace("，", ",")
+            .Replace("\\", "/")
+            .ReplaceLineBreaks(",")
+            .Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(x => x.TrimEx())
+            .Where(x => x.IsNotEmpty())
+            .ToList());
+    }
+
     public static List<string> GetEnumNames<TEnum>() where TEnum : Enum
     {
         return Enum.GetValues(typeof(TEnum))

--- a/v2rayN/ServiceLib/ViewModels/RoutingRuleDetailsViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/RoutingRuleDetailsViewModel.cs
@@ -57,7 +57,7 @@ public class RoutingRuleDetailsViewModel : MyReactiveObject
     {
         Domain = Utils.Convert2Comma(Domain);
         IP = Utils.Convert2Comma(IP);
-        Process = Utils.Convert2Comma(Process);
+        Process = Utils.ParseProcess(Process);
 
         if (AutoSort)
         {


### PR DESCRIPTION
fix #9612
修复路径中包含空格时的错误处理
添加 "添加可执行文件" 按钮，弹出系统对话框，选择结果将自动填入文本框
添加 avalonia OpenFileDialog filters