### PR TITLE
fix(hysteria2): emit https server_url for sing-box realm outbound

### DIFF
--- a/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
+++ b/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
@@ -1,8 +1,10 @@
 using AwesomeAssertions;
 using ServiceLib.Common;
 using ServiceLib.Enums;
+using ServiceLib.Handler.Fmt;
 using ServiceLib.Manager;
 using ServiceLib.Models;
+using ServiceLib.Models.Dto;
 using ServiceLib.Services.CoreConfig;
 using Xunit;
 
@@ -556,5 +558,38 @@ public class CoreConfigSingboxServiceTests
         cfg.dns.servers.Should().Contain(s => s.tag == Global.SingboxLocalDNSTag);
         cfg.dns.rules.Should().Contain(r => r.clash_mode == nameof(ERuleMode.Global));
         cfg.dns.rules.Should().Contain(r => r.clash_mode == nameof(ERuleMode.Direct));
+    }
+
+    [Fact]
+    public void GenerateClientConfigContent_Hysteria2Realm_ShouldEmitHttpsServerUrl()
+    {
+        var shareLink =
+            "hysteria2+realm://public@realm.hy2.io/my-realm-id?auth=uuid&stun=turn.cloudflare.com%3A3478&sni=cloudflare.com&pinSHA256=xxx#Realm-Test";
+        var node = Hysteria2Fmt.ResolveRealm(shareLink, out _);
+        node.Should().NotBeNull();
+        node!.CoreType = ECoreType.sing_box;
+
+        var config = CoreConfigTestFactory.CreateConfig(ECoreType.sing_box);
+        config.CoreTypeItem =
+        [
+            new CoreTypeItem { ConfigType = EConfigType.Hysteria2, CoreType = ECoreType.sing_box }
+        ];
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+        var context = CoreConfigTestFactory.CreateContext(config, node, ECoreType.sing_box);
+
+        var result = new CoreConfigSingboxService(context).GenerateClientConfigContent();
+
+        result.Success.Should().BeTrue($"ret msg: {result.Msg}");
+        var cfg = JsonUtils.Deserialize<SingboxConfig>(result.Data!.ToString())!;
+        var proxy = cfg.outbounds.First(o => o.tag == Global.ProxyTag);
+
+        proxy.type.Should().Be("hysteria2");
+        proxy.realm.Should().NotBeNull();
+        proxy.realm!.server_url.Should().StartWith("https://");
+        proxy.realm.server_url.Should().Contain("realm.hy2.io");
+        proxy.realm.token.Should().Be("public");
+        proxy.realm.realm_id.Should().Be("my-realm-id");
+        proxy.realm.stun_servers.Should().Contain("turn.cloudflare.com:3478");
+        proxy.server.Should().BeNull();
     }
 }

--- a/v2rayN/ServiceLib.Tests/Fmt/HyRealmTests.cs
+++ b/v2rayN/ServiceLib.Tests/Fmt/HyRealmTests.cs
@@ -1,4 +1,6 @@
 using AwesomeAssertions;
+using ServiceLib.Handler.Fmt;
+using ServiceLib.Models.Dto;
 using Xunit;
 
 namespace ServiceLib.Tests.Fmt;
@@ -57,5 +59,33 @@ public class HyRealmTests
         var uri = Hysteria2Fmt.ToUri(resolved);
         uri.Should().Contain("hysteria2+realm://mytoken@rendezvous.example.com");
         uri.Should().EndWith("#remark");
+    }
+
+    [Fact]
+    public void ToServerUrl_ShouldIncludeSchemeForSingbox()
+    {
+        var realm = new HyRealm(
+            IsHttp: false,
+            Token: "public",
+            RendezvousHost: "realm.hy2.io",
+            RendezvousPort: 443,
+            RealmName: "my-realm-id",
+            StunList: ["turn.cloudflare.com:3478"]
+        );
+
+        realm.ToServerUrl().Should().Be("https://realm.hy2.io:443");
+    }
+
+    [Fact]
+    public void ResolveRealm_Issue9635_ShouldProduceHttpsServerUrl()
+    {
+        var str = "hysteria2+realm://public@realm.hy2.io/my-realm-id?auth=uuid&stun=turn.cloudflare.com%3A3478&sni=cloudflare.com&pinSHA256=xxx#Realm-Test";
+        var resolved = Hysteria2Fmt.ResolveRealm(str, out _);
+        resolved.Should().NotBeNull();
+
+        HyRealm.TryParse(resolved!.GetProtocolExtra().Hy2RealmUrl, out var realm).Should().BeTrue();
+        realm!.ToServerUrl().Should().StartWith("https://");
+        realm.ToServerUrl().Should().Contain("realm.hy2.io");
+        realm.StunList.Should().Contain("turn.cloudflare.com:3478");
     }
 }

--- a/v2rayN/ServiceLib/Handler/Fmt/Hysteria2Fmt.cs
+++ b/v2rayN/ServiceLib/Handler/Fmt/Hysteria2Fmt.cs
@@ -110,6 +110,7 @@ public class Hysteria2Fmt : BaseFmt
             Hy2RealmUrl = realm.ToUri(),
         });
 
+        msg = string.Empty;
         return item;
     }
 

--- a/v2rayN/ServiceLib/Models/CoreConfigs/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/CoreConfigs/SingboxConfig.cs
@@ -257,6 +257,7 @@ public class HyRealm4Sbox
     public string? server_url { get; set; }
     public string? token { get; set; }
     public string? realm_id { get; set; }
+    public List<string>? stun_servers { get; set; }
 }
 
 public class Server4Sbox : BaseServer4Sbox

--- a/v2rayN/ServiceLib/Models/Dto/HyRealm.cs
+++ b/v2rayN/ServiceLib/Models/Dto/HyRealm.cs
@@ -15,6 +15,15 @@ public record HyRealm(
 {
     public string RendezvousHostPort => RendezvousPort > 0 ? $"{RendezvousHost}:{RendezvousPort}" : RendezvousHost;
 
+    /// <summary>
+    /// sing-box realm.server_url requires a scheme (https:// or http://).
+    /// </summary>
+    public string ToServerUrl()
+    {
+        var scheme = IsHttp ? "http" : "https";
+        return $"{scheme}://{RendezvousHostPort}";
+    }
+
     public static bool TryParse(string? str, out HyRealm? realm)
     {
         realm = null;

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -275,9 +275,10 @@ public partial class CoreConfigSingboxService
                         {
                             var realm4Sbox = new HyRealm4Sbox()
                             {
-                                server_url = realm.RendezvousHostPort,
+                                server_url = realm.ToServerUrl(),
                                 token = realm.Token,
                                 realm_id = realm.RealmName,
+                                stun_servers = realm.StunList?.Count > 0 ? realm.StunList : null,
                             };
                             outbound.realm = realm4Sbox;
                             outbound.server = null;


### PR DESCRIPTION
sing-box requires realm.server_url as a full URL (https://host:port). Bare host:port caused "missing host in realm server_url" on import. Also forward stun_servers and clear ResolveRealm success message.

Fixes #9635