### PR TITLE
Fix TCPing tests not stopping when ESC is pressed

### DIFF
--- a/v2rayN/ServiceLib/Services/SpeedtestService.cs
+++ b/v2rayN/ServiceLib/Services/SpeedtestService.cs
@@ -46,7 +46,7 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
         switch (actionType)
         {
             case ESpeedActionType.Tcping:
-                await RunTcpingAsync(lstSelected);
+                await RunTcpingAsync(lstSelected, exitLoopKey);
                 break;
 
             case ESpeedActionType.Realping:
@@ -135,16 +135,28 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
         return lstSelected;
     }
 
-    private async Task RunTcpingAsync(List<ServerTestItem> selecteds)
+    private async Task RunTcpingAsync(List<ServerTestItem> selecteds, string exitLoopKey)
     {
         var pageSize = Math.Min(selecteds.Count, _speedTestPageSize);
         var lstBatch = GetTestBatchItem(selecteds, pageSize);
 
         foreach (var lst in lstBatch)
         {
+            if (ShouldStopTest(exitLoopKey))
+            {
+                await UpdateFunc("", ResUI.SpeedtestingSkip);
+                return;
+            }
+
             List<Task> tasks = [];
+
             foreach (var it in lst)
             {
+                if (ShouldStopTest(exitLoopKey))
+                {
+                    return;
+                }
+
                 tasks.Add(Task.Run(async () =>
                 {
                     try
@@ -160,7 +172,14 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
                     }
                 }));
             }
+
             await Task.WhenAll(tasks);
+
+            if (ShouldStopTest(exitLoopKey))
+            {
+                return;
+            }
+
             await Task.Delay(_delayInterval);
         }
     }


### PR DESCRIPTION
## Summary

TCPing tests did not respect the existing ESC cancellation mechanism used by Real Ping, UDP Test, and Speed Test operations.

This change adds cancellation checks to the TCPing test loop so that pressing ESC stops scheduling and processing remaining TCPing tasks, making its behavior consistent with other test types.

## Changes

- Pass `exitLoopKey` to `RunTcpingAsync`
- Add `ShouldStopTest()` checks during TCPing batch processing
- Stop processing remaining batches when ESC is pressed

## Notes

This change prevents new TCPing tasks from being started after cancellation is requested.

It does not interrupt TCP connections that are already in progress. Existing `ConnectAsync()` operations will still complete or timeout normally.

## Related

This PR is a continuation of [#9392](https://github.com/2dust/v2rayN/pull/9392#issuecomment-4571295098).

While reviewing the previous changes, I noticed that TCPing did not participate in the existing ESC cancellation flow. This patch adds the missing cancellation checks so TCPing behaves consistently with Real Ping, UDP Test, and Speed Test. 