### PR TITLE
补齐旧版 TUN 保护下主 Xray 出口处理

### DIFF
--- a/v2rayN/ServiceLib/Common/Utils.cs
+++ b/v2rayN/ServiceLib/Common/Utils.cs
@@ -803,10 +803,230 @@ public class Utils
                .Any(ua => ua.Address.Equals(targetAddress));
     }
 
+    public static bool HasEffectiveSendThrough(string? sendThrough, bool strictRoute)
+    {
+        // strict_route clears SendThrough in generated TUN configs, so it should not suppress automatic interface binding.
+        // strict_route 会在生成 TUN 配置时清空 SendThrough，因此不应阻止自动绑定网口。
+        if (strictRoute)
+        {
+            return false;
+        }
+
+        sendThrough = sendThrough?.TrimEx();
+        return !sendThrough.IsNullOrEmpty() && IsLocalIP(sendThrough);
+    }
+
     public static bool ContainsInterfaceName(string inInterfaceName)
     {
+        inInterfaceName = inInterfaceName.TrimEx();
         return NetworkInterface.GetAllNetworkInterfaces()
             .Any(ni => ni.Name.Equals(inInterfaceName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public static bool IsLoopbackAddress(string? address)
+    {
+        if (address.IsNullOrEmpty())
+        {
+            return false;
+        }
+
+        address = address.TrimEx();
+        return IPAddress.TryParse(address, out var ipAddress)
+            ? IPAddress.IsLoopback(ipAddress)
+            : address.Equals(Global.Loopback, StringComparison.OrdinalIgnoreCase)
+              || address.Equals("localhost", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static string GetPreferredRealNetworkInterface(string? configuredInterface, string? destinationAddress = null)
+    {
+        var interfaceName = configuredInterface?.TrimEx();
+        if (!interfaceName.IsNullOrEmpty() && ContainsInterfaceName(interfaceName))
+        {
+            return interfaceName;
+        }
+
+        if (IsLoopbackAddress(destinationAddress))
+        {
+            // Loopback targets do not route through the TUN default route; avoid binding to a physical default interface.
+            // Loopback 目标不会被 TUN 默认路由回灌，因此不要回退绑定到物理默认出口。
+            return string.Empty;
+        }
+
+        interfaceName = GetLocalAddressMatchedRealNetworkInterface(destinationAddress);
+        if (!interfaceName.IsNullOrEmpty())
+        {
+            return interfaceName;
+        }
+
+        interfaceName = GetWindowsDefaultRealNetworkInterface();
+        if (!interfaceName.IsNullOrEmpty())
+        {
+            return interfaceName;
+        }
+
+        // Match sing-tun: do not guess an interface when the default route cannot be resolved.
+        // 与 sing-tun 对齐：无法解析默认出口时不猜测网卡。
+        return string.Empty;
+    }
+
+    public static bool IsUsableRealNetworkInterface(string interfaceName)
+    {
+        if (interfaceName.IsNullOrEmpty())
+        {
+            return false;
+        }
+
+        return GetUsableRealNetworkInterfaces()
+            .Any(ni => ni.Name.Equals(interfaceName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string GetLocalAddressMatchedRealNetworkInterface(string? destinationAddress)
+    {
+        if (!IPAddress.TryParse(destinationAddress, out var address)
+            || !IsUsableUnicastAddress(address))
+        {
+            return string.Empty;
+        }
+
+        var interfaces = GetRunningNetworkInterfaces();
+
+        foreach (var networkInterface in interfaces)
+        {
+            if (GetUsableUnicastAddresses(networkInterface)
+                .Any(unicast => unicast.Address.Equals(address)))
+            {
+                return networkInterface.Name;
+            }
+        }
+
+        foreach (var networkInterface in interfaces)
+        {
+            if (GetUsableUnicastAddresses(networkInterface)
+                .Any(unicast => IsInPrefix(address, unicast.Address, unicast.PrefixLength)))
+            {
+                return networkInterface.Name;
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static string GetWindowsDefaultRealNetworkInterface()
+    {
+        var interfacesByIndex = NetworkInterface.GetAllNetworkInterfaces()
+            .Select(ni => new
+            {
+                Interface = ni,
+                Index = TryGetIPv4InterfaceIndex(ni, out var index) ? (uint?)index : null,
+            })
+            .Where(item => item.Index.HasValue)
+            .GroupBy(item => item.Index!.Value)
+            .ToDictionary(group => group.Key, group => group.First().Interface);
+
+        foreach (var candidate in WindowsNetworkUtils.GetDefaultIPv4RouteCandidates())
+        {
+            if (interfacesByIndex.TryGetValue(candidate.InterfaceIndex, out var networkInterface))
+            {
+                return networkInterface.Name;
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static List<NetworkInterface> GetUsableRealNetworkInterfaces()
+    {
+        return NetworkInterface.GetAllNetworkInterfaces()
+            .Where(IsUsableRealNetworkInterface)
+            .ToList();
+    }
+
+    private static List<NetworkInterface> GetRunningNetworkInterfaces()
+    {
+        return NetworkInterface.GetAllNetworkInterfaces()
+            .Where(ni => ni.OperationalStatus == OperationalStatus.Up)
+            .ToList();
+    }
+
+    private static IEnumerable<UnicastIPAddressInformation> GetUsableUnicastAddresses(NetworkInterface networkInterface)
+    {
+        return networkInterface.GetIPProperties().UnicastAddresses
+            .Where(ua => IsUsableUnicastAddress(ua.Address));
+    }
+
+    private static bool TryGetIPv4InterfaceIndex(NetworkInterface networkInterface, out uint interfaceIndex)
+    {
+        interfaceIndex = 0;
+        try
+        {
+            var properties = networkInterface.GetIPProperties().GetIPv4Properties();
+            if (properties == null)
+            {
+                return false;
+            }
+
+            interfaceIndex = (uint)properties.Index;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool IsInPrefix(IPAddress address, IPAddress prefixAddress, int prefixLength)
+    {
+        if (address.AddressFamily != prefixAddress.AddressFamily)
+        {
+            return false;
+        }
+
+        var addressBytes = address.GetAddressBytes();
+        var prefixBytes = prefixAddress.GetAddressBytes();
+        var bitLength = addressBytes.Length * 8;
+        if (prefixLength < 0 || prefixLength > bitLength)
+        {
+            return false;
+        }
+
+        var fullBytes = prefixLength / 8;
+        var remainingBits = prefixLength % 8;
+        for (var i = 0; i < fullBytes; i++)
+        {
+            if (addressBytes[i] != prefixBytes[i])
+            {
+                return false;
+            }
+        }
+
+        if (remainingBits == 0)
+        {
+            return true;
+        }
+
+        var mask = (byte)(0xFF << (8 - remainingBits));
+        return (addressBytes[fullBytes] & mask) == (prefixBytes[fullBytes] & mask);
+    }
+
+    private static bool IsUsableRealNetworkInterface(NetworkInterface networkInterface)
+    {
+        if (networkInterface.OperationalStatus != OperationalStatus.Up
+            || networkInterface.NetworkInterfaceType == NetworkInterfaceType.Loopback)
+        {
+            return false;
+        }
+
+        var ipProperties = networkInterface.GetIPProperties();
+        return ipProperties.UnicastAddresses.Any(ua => IsUsableUnicastAddress(ua.Address));
+    }
+
+    private static bool IsUsableUnicastAddress(IPAddress address)
+    {
+        return address.AddressFamily is AddressFamily.InterNetwork or AddressFamily.InterNetworkV6
+               && !address.Equals(IPAddress.Any)
+               && !address.Equals(IPAddress.IPv6Any)
+               && !address.Equals(IPAddress.IPv6None)
+               && !IPAddress.IsLoopback(address);
     }
 
     #endregion Speed Test

--- a/v2rayN/ServiceLib/Common/WindowsNetworkUtils.cs
+++ b/v2rayN/ServiceLib/Common/WindowsNetworkUtils.cs
@@ -1,0 +1,397 @@
+namespace ServiceLib.Common;
+
+// Keep Windows default-route interop here so legacy TUN protect code does not handle Win32 route structs directly.
+// 将 Windows 默认路由互操作集中在这里，避免旧版 TUN 保护业务逻辑直接维护 Win32 路由结构。
+internal static class WindowsNetworkUtils
+{
+    private const string _tag = "WindowsNetworkUtils";
+    private const ushort AF_UNSPEC = 0;
+    private const ushort AF_INET = 2;
+    private const uint IfOperStatusUp = 1;
+    private const uint IfTypeSoftwareLoopback = 24;
+    private const uint IfTypePropVirtual = 53;
+    private const int IfMaxStringSize = 256;
+    private const int IfMaxPhysAddressLength = 32;
+    private static readonly object NetworkChangeLock = new();
+    private static IpForwardChangeCallback? _routeChangeCallback;
+    private static IpInterfaceChangeCallback? _interfaceChangeCallback;
+    private static IntPtr _routeChangeHandle;
+    private static IntPtr _interfaceChangeHandle;
+    private static bool _networkChangeMonitorStarted;
+
+    public static event EventHandler? NetworkChanged;
+
+    public static bool TryStartNetworkChangeMonitor()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return false;
+        }
+
+        lock (NetworkChangeLock)
+        {
+            if (_networkChangeMonitorStarted)
+            {
+                return true;
+            }
+
+            _routeChangeCallback = OnRouteChanged;
+            _interfaceChangeCallback = OnInterfaceChanged;
+
+            var routeResult = NotifyRouteChange2(
+                AF_UNSPEC,
+                _routeChangeCallback,
+                IntPtr.Zero,
+                false,
+                out _routeChangeHandle);
+            if (routeResult != 0)
+            {
+                ResetNetworkChangeMonitor();
+                Logging.SaveLog($"{_tag}: NotifyRouteChange2 failed: {routeResult}");
+                return false;
+            }
+
+            var interfaceResult = NotifyIpInterfaceChange(
+                AF_UNSPEC,
+                _interfaceChangeCallback,
+                IntPtr.Zero,
+                false,
+                out _interfaceChangeHandle);
+            if (interfaceResult != 0)
+            {
+                ResetNetworkChangeMonitor();
+                Logging.SaveLog($"{_tag}: NotifyIpInterfaceChange failed: {interfaceResult}");
+                return false;
+            }
+
+            _networkChangeMonitorStarted = true;
+            return true;
+        }
+    }
+
+    public static IReadOnlyList<DefaultRouteCandidate> GetDefaultIPv4RouteCandidates()
+    {
+        var candidates = new List<DefaultRouteCandidate>();
+        if (!OperatingSystem.IsWindows()
+            || GetIpForwardTable2(AF_INET, out var table) != 0
+            || table == IntPtr.Zero)
+        {
+            return candidates;
+        }
+
+        try
+        {
+            var count = (uint)Marshal.ReadInt32(table);
+            var rowOffset = (int)Marshal.OffsetOf<MibIpForwardTable2>(nameof(MibIpForwardTable2.Table));
+            var rowSize = Marshal.SizeOf<MibIpForwardRow2>();
+
+            for (var i = 0; i < count; i++)
+            {
+                var rowPtr = IntPtr.Add(table, rowOffset + i * rowSize);
+                var row = Marshal.PtrToStructure<MibIpForwardRow2>(rowPtr);
+                if (row.DestinationPrefix.PrefixLength != 0)
+                {
+                    continue;
+                }
+
+                if (!IsUsableDefaultRouteInterface(row.InterfaceLuid, row.InterfaceIndex))
+                {
+                    continue;
+                }
+
+                if (!TryGetInterfaceMetric(row.InterfaceLuid, row.InterfaceIndex, out var interfaceMetric, out var connected)
+                    || !connected)
+                {
+                    continue;
+                }
+
+                candidates.Add(new DefaultRouteCandidate(
+                    row.InterfaceIndex,
+                    (ulong)row.Metric + interfaceMetric));
+            }
+        }
+        catch (Exception ex)
+        {
+            candidates.Clear();
+            Logging.SaveLog(_tag, ex);
+        }
+        finally
+        {
+            FreeMibTable(table);
+        }
+
+        // sing-tun compares only the total metric; keep Windows route-table order on ties.
+        // sing-tun 只比较总 metric；metric 相同时保留 Windows 路由表顺序。
+        return candidates
+            .OrderBy(static candidate => candidate.TotalMetric)
+            .ToList();
+    }
+
+    private static bool TryGetInterfaceMetric(
+        ulong interfaceLuid,
+        uint interfaceIndex,
+        out uint metric,
+        out bool connected)
+    {
+        metric = 0;
+        connected = false;
+
+        var row = new MibIpInterfaceRow
+        {
+            Family = AF_INET,
+            InterfaceLuid = interfaceLuid,
+            InterfaceIndex = interfaceIndex,
+            ZoneIndices = new uint[16],
+        };
+
+        if (GetIpInterfaceEntry(ref row) != 0)
+        {
+            return false;
+        }
+
+        metric = row.Metric;
+        connected = row.Connected;
+        return true;
+    }
+
+    private static bool IsUsableDefaultRouteInterface(ulong interfaceLuid, uint interfaceIndex)
+    {
+        var row = CreateMibIfRow2(interfaceLuid, interfaceIndex);
+        if (GetIfEntry2(ref row) != 0)
+        {
+            return false;
+        }
+
+        return row.OperStatus == IfOperStatusUp
+               && row.Type != IfTypePropVirtual
+               && row.Type != IfTypeSoftwareLoopback;
+    }
+
+    private static MibIfRow2 CreateMibIfRow2(ulong interfaceLuid, uint interfaceIndex)
+    {
+        return new MibIfRow2
+        {
+            InterfaceLuid = interfaceLuid,
+            InterfaceIndex = interfaceIndex,
+            Alias = new ushort[IfMaxStringSize + 1],
+            Description = new ushort[IfMaxStringSize + 1],
+            PhysicalAddress = new byte[IfMaxPhysAddressLength],
+            PermanentPhysicalAddress = new byte[IfMaxPhysAddressLength],
+        };
+    }
+
+    private static void ResetNetworkChangeMonitor()
+    {
+        if (_routeChangeHandle != IntPtr.Zero)
+        {
+            CancelMibChangeNotify2(_routeChangeHandle);
+            _routeChangeHandle = IntPtr.Zero;
+        }
+
+        if (_interfaceChangeHandle != IntPtr.Zero)
+        {
+            CancelMibChangeNotify2(_interfaceChangeHandle);
+            _interfaceChangeHandle = IntPtr.Zero;
+        }
+
+        _routeChangeCallback = null;
+        _interfaceChangeCallback = null;
+        _networkChangeMonitorStarted = false;
+    }
+
+    private static void OnRouteChanged(IntPtr callerContext, IntPtr row, uint notificationType)
+    {
+        EmitNetworkChanged();
+    }
+
+    private static void OnInterfaceChanged(IntPtr callerContext, IntPtr row, uint notificationType)
+    {
+        EmitNetworkChanged();
+    }
+
+    private static void EmitNetworkChanged()
+    {
+        try
+        {
+            NetworkChanged?.Invoke(null, EventArgs.Empty);
+        }
+        catch (Exception ex)
+        {
+            Logging.SaveLog($"{_tag}: network change callback failed", ex);
+        }
+    }
+
+    internal readonly record struct DefaultRouteCandidate(
+        uint InterfaceIndex,
+        ulong TotalMetric);
+
+    [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+    private delegate void IpForwardChangeCallback(IntPtr callerContext, IntPtr row, uint notificationType);
+
+    [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+    private delegate void IpInterfaceChangeCallback(IntPtr callerContext, IntPtr row, uint notificationType);
+
+    [DllImport("iphlpapi.dll", ExactSpelling = true)]
+    private static extern int NotifyRouteChange2(
+        ushort family,
+        IpForwardChangeCallback callback,
+        IntPtr callerContext,
+        [MarshalAs(UnmanagedType.U1)] bool initialNotification,
+        out IntPtr notificationHandle);
+
+    [DllImport("iphlpapi.dll", ExactSpelling = true)]
+    private static extern int NotifyIpInterfaceChange(
+        ushort family,
+        IpInterfaceChangeCallback callback,
+        IntPtr callerContext,
+        [MarshalAs(UnmanagedType.U1)] bool initialNotification,
+        out IntPtr notificationHandle);
+
+    [DllImport("iphlpapi.dll", ExactSpelling = true)]
+    private static extern int CancelMibChangeNotify2(IntPtr notificationHandle);
+
+    [DllImport("iphlpapi.dll", ExactSpelling = true)]
+    private static extern int GetIpForwardTable2(ushort family, out IntPtr table);
+
+    [DllImport("iphlpapi.dll", ExactSpelling = true)]
+    private static extern void FreeMibTable(IntPtr memory);
+
+    [DllImport("iphlpapi.dll", ExactSpelling = true)]
+    private static extern int GetIpInterfaceEntry(ref MibIpInterfaceRow row);
+
+    [DllImport("iphlpapi.dll", ExactSpelling = true)]
+    private static extern int GetIfEntry2(ref MibIfRow2 row);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MibIpForwardTable2
+    {
+        public uint NumEntries;
+        public MibIpForwardRow2 Table;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct MibIpForwardRow2
+    {
+        public ulong InterfaceLuid;
+        public uint InterfaceIndex;
+        public IpAddressPrefix DestinationPrefix;
+        public RawSockaddrInet NextHop;
+        public byte SitePrefixLength;
+        public uint ValidLifetime;
+        public uint PreferredLifetime;
+        public uint Metric;
+        public uint Protocol;
+        [MarshalAs(UnmanagedType.U1)] public bool Loopback;
+        [MarshalAs(UnmanagedType.U1)] public bool AutoconfigureAddress;
+        [MarshalAs(UnmanagedType.U1)] public bool Publish;
+        [MarshalAs(UnmanagedType.U1)] public bool Immortal;
+        public uint Age;
+        public uint Origin;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Size = 32)]
+    private struct IpAddressPrefix
+    {
+        public RawSockaddrInet RawPrefix;
+        public byte PrefixLength;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Size = 28)]
+    private struct RawSockaddrInet
+    {
+        public ushort Family;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Size = 168)]
+    private struct MibIpInterfaceRow
+    {
+        public ushort Family;
+        public ulong InterfaceLuid;
+        public uint InterfaceIndex;
+        public uint MaxReassemblySize;
+        public ulong InterfaceIdentifier;
+        public uint MinRouterAdvertisementInterval;
+        public uint MaxRouterAdvertisementInterval;
+        [MarshalAs(UnmanagedType.U1)] public bool AdvertisingEnabled;
+        [MarshalAs(UnmanagedType.U1)] public bool ForwardingEnabled;
+        [MarshalAs(UnmanagedType.U1)] public bool WeakHostSend;
+        [MarshalAs(UnmanagedType.U1)] public bool WeakHostReceive;
+        [MarshalAs(UnmanagedType.U1)] public bool UseAutomaticMetric;
+        [MarshalAs(UnmanagedType.U1)] public bool UseNeighborUnreachabilityDetection;
+        [MarshalAs(UnmanagedType.U1)] public bool ManagedAddressConfigurationSupported;
+        [MarshalAs(UnmanagedType.U1)] public bool OtherStatefulConfigurationSupported;
+        [MarshalAs(UnmanagedType.U1)] public bool AdvertiseDefaultRoute;
+        public int RouterDiscoveryBehavior;
+        public uint DadTransmits;
+        public uint BaseReachableTime;
+        public uint RetransmitTime;
+        public uint PathMtuDiscoveryTimeout;
+        public int LinkLocalAddressBehavior;
+        public uint LinkLocalAddressTimeout;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+        public uint[] ZoneIndices;
+        public uint SitePrefixLength;
+        public uint Metric;
+        public uint NlMtu;
+        [MarshalAs(UnmanagedType.U1)] public bool Connected;
+        [MarshalAs(UnmanagedType.U1)] public bool SupportsWakeUpPatterns;
+        [MarshalAs(UnmanagedType.U1)] public bool SupportsNeighborDiscovery;
+        [MarshalAs(UnmanagedType.U1)] public bool SupportsRouterDiscovery;
+        public uint ReachableTime;
+        public byte TransmitOffload;
+        public byte ReceiveOffload;
+        [MarshalAs(UnmanagedType.U1)] public bool DisableDefaultRoutes;
+    }
+
+    // Mirrors MIB_IF_ROW2 layout; only Type and OperStatus are used for sing-tun-style filtering.
+    // 对齐 MIB_IF_ROW2 布局；这里只使用 Type 和 OperStatus 做 sing-tun 风格过滤。
+    [StructLayout(LayoutKind.Sequential, Size = 1352)]
+    private struct MibIfRow2
+    {
+        public ulong InterfaceLuid;
+        public uint InterfaceIndex;
+        public Guid InterfaceGuid;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = IfMaxStringSize + 1)]
+        public ushort[] Alias;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = IfMaxStringSize + 1)]
+        public ushort[] Description;
+        public uint PhysicalAddressLength;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = IfMaxPhysAddressLength)]
+        public byte[] PhysicalAddress;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = IfMaxPhysAddressLength)]
+        public byte[] PermanentPhysicalAddress;
+        public uint Mtu;
+        public uint Type;
+        public uint TunnelType;
+        public uint MediaType;
+        public uint PhysicalMediumType;
+        public uint AccessType;
+        public uint DirectionType;
+        public byte InterfaceAndOperStatusFlags;
+        public uint OperStatus;
+        public uint AdminStatus;
+        public uint MediaConnectState;
+        public Guid NetworkGuid;
+        public uint ConnectionType;
+        public ulong TransmitLinkSpeed;
+        public ulong ReceiveLinkSpeed;
+        public ulong InOctets;
+        public ulong InUcastPkts;
+        public ulong InNUcastPkts;
+        public ulong InDiscards;
+        public ulong InErrors;
+        public ulong InUnknownProtos;
+        public ulong InUcastOctets;
+        public ulong InMulticastOctets;
+        public ulong InBroadcastOctets;
+        public ulong OutOctets;
+        public ulong OutUcastPkts;
+        public ulong OutNUcastPkts;
+        public ulong OutDiscards;
+        public ulong OutErrors;
+        public ulong OutUcastOctets;
+        public ulong OutMulticastOctets;
+        public ulong OutBroadcastOctets;
+        public ulong OutQLen;
+    }
+}

--- a/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
+++ b/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
@@ -162,12 +162,20 @@ public class CoreConfigContextBuilder
                 ProtectDomainList = [.. mainResult.Context.ProtectDomainList, .. preResult.Context.ProtectDomainList],
             },
         };
+        // Legacy TUN protect forwards traffic through sing-box TUN -> local Xray SOCKS.
+        // 旧版 TUN 保护链路为 sing-box TUN -> 本地 Xray SOCKS，主 Xray 自身连接节点时也要避免被 TUN 回灌。
+        var shouldBindMainXray = ShouldBindMainXrayForLegacyTunProtect(mainResult.Context, preResult.Context);
         if (mainResult.Context.IsTunEnabled
-            && mainResult.Context.AppConfig.TunModeItem.StrictRoute)
+            && (mainResult.Context.AppConfig.TunModeItem.StrictRoute || shouldBindMainXray))
         {
             var appConfig = JsonUtils.DeepCopy(mainResult.Context.AppConfig);
-            appConfig.CoreBasicItem.BindInterface = string.Empty;
-            appConfig.CoreBasicItem.SendThrough = string.Empty;
+            appConfig.CoreBasicItem.BindInterface = shouldBindMainXray
+                ? ResolveMainCoreBindInterface(mainResult.Context)
+                : string.Empty;
+            if (mainResult.Context.AppConfig.TunModeItem.StrictRoute)
+            {
+                appConfig.CoreBasicItem.SendThrough = string.Empty;
+            }
             resolvedMainResult = resolvedMainResult with
             {
                 Context = resolvedMainResult.Context with
@@ -177,6 +185,47 @@ public class CoreConfigContextBuilder
             };
         }
         return new CoreConfigContextBuilderAllResult(resolvedMainResult, preResult);
+    }
+
+    private static bool ShouldBindMainXrayForLegacyTunProtect(
+        CoreConfigContext mainContext,
+        CoreConfigContext preContext)
+    {
+        return Utils.IsWindows()
+               && mainContext.AppConfig.TunModeItem.EnableLegacyProtect
+               && mainContext.RunCoreType == ECoreType.Xray
+               && preContext.RunCoreType == ECoreType.sing_box
+               && preContext.Node.ConfigType == EConfigType.SOCKS
+               && Utils.IsLoopbackAddress(preContext.Node.Address)
+               && preContext.Node.Port == AppManager.Instance.GetLocalPort(EInboundProtocol.socks);
+    }
+
+    private static string ResolveMainCoreBindInterface(CoreConfigContext mainContext)
+    {
+        if (!HasValidBindInterface(mainContext)
+            && Utils.HasEffectiveSendThrough(
+                mainContext.AppConfig.CoreBasicItem.SendThrough,
+                mainContext.AppConfig.TunModeItem.StrictRoute))
+        {
+            Logging.SaveLog("Skip auto binding main Xray outbound interface for legacy TUN protect: SendThrough is set.");
+            return string.Empty;
+        }
+
+        var interfaceName = Utils.GetPreferredRealNetworkInterface(
+            mainContext.AppConfig.CoreBasicItem.BindInterface,
+            mainContext.Node.Address);
+        if (!interfaceName.IsNullOrEmpty())
+        {
+            var action = mainContext.AppConfig.CoreBasicItem.BindInterface.IsNullOrEmpty() ? "Auto bind" : "Bind";
+            Logging.SaveLog($"{action} main Xray outbound interface for legacy TUN protect: {interfaceName}");
+        }
+        return interfaceName;
+    }
+
+    private static bool HasValidBindInterface(CoreConfigContext mainContext)
+    {
+        var bindInterface = mainContext.AppConfig.CoreBasicItem.BindInterface?.TrimEx();
+        return !bindInterface.IsNullOrEmpty() && Utils.ContainsInterfaceName(bindInterface);
     }
 
     /// <summary>

--- a/v2rayN/ServiceLib/Manager/CoreManager.cs
+++ b/v2rayN/ServiceLib/Manager/CoreManager.cs
@@ -15,6 +15,8 @@ public class CoreManager
     private bool _linuxSudo = false;
     private Func<bool, string, Task>? _updateFunc;
     private const string _tag = "CoreHandler";
+    private const int SocksProxyReadyAttempts = 10;
+    private static readonly TimeSpan SocksProxyReadyRetryDelay = TimeSpan.FromMilliseconds(500);
 
     public async Task Init(Config config, Func<bool, string, Task> updateFunc)
     {
@@ -90,9 +92,9 @@ public class CoreManager
         }
 
         await CoreStart(mainContext);
-        await CoreStartPreService(preContext);
+        var preServiceStarted = await CoreStartPreService(preContext);
 
-        AppManager.Instance.RunningCoreType = preContext?.RunCoreType ?? mainContext.RunCoreType;
+        AppManager.Instance.RunningCoreType = preServiceStarted ? preContext!.RunCoreType : mainContext.RunCoreType;
 
         if (_processService != null)
         {
@@ -151,18 +153,18 @@ public class CoreManager
                 _linuxSudo = false;
             }
 
-            if (_processService != null)
-            {
-                await _processService.StopAsync();
-                _processService.Dispose();
-                _processService = null;
-            }
-
             if (_processPreService != null)
             {
                 await _processPreService.StopAsync();
                 _processPreService.Dispose();
                 _processPreService = null;
+            }
+
+            if (_processService != null)
+            {
+                await _processService.StopAsync();
+                _processService.Dispose();
+                _processService = null;
             }
         }
         catch (Exception ex)
@@ -188,10 +190,15 @@ public class CoreManager
         _processService = proc;
     }
 
