### PR TITLE
Update build-linux.yml

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -258,7 +258,7 @@ jobs:
         export VIRTIOFSD_SOCKET="$RUNNER_TEMP/virtiofs-deb-loong64.sock"
         rm -f "$VIRTIOFSD_SOCKET"
 
-        sudo virtiofsd --socket-path="$VIRTIOFSD_SOCKET" -o source="$GITHUB_WORKSPACE" -o cache=auto &
+        sudo virtiofsd --socket-path="$VIRTIOFSD_SOCKET" --shared-dir="$GITHUB_WORKSPACE" --cache=auto &
 
         VIRTIOFSD_PID=$!
         trap 'sudo kill "$VIRTIOFSD_PID" 2>/dev/null || true; rm -f "$VIRTIOFSD_SOCKET"' EXIT
@@ -408,7 +408,7 @@ jobs:
         export VIRTIOFSD_SOCKET="$RUNNER_TEMP/virtiofs-rpm-loong64.sock"
         rm -f "$VIRTIOFSD_SOCKET"
 
-        sudo virtiofsd --socket-path="$VIRTIOFSD_SOCKET" -o source="$GITHUB_WORKSPACE" -o cache=auto &
+        sudo virtiofsd --socket-path="$VIRTIOFSD_SOCKET" --shared-dir="$GITHUB_WORKSPACE" --cache=auto &
 
         VIRTIOFSD_PID=$!
         trap 'sudo kill "$VIRTIOFSD_PID" 2>/dev/null || true; rm -f "$VIRTIOFSD_SOCKET"' EXIT

--- a/package-debian-loong.sh
+++ b/package-debian-loong.sh
@@ -116,20 +116,7 @@ install_dependencies() {
 
     export PATH="$HOME/.dotnet:$PATH"
     export DOTNET_ROOT="$HOME/.dotnet"
-
-    mkdir -p "$HOME/.nuget/NuGet"
-
-    cat > "$HOME/.nuget/NuGet/NuGet.Config" <<EOF
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="loongnix" value="https://lnuget.loongnix.cn/v3/index.json" allowInsecureConnections="true" />
-  </packageSources>
-</configuration>
-EOF
-
+    
     dotnet --info >/dev/null 2>&1 && install_ok=1
   fi
 

--- a/package-debian-loong.sh
+++ b/package-debian-loong.sh
@@ -8,7 +8,7 @@ BUILD_FROM=""
 XRAY_VER="${XRAY_VER:-}"
 SING_VER="${SING_VER:-}"
 
-MIN_KERNEL="5.10"
+MIN_KERNEL="6.12"
 PKGROOT="v2rayN-publish"
 PROJECT_HINT="v2rayN.Desktop/v2rayN.Desktop.csproj"
 OUTPUT_DIR="${HOME}/debbuild"

--- a/package-rhel-loong.sh
+++ b/package-rhel-loong.sh
@@ -8,7 +8,7 @@ BUILD_FROM=""
 XRAY_VER="${XRAY_VER:-}"
 SING_VER="${SING_VER:-}"
 
-MIN_KERNEL="5.10"
+MIN_KERNEL="6.12"
 PKGROOT="v2rayN-publish"
 PROJECT_HINT="v2rayN.Desktop/v2rayN.Desktop.csproj"
 RPM_TOPDIR="${HOME}/rpmbuild"

--- a/package-rhel-loong.sh
+++ b/package-rhel-loong.sh
@@ -112,20 +112,7 @@ install_dependencies() {
 
     export PATH="$HOME/.dotnet:$PATH"
     export DOTNET_ROOT="$HOME/.dotnet"
-
-    mkdir -p "$HOME/.nuget/NuGet"
-
-    cat > "$HOME/.nuget/NuGet/NuGet.Config" <<EOF
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="loongnix" value="https://lnuget.loongnix.cn/v3/index.json" allowInsecureConnections="true" />
-  </packageSources>
-</configuration>
-EOF
-
+    
     dotnet --info >/dev/null 2>&1 || install_ok=0
   fi
 


### PR DESCRIPTION
[WARN  virtiofsd] Use of deprecated option format '-o': Please specify options without it (e.g., '--cache auto' instead of '-o cache=auto')

迁移新要求