### PR TITLE
Fix DNS deadlock for standalone external cores under TUN

### DIFF
--- a/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
+++ b/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
@@ -561,35 +561,80 @@ public class CoreConfigSingboxServiceTests
     }
 
     [Fact]
-    public void GenerateClientConfigContent_Hysteria2Realm_ShouldEmitHttpsServerUrl()
+    public void GenerateClientConfigContent_TunEnabled_StandaloneCoreDnsNotHijacked()
     {
-        var shareLink =
-            "hysteria2+realm://public@realm.hy2.io/my-realm-id?auth=uuid&stun=turn.cloudflare.com%3A3478&sni=cloudflare.com&pinSHA256=xxx#Realm-Test";
-        var node = Hysteria2Fmt.ResolveRealm(shareLink, out _);
-        node.Should().NotBeNull();
-        node!.CoreType = ECoreType.sing_box;
-
         var config = CoreConfigTestFactory.CreateConfig(ECoreType.sing_box);
-        config.CoreTypeItem =
-        [
-            new CoreTypeItem { ConfigType = EConfigType.Hysteria2, CoreType = ECoreType.sing_box }
-        ];
         CoreConfigTestFactory.BindAppManagerConfig(config);
-        var context = CoreConfigTestFactory.CreateContext(config, node, ECoreType.sing_box);
+
+        var node = CoreConfigTestFactory.CreateSocksNode(ECoreType.sing_box, "n-main", "main");
+        var context = CoreConfigTestFactory.CreateContext(config, node, ECoreType.sing_box) with
+        {
+            IsTunEnabled = true,
+        };
 
         var result = new CoreConfigSingboxService(context).GenerateClientConfigContent();
-
         result.Success.Should().BeTrue($"ret msg: {result.Msg}");
         var cfg = JsonUtils.Deserialize<SingboxConfig>(result.Data!.ToString())!;
-        var proxy = cfg.outbounds.First(o => o.tag == Global.ProxyTag);
 
-        proxy.type.Should().Be("hysteria2");
-        proxy.realm.Should().NotBeNull();
-        proxy.realm!.server_url.Should().StartWith("https://");
-        proxy.realm.server_url.Should().Contain("realm.hy2.io");
-        proxy.realm.token.Should().Be("public");
-        proxy.realm.realm_id.Should().Be("my-realm-id");
-        proxy.realm.stun_servers.Should().Contain("turn.cloudflare.com:3478");
-        proxy.server.Should().BeNull();
+        var hijack = cfg.route.rules.FirstOrDefault(r =>
+            r.action == "hijack-dns" && r.port != null && r.port.Contains(53) && r.process_name != null);
+        hijack.Should().NotBeNull("TUN mode must emit a process-scoped hijack-dns rule");
+
+        // Standalone external cores must NOT have their DNS hijacked (would loop via proxy detour).
+        // Pull each core's actual CoreExes so platform-suffixed variants
+        // (hysteria-windows-amd64, brook_windows_amd64, overtls-bin, ...) are covered, not just the base name.
+        foreach (var coreType in Global.StandaloneExternalCores)
+        {
+            var coreExes = CoreInfoManager.Instance.GetCoreInfo(coreType)?.CoreExes ?? [];
+            coreExes.Should().NotBeEmpty($"{coreType} must have at least one exe registered");
+            foreach (var exe in coreExes)
+            {
+                hijack!.process_name.Should().NotContain(Utils.GetExeName(exe),
+                    $"{coreType}/{exe} DNS must go direct, not be hijacked into sing-box DNS under TUN");
+            }
+        }
+
+        // The running core (sing-box) must also remain excluded (lock in existing behavior).
+        hijack!.process_name.Should().NotContain(Utils.GetExeName("sing-box"));
+        hijack.process_name.Should().NotContain(Utils.GetExeName("sing-box-client"));
+
+        // A non-standalone, non-running core (e.g. mihomo) should still be hijacked.
+        hijack.process_name.Should().Contain(Utils.GetExeName("mihomo"));
+        // Cores that use internal DNS clients (Xray, v2fly) must also remain hijacked,
+        // so any fallback OS resolver attempt is still caught.
+        hijack.process_name.Should().Contain(Utils.GetExeName("xray"));
+    }
+
+    [Fact]
+    public void GenerateClientConfigContent_TunEnabled_StandaloneCoreStillDirect()
+    {
+        var config = CoreConfigTestFactory.CreateConfig(ECoreType.sing_box);
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+
+        var node = CoreConfigTestFactory.CreateSocksNode(ECoreType.sing_box, "n-main", "main");
+        var context = CoreConfigTestFactory.CreateContext(config, node, ECoreType.sing_box) with
+        {
+            IsTunEnabled = true,
+        };
+
+        var result = new CoreConfigSingboxService(context).GenerateClientConfigContent();
+        result.Success.Should().BeTrue($"ret msg: {result.Msg}");
+        var cfg = JsonUtils.Deserialize<SingboxConfig>(result.Data!.ToString())!;
+
+        var direct = cfg.route.rules.FirstOrDefault(r =>
+            r.outbound == Global.DirectTag && r.process_name != null);
+        direct.Should().NotBeNull();
+
+        // The fix's load-bearing post-condition: every exe removed from DNS hijack must
+        // remain on the direct list, otherwise the helper's non-DNS traffic would also stop working.
+        foreach (var coreType in Global.StandaloneExternalCores)
+        {
+            var coreExes = CoreInfoManager.Instance.GetCoreInfo(coreType)?.CoreExes ?? [];
+            foreach (var exe in coreExes)
+            {
+                direct!.process_name.Should().Contain(Utils.GetExeName(exe),
+                    $"{coreType}/{exe} non-DNS traffic must still be routed direct");
+            }
+        }
     }
 }

