### PR TITLE
启动 TUN pre-service 前确保 SOCKS 依赖就绪避免连接实际不可用

### DIFF
--- a/v2rayN/ServiceLib/Common/Utils.cs
+++ b/v2rayN/ServiceLib/Common/Utils.cs
@@ -809,6 +809,109 @@ public class Utils
             .Any(ni => ni.Name.Equals(inInterfaceName, StringComparison.OrdinalIgnoreCase));
     }
 
+    public static bool IsLoopbackAddress(string? address)
+    {
+        if (address.IsNullOrEmpty())
+        {
+            return false;
+        }
+
+        return IPAddress.TryParse(address, out var ipAddress)
+            ? IPAddress.IsLoopback(ipAddress)
+            : address.Equals(Global.Loopback, StringComparison.OrdinalIgnoreCase)
+              || address.Equals("localhost", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static string GetPreferredRealNetworkInterface(string? configuredInterface)
+    {
+        var interfaceName = configuredInterface?.TrimEx();
+        if (!interfaceName.IsNullOrEmpty() && IsUsableRealNetworkInterface(interfaceName))
+        {
+            return interfaceName;
+        }
+
+        return NetworkInterface.GetAllNetworkInterfaces()
+            .Where(IsUsableRealNetworkInterface)
+            .OrderByDescending(GetRealNetworkInterfacePriority)
+            .ThenByDescending(ni => ni.Speed)
+            .Select(ni => ni.Name)
+            .FirstOrDefault() ?? string.Empty;
+    }
+
+    public static bool IsUsableRealNetworkInterface(string interfaceName)
+    {
+        if (interfaceName.IsNullOrEmpty())
+        {
+            return false;
+        }
+
+        return NetworkInterface.GetAllNetworkInterfaces()
+            .Any(ni => ni.Name.Equals(interfaceName, StringComparison.OrdinalIgnoreCase)
+                       && IsUsableRealNetworkInterface(ni));
+    }
+
+    private static bool IsUsableRealNetworkInterface(NetworkInterface networkInterface)
+    {
+        if (networkInterface.OperationalStatus != OperationalStatus.Up
+            || networkInterface.NetworkInterfaceType is NetworkInterfaceType.Loopback or NetworkInterfaceType.Tunnel)
+        {
+            return false;
+        }
+
+        var name = networkInterface.Name ?? string.Empty;
+        var description = networkInterface.Description ?? string.Empty;
+        if (IsVirtualOrTunInterfaceName(name) || IsVirtualOrTunInterfaceName(description))
+        {
+            return false;
+        }
+
+        var ipProperties = networkInterface.GetIPProperties();
+        return ipProperties.GatewayAddresses.Any(g => IsUsableGatewayAddress(g.Address))
+               && ipProperties.UnicastAddresses.Any(ua => IsUsableUnicastAddress(ua.Address));
+    }
+
+    private static bool IsUsableGatewayAddress(IPAddress address)
+    {
+        return address.AddressFamily == AddressFamily.InterNetwork
+               && !address.Equals(IPAddress.Any)
+               && !IPAddress.IsLoopback(address);
+    }
+
+    private static bool IsUsableUnicastAddress(IPAddress address)
+    {
+        return address.AddressFamily == AddressFamily.InterNetwork
+               && !address.Equals(IPAddress.Any)
+               && !IPAddress.IsLoopback(address);
+    }
+
+    private static int GetRealNetworkInterfacePriority(NetworkInterface networkInterface)
+    {
+        return networkInterface.NetworkInterfaceType switch
+        {
+            NetworkInterfaceType.Wireless80211 => 3,
+            NetworkInterfaceType.Ethernet => 2,
+            NetworkInterfaceType.GigabitEthernet => 2,
+            NetworkInterfaceType.FastEthernetFx => 2,
+            NetworkInterfaceType.FastEthernetT => 2,
+            NetworkInterfaceType.Ppp => 1,
+            _ => 0,
+        };
+    }
+
+    private static bool IsVirtualOrTunInterfaceName(string name)
+    {
+        return name.Contains("singbox_tun", StringComparison.OrdinalIgnoreCase)
+               || name.Contains("xray_tun", StringComparison.OrdinalIgnoreCase)
+               || name.Contains("wintun", StringComparison.OrdinalIgnoreCase)
+               || name.Contains("wireguard", StringComparison.OrdinalIgnoreCase)
+               || name.Contains("tap", StringComparison.OrdinalIgnoreCase)
+               || name.Contains("tun", StringComparison.OrdinalIgnoreCase)
+               || name.Contains("vethernet", StringComparison.OrdinalIgnoreCase)
+               || name.Contains("virtualbox", StringComparison.OrdinalIgnoreCase)
+               || name.Contains("vmware", StringComparison.OrdinalIgnoreCase)
+               || name.Contains("hyper-v", StringComparison.OrdinalIgnoreCase);
+    }
+
     #endregion Speed Test
 
     #region Miscellaneous

--- a/v2rayN/ServiceLib/Common/Utils.cs
+++ b/v2rayN/ServiceLib/Common/Utils.cs
@@ -822,7 +822,7 @@ public class Utils
               || address.Equals("localhost", StringComparison.OrdinalIgnoreCase);
     }
 
-    public static string GetPreferredRealNetworkInterface(string? configuredInterface)
+    public static string GetPreferredRealNetworkInterface(string? configuredInterface, string? destinationAddress = null)
     {
         var interfaceName = configuredInterface?.TrimEx();
         if (!interfaceName.IsNullOrEmpty() && IsUsableRealNetworkInterface(interfaceName))
@@ -830,10 +830,22 @@ public class Utils
             return interfaceName;
         }
 
-        return NetworkInterface.GetAllNetworkInterfaces()
-            .Where(IsUsableRealNetworkInterface)
-            .OrderByDescending(GetRealNetworkInterfacePriority)
-            .ThenByDescending(ni => ni.Speed)
+        // 旧版 TUN 保护需要让主 Xray 连接代理服务器时避开 TUN 回灌；这里按 sing-box 的默认接口思路取真实出口。
+        // Legacy TUN protect needs main Xray's own proxy-server connection to bypass TUN capture; mirror sing-box's default-interface selection idea.
+        interfaceName = GetLocalAddressMatchedRealNetworkInterface(destinationAddress);
+        if (!interfaceName.IsNullOrEmpty())
+        {
+            return interfaceName;
+        }
+
+        interfaceName = GetWindowsDefaultRealNetworkInterface();
+        if (!interfaceName.IsNullOrEmpty())
+        {
+            return interfaceName;
+        }
+
+        return GetUsableRealNetworkInterfaces()
+            .OrderByDescending(ni => ni.Speed)
             .Select(ni => ni.Name)
             .FirstOrDefault() ?? string.Empty;
     }