-    private async Task CoreStartPreService(CoreConfigContext? preContext)
+    private async Task<bool> CoreStartPreService(CoreConfigContext? preContext)
     {
         if (_processService is { HasExited: false } && preContext != null)
         {
+            if (!await WaitForPreServiceDependencyReady(preContext))
+            {
+                return false;
+            }
+
             var preCoreType = preContext?.Node?.CoreType ?? ECoreType.sing_box;
             var fileName = Utils.GetBinConfigPath(Global.CorePreConfigFileName);
             var result = await CoreConfigHandler.GenerateClientConfig(preContext, fileName);
@@ -201,10 +208,77 @@ public class CoreManager
                 var proc = await RunProcess(coreInfo, Global.CorePreConfigFileName, true, true);
                 if (proc is null)
                 {
-                    return;
+                    return false;
                 }
                 _processPreService = proc;
+                return true;
             }
+        }
+
+        return false;
+    }
+
+    private async Task<bool> WaitForPreServiceDependencyReady(CoreConfigContext preContext)
+    {
+        if (!ShouldWaitForSocksPreServiceDependency(preContext, out var address, out var port))
+        {
+            return true;
+        }
+
+        var endpoint = $"{address}:{port}";
+        await UpdateFunc(false, $"Waiting for SOCKS proxy {endpoint} before starting TUN pre-service...");
+
+        for (var attempt = 1; attempt <= SocksProxyReadyAttempts; attempt++)
+        {
+            if (_processService is null or { HasExited: true })
+            {
+                var msg = $"Main core exited before SOCKS proxy {endpoint} became ready.";
+                Logging.SaveLog($"{_tag}: {msg}");
+                await UpdateFunc(true, msg);
+                return false;
+            }
+
+            if (await CanConnectTcp(address!, port!.Value, TimeSpan.FromMilliseconds(300)))
+            {
+                await UpdateFunc(false, $"SOCKS proxy port {endpoint} is ready.");
+                return true;
+            }
+
+            await Task.Delay(SocksProxyReadyRetryDelay);
+        }
+
+        var timeoutMsg = $"SOCKS proxy {endpoint} is not ready; skip starting TUN pre-service.";
+        Logging.SaveLog($"{_tag}: {timeoutMsg}");
+        await UpdateFunc(true, timeoutMsg);
+        return false;
+    }
+
+    private static bool ShouldWaitForSocksPreServiceDependency(CoreConfigContext preContext, out string? address, out int? port)
+    {
+        address = preContext.Node.Address;
+        if (address.IsNullOrEmpty())
+        {
+            address = Global.Loopback;
+        }
+        port = preContext.Node.Port;
+
+        return preContext.Node.ConfigType == EConfigType.SOCKS
+            && Utils.IsLoopbackAddress(address)
+            && port is > 0 and <= Global.MaxPort;
+    }
+
+    private static async Task<bool> CanConnectTcp(string address, int port, TimeSpan timeout)
+    {
+        try
+        {
+            using var cts = new CancellationTokenSource(timeout);
+            using var client = new TcpClient();
+            await client.ConnectAsync(address, port, cts.Token);
+            return true;
+        }
+        catch
+        {
+            return false;
         }
     }
 

