### PR TITLE
[codex] Fix shell script execute permission

### DIFF
--- a/v2rayN/ServiceLib.Tests/Common/FileUtilsTests.cs
+++ b/v2rayN/ServiceLib.Tests/Common/FileUtilsTests.cs
@@ -1,0 +1,39 @@
+using AwesomeAssertions;
+using Xunit;
+
+namespace ServiceLib.Tests.Common;
+
+public class FileUtilsTests
+{
+    [Fact]
+    public async Task CreateLinuxShellFile_ShouldMakeExistingFileExecutable_WhenOverwriteIsFalse()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        var fileName = $"test-shell-{Guid.NewGuid():N}.sh";
+        var filePath = Utils.GetBinConfigPath(fileName);
+
+        try
+        {
+            File.WriteAllText(filePath, "old content");
+            File.SetUnixFileMode(filePath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+            var result = await FileUtils.CreateLinuxShellFile(fileName, "new content", false);
+
+            result.Should().Be(filePath);
+            File.ReadAllText(filePath).Should().Be("old content");
+
+            var mode = File.GetUnixFileMode(filePath);
+            mode.Should().HaveFlag(UnixFileMode.UserExecute);
+            mode.Should().HaveFlag(UnixFileMode.GroupExecute);
+            mode.Should().HaveFlag(UnixFileMode.OtherExecute);
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
+    }
+}

--- a/v2rayN/ServiceLib/Common/FileUtils.cs
+++ b/v2rayN/ServiceLib/Common/FileUtils.cs
@@ -241,6 +241,7 @@ public static class FileUtils
         // Check if the file already exists and if we should overwrite it
         if (!overwrite && File.Exists(shFilePath))
         {
+            await Utils.SetLinuxChmod(shFilePath);
             return shFilePath;
         }
 


### PR DESCRIPTION
## Summary

- Ensure generated shell files are made executable even when the file already exists and `overwrite` is false.
- Add a regression test for an existing shell file that lost execute permission.

## Root cause

`CreateLinuxShellFile` returned an existing shell file without re-applying executable permissions. If `binConfigs/proxy_set_osx_sh.sh` already existed with mode `0644`, macOS system proxy updates could fail before the script runs with `Permission denied`, while the UI still reflects the configured proxy mode.

## Validation

- `git diff --check`
- `dotnet test ./ServiceLib.Tests`