@@ -845,9 +857,117 @@ public class Utils
             return false;
         }
 
+        return GetUsableRealNetworkInterfaces()
+            .Any(ni => ni.Name.Equals(interfaceName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string GetLocalAddressMatchedRealNetworkInterface(string? destinationAddress)
+    {
+        if (!IPAddress.TryParse(destinationAddress, out var address)
+            || address.AddressFamily != AddressFamily.InterNetwork)
+        {
+            return string.Empty;
+        }
+
+        var interfaces = GetUsableRealNetworkInterfaces();
+
+        foreach (var networkInterface in interfaces)
+        {
+            if (GetUsableIPv4UnicastAddresses(networkInterface)
+                .Any(unicast => unicast.Address.Equals(address)))
+            {
+                return networkInterface.Name;
+            }
+        }
+
+        foreach (var networkInterface in interfaces)
+        {
+            if (GetUsableIPv4UnicastAddresses(networkInterface)
+                .Any(unicast => IsInIPv4Prefix(address, unicast.Address, unicast.PrefixLength)))
+            {
+                return networkInterface.Name;
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static string GetWindowsDefaultRealNetworkInterface()
+    {
+        var interfacesByIndex = GetUsableRealNetworkInterfaces()
+            .Select(ni => new
+            {
+                Interface = ni,
+                Index = TryGetIPv4InterfaceIndex(ni, out var index) ? (uint?)index : null,
+            })
+            .Where(item => item.Index.HasValue)
+            .GroupBy(item => item.Index!.Value)
+            .ToDictionary(group => group.Key, group => group.First().Interface);
+
+        foreach (var candidate in WindowsNetworkUtils.GetDefaultIPv4RouteCandidates())
+        {
+            if (interfacesByIndex.TryGetValue(candidate.InterfaceIndex, out var networkInterface))
+            {
+                return networkInterface.Name;
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static List<NetworkInterface> GetUsableRealNetworkInterfaces()
+    {
         return NetworkInterface.GetAllNetworkInterfaces()
-            .Any(ni => ni.Name.Equals(interfaceName, StringComparison.OrdinalIgnoreCase)
-                       && IsUsableRealNetworkInterface(ni));
+            .Where(IsUsableRealNetworkInterface)
+            .ToList();
+    }
+
+    private static IEnumerable<UnicastIPAddressInformation> GetUsableIPv4UnicastAddresses(NetworkInterface networkInterface)
+    {
+        return networkInterface.GetIPProperties().UnicastAddresses
+            .Where(ua => IsUsableUnicastAddress(ua.Address));
+    }
+
+    private static bool TryGetIPv4InterfaceIndex(NetworkInterface networkInterface, out uint interfaceIndex)
+    {
+        interfaceIndex = 0;
+        try
+        {
+            var properties = networkInterface.GetIPProperties().GetIPv4Properties();
+            if (properties == null)
+            {
+                return false;
+            }
+
+            interfaceIndex = (uint)properties.Index;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool IsInIPv4Prefix(IPAddress address, IPAddress prefixAddress, int prefixLength)
+    {
+        if (prefixLength is <= 0 or > 32)
+        {
+            return false;
+        }
+
+        var addressValue = ToUInt32BigEndian(address);
+        var prefixValue = ToUInt32BigEndian(prefixAddress);
+        var mask = uint.MaxValue << (32 - prefixLength);
+        return (addressValue & mask) == (prefixValue & mask);
+    }
+
+    private static uint ToUInt32BigEndian(IPAddress address)
+    {
+        var bytes = address.GetAddressBytes();
+        return ((uint)bytes[0] << 24)
+               | ((uint)bytes[1] << 16)
+               | ((uint)bytes[2] << 8)
+               | bytes[3];
     }
 
     private static bool IsUsableRealNetworkInterface(NetworkInterface networkInterface)
@@ -882,20 +1002,6 @@ public class Utils
         return address.AddressFamily == AddressFamily.InterNetwork
                && !address.Equals(IPAddress.Any)
                && !IPAddress.IsLoopback(address);
-    }
-
-    private static int GetRealNetworkInterfacePriority(NetworkInterface networkInterface)
-    {
-        return networkInterface.NetworkInterfaceType switch
-        {
-            NetworkInterfaceType.Wireless80211 => 3,
-            NetworkInterfaceType.Ethernet => 2,
-            NetworkInterfaceType.GigabitEthernet => 2,
-            NetworkInterfaceType.FastEthernetFx => 2,
-            NetworkInterfaceType.FastEthernetT => 2,
-            NetworkInterfaceType.Ppp => 1,
-            _ => 0,
-        };
     }
 
     private static bool IsVirtualOrTunInterfaceName(string name)

--- a/v2rayN/ServiceLib/Common/WindowsNetworkUtils.cs
+++ b/v2rayN/ServiceLib/Common/WindowsNetworkUtils.cs
@@ -1,0 +1,185 @@
+namespace ServiceLib.Common;
+
+// Windows 默认出口读取集中在这里，避免旧版 TUN 保护的业务代码直接操作 Win32 路由结构。
+// Keep Windows default-route interop here so legacy TUN protect logic does not handle Win32 route structs directly.
+internal static class WindowsNetworkUtils
+{
+    private const string _tag = "WindowsNetworkUtils";
+    private const ushort AF_INET = 2;
+
+    public static IReadOnlyList<DefaultRouteCandidate> GetDefaultIPv4RouteCandidates()
+    {
+        var candidates = new List<DefaultRouteCandidate>();
+        if (!OperatingSystem.IsWindows()
+            || GetIpForwardTable2(AF_INET, out var table) != 0
+            || table == IntPtr.Zero)
+        {
+            return candidates;
+        }
+
+        try
+        {
+            var count = (uint)Marshal.ReadInt32(table);
+            var rowOffset = (int)Marshal.OffsetOf<MibIpForwardTable2>(nameof(MibIpForwardTable2.Table));
+            var rowSize = Marshal.SizeOf<MibIpForwardRow2>();
+
+            for (var i = 0; i < count; i++)
+            {
+                var rowPtr = IntPtr.Add(table, rowOffset + i * rowSize);
+                var row = Marshal.PtrToStructure<MibIpForwardRow2>(rowPtr);
+                if (row.DestinationPrefix.PrefixLength != 0)
+                {
+                    continue;
+                }
+
+                if (!TryGetInterfaceMetric(row.InterfaceLuid, row.InterfaceIndex, out var interfaceMetric, out var connected)
+                    || !connected)
+                {
+                    continue;
+                }
+
+                candidates.Add(new DefaultRouteCandidate(
+                    row.InterfaceIndex,
+                    (ulong)row.Metric + interfaceMetric,
+                    row.Metric,
+                    interfaceMetric));
+            }
+        }
+        catch (Exception ex)
+        {
+            candidates.Clear();
+            Logging.SaveLog(_tag, ex);
+        }
+        finally
+        {
+            FreeMibTable(table);
+        }
+
+        return candidates
+            .OrderBy(static candidate => candidate.TotalMetric)
+            .ThenBy(static candidate => candidate.RouteMetric)
+            .ThenBy(static candidate => candidate.InterfaceMetric)
+            .ToList();
+    }
+
+    private static bool TryGetInterfaceMetric(ulong interfaceLuid,
+        uint interfaceIndex,
+        out uint metric,
+        out bool connected)
+    {
+        metric = 0;
+        connected = false;
+
+        var row = new MibIpInterfaceRow
+        {
+            Family = AF_INET,
+            InterfaceLuid = interfaceLuid,
+            InterfaceIndex = interfaceIndex,
+            ZoneIndices = new uint[16],
+        };
+
+        if (GetIpInterfaceEntry(ref row) != 0)
+        {
+            return false;
+        }
+
+        metric = row.Metric;
+        connected = row.Connected;
+        return true;
+    }
+
+    internal readonly record struct DefaultRouteCandidate(
+        uint InterfaceIndex,
+        ulong TotalMetric,
+        uint RouteMetric,
+        uint InterfaceMetric);
+
+    [DllImport("iphlpapi.dll", ExactSpelling = true)]
+    private static extern int GetIpForwardTable2(ushort family, out IntPtr table);
+
+    [DllImport("iphlpapi.dll", ExactSpelling = true)]
+    private static extern void FreeMibTable(IntPtr memory);
+
+    [DllImport("iphlpapi.dll", ExactSpelling = true)]
+    private static extern int GetIpInterfaceEntry(ref MibIpInterfaceRow row);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MibIpForwardTable2
+    {
+        public uint NumEntries;
+        public MibIpForwardRow2 Table;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MibIpForwardRow2
+    {
+        public ulong InterfaceLuid;
+        public uint InterfaceIndex;
+        public IpAddressPrefix DestinationPrefix;
+        public RawSockaddrInet NextHop;
+        public byte SitePrefixLength;
+        public uint ValidLifetime;
+        public uint PreferredLifetime;
+        public uint Metric;
+        public uint Protocol;
+        [MarshalAs(UnmanagedType.U1)] public bool Loopback;
+        [MarshalAs(UnmanagedType.U1)] public bool AutoconfigureAddress;
+        [MarshalAs(UnmanagedType.U1)] public bool Publish;
+        [MarshalAs(UnmanagedType.U1)] public bool Immortal;
+        public uint Age;
+        public uint Origin;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Size = 32)]
+    private struct IpAddressPrefix
+    {
+        public RawSockaddrInet RawPrefix;
+        public byte PrefixLength;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Size = 28)]
+    private struct RawSockaddrInet
+    {
+        public ushort Family;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MibIpInterfaceRow
+    {
+        public ushort Family;
+        public ulong InterfaceLuid;
+        public uint InterfaceIndex;
+        public uint MaxReassemblySize;
+        public ulong InterfaceIdentifier;
+        public uint MinRouterAdvertisementInterval;
+        public uint MaxRouterAdvertisementInterval;
+        [MarshalAs(UnmanagedType.U1)] public bool AdvertisingEnabled;
+        [MarshalAs(UnmanagedType.U1)] public bool ForwardingEnabled;
+        [MarshalAs(UnmanagedType.U1)] public bool WeakHostSend;
+        [MarshalAs(UnmanagedType.U1)] public bool WeakHostReceive;
+        [MarshalAs(UnmanagedType.U1)] public bool UseAutomaticMetric;
+        [MarshalAs(UnmanagedType.U1)] public bool UseNeighborUnreachabilityDetection;
+        [MarshalAs(UnmanagedType.U1)] public bool ManagedAddressConfigurationSupported;
+        [MarshalAs(UnmanagedType.U1)] public bool OtherStatefulConfigurationSupported;
+        [MarshalAs(UnmanagedType.U1)] public bool AdvertiseDefaultRoute;
+        public int RouterDiscoveryBehavior;
+        public uint DadTransmits;
+        public uint BaseReachableTime;
+        public uint RetransmitTime;
+        public uint PathMtuDiscoveryTimeout;
+        public int LinkLocalAddressBehavior;
+        public uint LinkLocalAddressTimeout;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+        public uint[] ZoneIndices;
+        public uint SitePrefixLength;
+        public uint Metric;
+        public uint NlMtu;
+        [MarshalAs(UnmanagedType.U1)] public bool Connected;
+        [MarshalAs(UnmanagedType.U1)] public bool SupportsWakeUpPatterns;
+        [MarshalAs(UnmanagedType.U1)] public bool SupportsNeighborDiscovery;
+        [MarshalAs(UnmanagedType.U1)] public bool SupportsRouterDiscovery;
+        public byte TransmitOffload;
+        public byte ReceiveOffload;
+        [MarshalAs(UnmanagedType.U1)] public bool DisableDefaultRoutes;
+    }
+}

--- a/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
+++ b/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
@@ -162,12 +162,18 @@ public class CoreConfigContextBuilder
                 ProtectDomainList = [.. mainResult.Context.ProtectDomainList, .. preResult.Context.ProtectDomainList],
             },
         };
+        var shouldBindMainXray = ShouldBindMainXrayForLegacyTunProtect(mainResult.Context, preResult.Context);
         if (mainResult.Context.IsTunEnabled
-            && mainResult.Context.AppConfig.TunModeItem.StrictRoute)
+            && (mainResult.Context.AppConfig.TunModeItem.StrictRoute || shouldBindMainXray))
         {
             var appConfig = JsonUtils.DeepCopy(mainResult.Context.AppConfig);
-            appConfig.CoreBasicItem.BindInterface = string.Empty;
-            appConfig.CoreBasicItem.SendThrough = string.Empty;
+            appConfig.CoreBasicItem.BindInterface = shouldBindMainXray
+                ? ResolveMainCoreBindInterface(mainResult.Context)
+                : string.Empty;
+            if (mainResult.Context.AppConfig.TunModeItem.StrictRoute)
+            {
+                appConfig.CoreBasicItem.SendThrough = string.Empty;
+            }
             resolvedMainResult = resolvedMainResult with
             {
                 Context = resolvedMainResult.Context with
@@ -177,6 +183,28 @@ public class CoreConfigContextBuilder
             };
         }
         return new CoreConfigContextBuilderAllResult(resolvedMainResult, preResult);
+    }
+
+    private static bool ShouldBindMainXrayForLegacyTunProtect(CoreConfigContext mainContext,
+        CoreConfigContext preContext)
+    {
+        return Utils.IsWindows()
+               && mainContext.AppConfig.TunModeItem.EnableLegacyProtect
+               && mainContext.RunCoreType == ECoreType.Xray
+               && preContext.RunCoreType == ECoreType.sing_box
+               && preContext.Node.ConfigType == EConfigType.SOCKS
+               && Utils.IsLoopbackAddress(preContext.Node.Address)
+               && preContext.Node.Port == AppManager.Instance.GetLocalPort(EInboundProtocol.socks);
+    }
+
+    private static string ResolveMainCoreBindInterface(CoreConfigContext mainContext)
+    {
+        var interfaceName = Utils.GetPreferredRealNetworkInterface(mainContext.AppConfig.CoreBasicItem.BindInterface);
+        if (!interfaceName.IsNullOrEmpty())
+        {
+            Logging.SaveLog($"Auto bind main Xray outbound interface for legacy TUN protect: {interfaceName}");
+        }
+        return interfaceName;
     }
 
     /// <summary>

--- a/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
+++ b/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
@@ -162,6 +162,8 @@ public class CoreConfigContextBuilder
                 ProtectDomainList = [.. mainResult.Context.ProtectDomainList, .. preResult.Context.ProtectDomainList],
             },
         };
+        // 旧版 TUN 保护链路是 sing-box TUN -> 本地 Xray SOCKS；主 Xray 自身连接节点时也要避免被 TUN 回灌。
+        // Legacy TUN protect forwards traffic through sing-box TUN -> local Xray SOCKS; bind main Xray so its own server connection is not captured by TUN.
         var shouldBindMainXray = ShouldBindMainXrayForLegacyTunProtect(mainResult.Context, preResult.Context);
         if (mainResult.Context.IsTunEnabled
             && (mainResult.Context.AppConfig.TunModeItem.StrictRoute || shouldBindMainXray))
@@ -199,7 +201,9 @@ public class CoreConfigContextBuilder
 
     private static string ResolveMainCoreBindInterface(CoreConfigContext mainContext)
     {
-        var interfaceName = Utils.GetPreferredRealNetworkInterface(mainContext.AppConfig.CoreBasicItem.BindInterface);
+        var interfaceName = Utils.GetPreferredRealNetworkInterface(
+            mainContext.AppConfig.CoreBasicItem.BindInterface,
+            mainContext.Node.Address);
         if (!interfaceName.IsNullOrEmpty())
         {
             Logging.SaveLog($"Auto bind main Xray outbound interface for legacy TUN protect: {interfaceName}");

--- a/v2rayN/ServiceLib/Manager/CoreManager.cs
+++ b/v2rayN/ServiceLib/Manager/CoreManager.cs
@@ -15,6 +15,8 @@ public class CoreManager
     private bool _linuxSudo = false;
     private Func<bool, string, Task>? _updateFunc;
     private const string _tag = "CoreHandler";
+    private const int SocksProxyReadyAttempts = 10;
+    private static readonly TimeSpan SocksProxyReadyRetryDelay = TimeSpan.FromMilliseconds(500);
 
     public async Task Init(Config config, Func<bool, string, Task> updateFunc)
     {
@@ -90,9 +92,9 @@ public class CoreManager
         }
 
         await CoreStart(mainContext);
-        await CoreStartPreService(preContext);
+        var preServiceStarted = await CoreStartPreService(preContext);
 
-        AppManager.Instance.RunningCoreType = preContext?.RunCoreType ?? mainContext.RunCoreType;
+        AppManager.Instance.RunningCoreType = preServiceStarted ? preContext!.RunCoreType : mainContext.RunCoreType;
 
         if (_processService != null)
         {
@@ -188,10 +190,15 @@ public class CoreManager
         _processService = proc;
     }
 
-    private async Task CoreStartPreService(CoreConfigContext? preContext)
+    private async Task<bool> CoreStartPreService(CoreConfigContext? preContext)
     {
         if (_processService is { HasExited: false } && preContext != null)
         {
+            if (!await WaitForPreServiceDependencyReady(preContext))
+            {
+                return false;
+            }
+
             var preCoreType = preContext?.Node?.CoreType ?? ECoreType.sing_box;
             var fileName = Utils.GetBinConfigPath(Global.CorePreConfigFileName);
             var result = await CoreConfigHandler.GenerateClientConfig(preContext, fileName);
@@ -201,10 +208,76 @@ public class CoreManager
                 var proc = await RunProcess(coreInfo, Global.CorePreConfigFileName, true, true);
                 if (proc is null)
                 {
-                    return;
+                    return false;
                 }
                 _processPreService = proc;
+                return true;
             }
+        }
+
+        return false;
+    }
+
+    private async Task<bool> WaitForPreServiceDependencyReady(CoreConfigContext preContext)
+    {
+        if (!ShouldWaitForSocksPreServiceDependency(preContext, out var address, out var port))
+        {
+            return true;
+        }
+
+        var endpoint = $"{address}:{port}";
+        await UpdateFunc(false, $"Waiting for SOCKS proxy {endpoint} before starting TUN pre-service...");
+
+        for (var attempt = 1; attempt <= SocksProxyReadyAttempts; attempt++)
+        {
+            if (_processService is null or { HasExited: true })
+            {
+                var msg = $"Main core exited before SOCKS proxy {endpoint} became ready.";
+                Logging.SaveLog($"{_tag}: {msg}");
+                await UpdateFunc(true, msg);
+                return false;
+            }
+
+            if (await CanConnectTcp(address!, port!.Value, TimeSpan.FromMilliseconds(300)))
+            {
+                await UpdateFunc(false, $"SOCKS proxy port {endpoint} is ready.");
+                return true;
+            }
+
+            await Task.Delay(SocksProxyReadyRetryDelay);
+        }
+
+        var timeoutMsg = $"SOCKS proxy {endpoint} is not ready; skip starting TUN pre-service.";
+        Logging.SaveLog($"{_tag}: {timeoutMsg}");
+        await UpdateFunc(true, timeoutMsg);
+        return false;
+    }
+
+    private static bool ShouldWaitForSocksPreServiceDependency(CoreConfigContext preContext, out string? address, out int? port)
+    {
+        address = preContext.Node.Address;
+        if (address.IsNullOrEmpty())
+        {
+            address = Global.Loopback;
+        }
+        port = preContext.Node.Port;
+
+        return preContext.Node.ConfigType == EConfigType.SOCKS
+            && port is > 0 and <= Global.MaxPort;
+    }
+
+    private static async Task<bool> CanConnectTcp(string address, int port, TimeSpan timeout)
+    {
+        try
+        {
+            using var cts = new CancellationTokenSource(timeout);
+            using var client = new TcpClient();
+            await client.ConnectAsync(address, port, cts.Token);
+            return true;
+        }
+        catch
+        {
+            return false;
         }
     }
 

--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -67,6 +67,12 @@ public class MainWindowViewModel : MyReactiveObject
 
     [Reactive] public bool BlNewUpdate { get; set; }
 
+    private const int LegacyTunProtectNetworkChangeDelayMs = 6000;
+    private bool _legacyTunProtectBindInterfaceTracked;
+    private string _legacyTunProtectBindInterface = string.Empty;
+    private bool _networkChangeMonitorRegistered;
+    private int _networkChangeVersion;
+
     #endregion Menu
 
     #region Init
@@ -273,6 +279,7 @@ public class MainWindowViewModel : MyReactiveObject
         await ProfileExManager.Instance.Init();
         await CoreManager.Instance.Init(_config, UpdateHandler);
         TaskManager.Instance.RegUpdateTask(_config, UpdateTaskHandler);
+        RegisterNetworkChangeMonitor();
 
         if (_config.GuiItem.EnableStatistics || _config.GuiItem.DisplayRealTimeSpeed)
         {
@@ -575,6 +582,7 @@ public class MainWindowViewModel : MyReactiveObject
             {
                 return;
             }
+            UpdateLegacyTunProtectBindInterfaceSnapshot(allResult);
 
             await Task.Run(async () =>
             {
@@ -622,6 +630,91 @@ public class MainWindowViewModel : MyReactiveObject
     private async Task LoadCore(CoreConfigContext? mainContext, CoreConfigContext? preContext)
     {
         await CoreManager.Instance.LoadCore(mainContext, preContext);
+    }
+
+    private void RegisterNetworkChangeMonitor()
+    {
+        if (!Utils.IsWindows() || _networkChangeMonitorRegistered)
+        {
+            return;
+        }
+
+        NetworkChange.NetworkAddressChanged += OnNetworkChanged;
+        NetworkChange.NetworkAvailabilityChanged += OnNetworkChanged;
+        _networkChangeMonitorRegistered = true;
+    }
+
+    private void OnNetworkChanged(object? sender, EventArgs e)
+    {
+        _ = ScheduleLegacyTunProtectNetworkChangeCheck();
+    }
+
+    private async Task ScheduleLegacyTunProtectNetworkChangeCheck()
+    {
+        var version = Interlocked.Increment(ref _networkChangeVersion);
+        await Task.Delay(LegacyTunProtectNetworkChangeDelayMs);
+        if (version != _networkChangeVersion)
+        {
+            return;
+        }
+
+        await ReloadIfLegacyTunProtectBindInterfaceChanged();
+    }
+
+    private async Task ReloadIfLegacyTunProtectBindInterfaceChanged()
+    {
+        if (!_legacyTunProtectBindInterfaceTracked
+            || !_config.TunModeItem.EnableTun
+            || !_config.TunModeItem.EnableLegacyProtect)
+        {
+            return;
+        }
+
+        var currentInterface = ResolvePreferredMainCoreBindInterface();
+        if (currentInterface.IsNullOrEmpty())
+        {
+            Logging.SaveLog("Network changed; no usable interface found for legacy TUN protect Xray binding.");
+            return;
+        }
+
+        if (currentInterface.Equals(_legacyTunProtectBindInterface, StringComparison.OrdinalIgnoreCase)
+            && Utils.IsUsableRealNetworkInterface(_legacyTunProtectBindInterface))
+        {
+            return;
+        }
+
+        var msg =
+            $"Network changed; reload legacy TUN protect Xray binding: {_legacyTunProtectBindInterface} -> {currentInterface}";
+        Logging.SaveLog(msg);
+        NoticeManager.Instance.SendMessage(msg);
+        await Reload();
+    }
+
+    private void UpdateLegacyTunProtectBindInterfaceSnapshot(CoreConfigContextBuilderAllResult allResult)
+    {
+        var mainContext = allResult.MainResult.Context;
+        var preContext = allResult.PreSocksResult?.Context;
+        _legacyTunProtectBindInterfaceTracked = IsLegacyTunProtectXrayBindContext(mainContext, preContext);
+        _legacyTunProtectBindInterface = _legacyTunProtectBindInterfaceTracked
+            ? mainContext.AppConfig.CoreBasicItem.BindInterface ?? string.Empty
+            : string.Empty;
+    }
+
+    private bool IsLegacyTunProtectXrayBindContext(CoreConfigContext mainContext, CoreConfigContext? preContext)
+    {
+        return Utils.IsWindows()
+               && _config.TunModeItem.EnableTun
+               && _config.TunModeItem.EnableLegacyProtect
+               && mainContext.RunCoreType == ECoreType.Xray
+               && preContext?.RunCoreType == ECoreType.sing_box
+               && preContext.Node.ConfigType == EConfigType.SOCKS
+               && Utils.IsLoopbackAddress(preContext.Node.Address)
+               && preContext.Node.Port == AppManager.Instance.GetLocalPort(EInboundProtocol.socks);
+    }
+
+    private string ResolvePreferredMainCoreBindInterface()
+    {
+        return Utils.GetPreferredRealNetworkInterface(_config.CoreBasicItem.BindInterface);
     }
 
     #endregion core job

--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -70,6 +70,7 @@ public class MainWindowViewModel : MyReactiveObject
     private const int LegacyTunProtectNetworkChangeDelayMs = 6000;
     private bool _legacyTunProtectBindInterfaceTracked;
     private string _legacyTunProtectBindInterface = string.Empty;
+    private string _legacyTunProtectBindDestination = string.Empty;
     private bool _networkChangeMonitorRegistered;
     private int _networkChangeVersion;
 
@@ -698,6 +699,9 @@ public class MainWindowViewModel : MyReactiveObject
         _legacyTunProtectBindInterface = _legacyTunProtectBindInterfaceTracked
             ? mainContext.AppConfig.CoreBasicItem.BindInterface ?? string.Empty
             : string.Empty;
+        _legacyTunProtectBindDestination = _legacyTunProtectBindInterfaceTracked
+            ? mainContext.Node.Address ?? string.Empty
+            : string.Empty;
     }
 
     private bool IsLegacyTunProtectXrayBindContext(CoreConfigContext mainContext, CoreConfigContext? preContext)
@@ -714,7 +718,9 @@ public class MainWindowViewModel : MyReactiveObject
 
     private string ResolvePreferredMainCoreBindInterface()
     {
-        return Utils.GetPreferredRealNetworkInterface(_config.CoreBasicItem.BindInterface);
+        return Utils.GetPreferredRealNetworkInterface(
+            _config.CoreBasicItem.BindInterface,
+            _legacyTunProtectBindDestination);
     }
 
     #endregion core job


### PR DESCRIPTION
#9630 我之前提了issue，前面做了更详尽的复测和分析，已经定位到了代码行为问题并修复和测试完毕

问题：

在 Windows 下启用 TUN，并开启“旧版 TUN 保护”时，非 sing-box 主 core 会先启动本地 SOCKS 代理，再由 sing-box TUN pre-service 接管系统流量并转发到该本地 SOCKS 端口。

当前启动流程中，`CoreStart(mainContext)` 返回后会立即启动 pre-service。但此时主 core 进程虽然已经启动，本地 SOCKS 端口也可能已经开始监听，却不一定已经能完成真实代理请求。

如果 sing-box TUN 在本地 SOCKS 代理实际可用前接管路由/DNS，可能导致启动后测速为 `-1`，并且实际连接不可用。用户手动关闭 TUN，等待系统代理可用后再重新开启 TUN，则可以恢复，这说明问题与启动顺序有关。

修改：

本 PR 在启动 sing-box TUN pre-service 前增加本地 SOCKS 依赖检查：

- 仅在 pre-service 是 `sing_box + SOCKS + loopback` 时执行等待。
- 先检查本地端口是否可 TCP 连接。
- TCP 连接成功后，再通过该 SOCKS 代理执行一次真实 HTTP 测试。
- 只有本地 SOCKS 代理真实可用后，才启动 sing-box TUN pre-service。
- 如果主 core 在等待期间退出，或等待超时，则跳过 TUN pre-service，并输出明确日志。
- pre-service 未实际启动时，`RunningCoreType` 回退为主 core 类型，避免运行状态与实际进程不一致。

范围：

该修复只针对旧版 TUN 保护 / pre-socks 链路：

```text
sing-box TUN pre-service -> loopback SOCKS -> 主 core
```

不改变 sing-box 作为主 core 自身启用 TUN 的行为，因为该场景不存在 pre-service 依赖另一个本地 SOCKS core 的启动顺序问题。

验证：

本地基于 `7.23.0` 构建测试版，并在以下场景反复测试未再复现：

- Windows x64
- Xray + VLESS 节点
- 启用系统代理
- 启用 TUN
- 启用旧版 TUN 保护
- 多次重启服务
- 多次关闭/启用 TUN