--- a/v2rayN/ServiceLib/Services/ProcessService.cs
+++ b/v2rayN/ServiceLib/Services/ProcessService.cs
@@ -2,6 +2,7 @@ namespace ServiceLib.Services;
 
 public class ProcessService : IDisposable
 {
+    private static readonly TimeSpan StopExitTimeout = TimeSpan.FromSeconds(2);
     private readonly Process _process;
     private readonly Func<bool, string, Task>? _updateFunc;
     private bool _isDisposed;
@@ -108,11 +109,31 @@ public class ProcessService : IDisposable
             }
             catch { }
 
-            await Task.Delay(100);
+            await WaitForExitAsync();
         }
         catch (Exception ex)
         {
             await _updateFunc?.Invoke(true, ex.Message);
+        }
+    }
+
+    private async Task WaitForExitAsync()
+    {
+        if (_process.HasExited)
+        {
+            return;
+        }
+
+        try
+        {
+            using var cts = new CancellationTokenSource(StopExitTimeout);
+            await _process.WaitForExitAsync(cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (InvalidOperationException)
+        {
         }
     }
 

--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -67,6 +67,13 @@ public class MainWindowViewModel : MyReactiveObject
 
     [Reactive] public bool BlNewUpdate { get; set; }
 
+    private const int LegacyTunProtectNetworkChangeDelayMs = 2000;
+    private bool _legacyTunProtectBindInterfaceTracked;
+    private string _legacyTunProtectBindInterface = string.Empty;
+    private string _legacyTunProtectBindDestination = string.Empty;
+    private bool _networkChangeMonitorRegistered;
+    private int _networkChangeVersion;
+
     #endregion Menu
 
     #region Init
@@ -273,6 +280,7 @@ public class MainWindowViewModel : MyReactiveObject
         await ProfileExManager.Instance.Init();
         await CoreManager.Instance.Init(_config, UpdateHandler);
         TaskManager.Instance.RegUpdateTask(_config, UpdateTaskHandler);
+        RegisterNetworkChangeMonitor();
 
         if (_config.GuiItem.EnableStatistics || _config.GuiItem.DisplayRealTimeSpeed)
         {
@@ -575,6 +583,7 @@ public class MainWindowViewModel : MyReactiveObject
             {
                 return;
             }
+            UpdateLegacyTunProtectBindInterfaceSnapshot(allResult);
 
             await Task.Run(async () =>
             {
@@ -622,6 +631,121 @@ public class MainWindowViewModel : MyReactiveObject
     private async Task LoadCore(CoreConfigContext? mainContext, CoreConfigContext? preContext)
     {
         await CoreManager.Instance.LoadCore(mainContext, preContext);
+    }
+
+    private void RegisterNetworkChangeMonitor()
+    {
+        if (!Utils.IsWindows() || _networkChangeMonitorRegistered)
+        {
+            return;
+        }
+
+        if (!WindowsNetworkUtils.TryStartNetworkChangeMonitor())
+        {
+            return;
+        }
+
+        WindowsNetworkUtils.NetworkChanged += OnNetworkChanged;
+        _networkChangeMonitorRegistered = true;
+    }
+
+    private void OnNetworkChanged(object? sender, EventArgs e)
+    {
+        _ = ScheduleLegacyTunProtectNetworkChangeCheck();
+    }
+
+    private async Task ScheduleLegacyTunProtectNetworkChangeCheck()
+    {
+        try
+        {
+            var version = Interlocked.Increment(ref _networkChangeVersion);
+            await Task.Delay(LegacyTunProtectNetworkChangeDelayMs);
+            if (version != _networkChangeVersion)
+            {
+                return;
+            }
+
+            await ReloadIfLegacyTunProtectBindInterfaceChanged();
+        }
+        catch (Exception ex)
+        {
+            Logging.SaveLog("Legacy TUN protect network change check failed", ex);
+        }
+    }
+
+    private async Task ReloadIfLegacyTunProtectBindInterfaceChanged()
+    {
+        if (!_legacyTunProtectBindInterfaceTracked
+            || !_config.TunModeItem.EnableTun
+            || !_config.TunModeItem.EnableLegacyProtect)
+        {
+            return;
+        }
+
+        var currentInterface = ResolvePreferredMainCoreBindInterface();
+        if (currentInterface.IsNullOrEmpty())
+        {
+            Logging.SaveLog("Network changed; no usable interface found for legacy TUN protect Xray binding.");
+            return;
+        }
+
+        if (currentInterface.Equals(_legacyTunProtectBindInterface, StringComparison.OrdinalIgnoreCase)
+            && Utils.IsUsableRealNetworkInterface(_legacyTunProtectBindInterface))
+        {
+            return;
+        }
+
+        var msg =
+            $"Network changed; reload legacy TUN protect Xray binding: {_legacyTunProtectBindInterface} -> {currentInterface}";
+        Logging.SaveLog(msg);
+        NoticeManager.Instance.SendMessage(msg);
+        await Reload();
+    }
+
+    private void UpdateLegacyTunProtectBindInterfaceSnapshot(CoreConfigContextBuilderAllResult allResult)
+    {
+        var mainContext = allResult.MainResult.Context;
+        var preContext = allResult.PreSocksResult?.Context;
+        _legacyTunProtectBindInterfaceTracked = IsLegacyTunProtectXrayBindContext(mainContext, preContext);
+        _legacyTunProtectBindInterface = _legacyTunProtectBindInterfaceTracked
+            ? mainContext.AppConfig.CoreBasicItem.BindInterface ?? string.Empty
+            : string.Empty;
+        _legacyTunProtectBindDestination = _legacyTunProtectBindInterfaceTracked
+            ? mainContext.Node.Address ?? string.Empty
+            : string.Empty;
+    }
+
+    private bool IsLegacyTunProtectXrayBindContext(CoreConfigContext mainContext, CoreConfigContext? preContext)
+    {
+        return Utils.IsWindows()
+               && _config.TunModeItem.EnableTun
+               && _config.TunModeItem.EnableLegacyProtect
+               && IsLegacyTunProtectBindInterfaceAutoResolved()
+               && mainContext.RunCoreType == ECoreType.Xray
+               && preContext?.RunCoreType == ECoreType.sing_box
+               && preContext.Node.ConfigType == EConfigType.SOCKS
+               && Utils.IsLoopbackAddress(preContext.Node.Address)
+               && preContext.Node.Port == AppManager.Instance.GetLocalPort(EInboundProtocol.socks);
+    }
+
+    private bool IsLegacyTunProtectBindInterfaceAutoResolved()
+    {
+        var bindInterface = _config.CoreBasicItem.BindInterface?.TrimEx();
+        if (!bindInterface.IsNullOrEmpty() && Utils.ContainsInterfaceName(bindInterface))
+        {
+            return false;
+        }
+
+        return !Utils.HasEffectiveSendThrough(
+            _config.CoreBasicItem.SendThrough,
+            _config.TunModeItem.StrictRoute);
+    }
+
+    private string ResolvePreferredMainCoreBindInterface()
+    {
+        return Utils.GetPreferredRealNetworkInterface(
+            _config.CoreBasicItem.BindInterface,
+            _legacyTunProtectBindDestination);
     }
 
     #endregion core job


### PR DESCRIPTION
对 Windows 下“启用 TUN + 旧版 TUN 保护 + 主 core 为 Xray + pre-service 为 sing-box”的链路做了几处补充：

1. 启动 pre-service 前增加本地 SOCKS 端口检查
CoreStart(mainContext) 后，先等待主 Xray 的本地 SOCKS 端口可连接，再启动 sing-box TUN pre-service。
如果主 core 已退出或端口等待超时，则跳过 pre-service，并写入明确日志，避免 TUN 先接管路由但本地 SOCKS 尚未可用。
2. 旧版 TUN 保护下为主 Xray 自动绑定真实出口网口
在上述链路中，主 Xray 自身连接节点时也可能受到 TUN 路由影响。
本 PR 在生成运行时配置时，为主 Xray 自动写入 sockopt.interface，选择逻辑参考 sing-box/sing-tun 的默认出口判断：
用户显式填写有效 BindInterface 时，尊重用户配置
非 strict_route 且用户填写有效 SendThrough 时，尊重用户源地址，不自动绑定网口
否则先按节点地址匹配本机接口地址/前缀
再回退到 Windows IPv4 默认路由中 metric 最低的真实网口
过滤虚拟网卡和 loopback 网卡
该处理只修改运行时生成的配置，不写回用户配置。
3. 网络出口变化时自动重新判断绑定网口
当系统路由或网口状态变化时，若当前处于自动绑定场景，会延迟重新判断默认出口网口。
如果出口网口发生变化，则自动 reload，使主 Xray 的出站绑定跟随真实出口变化。
4. 停止顺序和进程退出等待
停止 core 时先停止 pre-service，再停止主 core。
ProcessService.StopAsync() 中 kill 后等待进程实际退出，减少 TUN/Wintun 或端口资源尚未释放就再次启动的情况。

这部分主要是把 sing-box TUN 已有的默认出口判断补到旧版 TUN 保护下的主 Xray 链路中，避免用户在多网口环境下必须手动填写 BindInterface。若这个方向可接受，我可以继续按维护建议调整实现范围和代码结构，以及做其他系统适配。