--- a/v2rayN/ServiceLib/Global.cs
+++ b/v2rayN/ServiceLib/Global.cs
@@ -647,6 +647,25 @@ public class Global
         { ECoreType.v2rayN, "2dust/v2rayN" },
     };
 
+    // Cores that run as a SEPARATE process while sing-box owns the TUN pre-service,
+    // reached via a loopback SOCKS pre-socks port. Their own DNS must NOT be hijacked into
+    // sing-box's DNS module (whose remote-DNS server detours through the proxy outbound,
+    // i.e. back into this very helper process), otherwise DNS resolution deadlocks under TUN.
+    // Xray/v2fly/mihomo are intentionally omitted: they ship internal DNS clients and do not
+    // depend on the OS resolver for proxy lookups, so the loop never forms for them.
+    public static readonly HashSet<ECoreType> StandaloneExternalCores =
+    [
+        ECoreType.naiveproxy,
+        ECoreType.tuic,
+        ECoreType.juicity,
+        ECoreType.hysteria,
+        ECoreType.hysteria2,
+        ECoreType.brook,
+        ECoreType.overtls,
+        ECoreType.shadowquic,
+        ECoreType.mieru,
+    ];
+
     public static readonly List<string> OtherGeoUrls =
     [
         @"https://raw.githubusercontent.com/Loyalsoldier/geoip/release/geoip-only-cn-private.dat",

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
@@ -272,7 +272,12 @@ public partial class CoreConfigSingboxService
 
             foreach (var baseExeName in coreConfig.CoreExes)
             {
-                if (coreConfig.CoreType != ECoreType.sing_box)
+                // Exclude the running core (sing-box) AND any standalone external core
+                // (naive/tuic/juicity/hysteria/...) from DNS hijacking. Their DNS must go
+                // direct; hijacking it routes remote DNS back through the proxy outbound,
+                // which loops into the same helper process and deadlocks under TUN.
+                if (coreConfig.CoreType != ECoreType.sing_box
+                    && !Global.StandaloneExternalCores.Contains(coreConfig.CoreType))
                 {
                     dnsExeSet.Add(Utils.GetExeName(baseExeName));
                 }

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayRoutingService.cs
@@ -248,7 +248,13 @@ public partial class CoreConfigV2rayService
 
             foreach (var baseExeName in coreConfig.CoreExes)
             {
-                if (coreConfig.CoreType != ECoreType.Xray)
+                // Mirror SingboxRoutingService.BuildRoutingDirectExe: exclude the running core (Xray)
+                // AND any standalone external core from DNS hijacking, to avoid the helper-loops-on-itself
+                // deadlock when DNS is detoured through the proxy outbound under TUN.
+                // Note: GetPreSocksItem currently never produces an Xray-as-TUN-owner config, so this
+                // branch is unreachable today; the guard is kept symmetric with the sing-box service.
+                if (coreConfig.CoreType != ECoreType.Xray
+                    && !Global.StandaloneExternalCores.Contains(coreConfig.CoreType))
                 {
                     dnsExeSet.Add(Utils.GetExeName(baseExeName));
                 }


### PR DESCRIPTION
## Summary

When the main proxy node runs on a standalone external core (naiveproxy, tuic, juicity, hysteria, hysteria2, brook, overtls, shadowquic, mieru) and sing-box runs as a TUN pre-service in front of it, DNS resolution stalls while TUN is enabled.

Root cause: `SingboxRoutingService.BuildRoutingDirectExe` adds every non-sing-box core executable to the DNS-hijack list.
The helper's port-53 traffic is hijacked into sing-box's DNS module, whose remote-DNS server detours through the `proxy` outbound — which is SOCKS to `127.0.0.1:PreSocksPort`, i.e. back into the same helper process.
The helper is still waiting on its own lookup, so the query never completes.

Fix: exclude standalone external cores from `lstDnsExe` (they stay on `lstDirectExe`).
After the fix, the helper's port-53 packet falls through `hijack-dns` to the next rule (`outbound = direct`) and is forwarded as an ordinary UDP/53 datagram via the direct outbound on the physical interface.
The cycle is broken at the routing layer.

Cores using internal DNS clients (Xray, v2fly, mihomo) are intentionally not added to the standalone set, since they do not depend on the OS resolver for proxy lookups.

## Changes

- `ServiceLib/Global.cs`: new `StandaloneExternalCores` set listing the affected cores.
- `ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs`: skip these cores when populating `dnsExeSet` (primary fix).
- `ServiceLib/Services/CoreConfig/V2ray/V2rayRoutingService.cs`: symmetric guard; the path is currently unreachable but kept consistent with the sing-box service.
- `ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs`: two new facts that iterate every standalone core's actual `CoreExes` (covering platform-suffixed variants like `hysteria-windows-amd64`, `brook_windows_amd64`, `overtls-bin`) and assert hijack-NOT-contain plus direct-DOES-contain.