### PR TITLE
Fix speed test result display issues

### DIFF
--- a/v2rayN/ServiceLib/Helper/DownloaderHelper.cs
+++ b/v2rayN/ServiceLib/Helper/DownloaderHelper.cs
@@ -111,7 +111,8 @@ public class DownloaderHelper
                 }
                 else if (value.Error != null)
                 {
-                    progress.Report(value.Error?.Message);
+                    Logging.SaveLog("DownloaderHelper", value.Error);
+                    progress.Report(ResUI.SpeedtestingSkip);
                 }
                 else
                 {

--- a/v2rayN/ServiceLib/Services/DownloadService.cs
+++ b/v2rayN/ServiceLib/Services/DownloadService.cs
@@ -30,11 +30,8 @@ public class DownloadService
         }
         catch (Exception ex)
         {
-            await updateFunc?.Invoke(false, ex.Message);
-            if (ex.InnerException != null)
-            {
-                await updateFunc?.Invoke(false, ex.InnerException.Message);
-            }
+            Logging.SaveLog(_tag, ex);
+            await updateFunc?.Invoke(false, ResUI.SpeedtestingSkip);
         }
         return 0;
     }

--- a/v2rayN/ServiceLib/Services/SpeedtestService.cs
+++ b/v2rayN/ServiceLib/Services/SpeedtestService.cs
@@ -15,8 +15,15 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
     {
         Task.Run(async () =>
         {
-            await RunAsync(actionType, selecteds);
+            var wasStopped = await RunAsync(actionType, selecteds);
             await ProfileExManager.Instance.SaveTo();
+
+            //Refresh the UI from the saved test results when the test was terminated,
+            //so that the remaining "Testing..." placeholders are cleared
+            if (wasStopped)
+            {
+                AppEvents.ProfilesRefreshRequested.Publish();
+            }
             await UpdateFunc("", ResUI.SpeedtestingCompleted);
         });
     }
@@ -36,7 +43,7 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
         return _lstExitLoop.All(p => p != exitLoopKey);
     }
 
-    private async Task RunAsync(ESpeedActionType actionType, List<ProfileItem> selecteds)
+    private async Task<bool> RunAsync(ESpeedActionType actionType, List<ProfileItem> selecteds)
     {
         var exitLoopKey = Utils.GetGuid(false);
         _lstExitLoop.Add(exitLoopKey);
@@ -65,6 +72,8 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
                 await RunMixedTestAsync(lstSelected, _config.SpeedTestItem.MixedConcurrencyCount, true, exitLoopKey);
                 break;
         }
+
+        return ShouldStopTest(exitLoopKey);
     }
 
     private async Task<List<ServerTestItem>> GetClearItem(ESpeedActionType actionType, List<ProfileItem> selecteds)

--- a/v2rayN/ServiceLib/Services/SpeedtestService.cs
+++ b/v2rayN/ServiceLib/Services/SpeedtestService.cs
@@ -375,7 +375,8 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
                     processService = await CoreManager.Instance.LoadCoreConfigSpeedtest(it);
                     if (processService is null)
                     {
-                        await UpdateFunc(it.IndexId, "", ResUI.FailedToRunCore);
+                        ProfileExManager.Instance.SetTestDelay(it.IndexId, -1);
+                        await UpdateFunc(it.IndexId, "-1", ResUI.FailedToRunCore);
                         return;
                     }
 


### PR DESCRIPTION
### What this PR does

Fixes three small issues with how speed test results are displayed.

**1. Raw exception resource keys shown in the Speed column**

When a download speed test fails, the raw exception message is displayed in the Speed column. Since Release builds are published with `UseSystemResourceKeys=true`, .NET exception messages are trimmed down to their resource keys, so users see cryptic untranslatable identifiers such as:

- `OperationCanceled`
- `net_http_ssl_connection_failed`
- `TaskCanceledException_ctor_DefaultMessage`

| Delay (ms) | Speed (MB/s) |
|---|---|
| 322 | TaskCanceledException_ctor_DefaultMessage |
| 68 | 49,7 |
| 55 | net_http_ssl_connection_failed |

Fix: display the existing localized `ResUI.SpeedtestingSkip` string instead (reuses an existing resource key, so no new translations are required), and write the actual exception to the log file so the failure details are not lost.

**2. Empty Delay when the core fails to run**

During a speed test, when the core fails to start ("Failed to run Core, please check the prompt information"), the Delay column is left empty instead of showing `-1` like every other failed test.

Fix: set the test delay to `-1` (both in the UI and in the stored profile results).

**3. Stale "Testing..." placeholders after the test is terminated with ESC**

When a running test is terminated with ESC, the servers that were not tested keep the red "Testing..." placeholder in the Delay column indefinitely (until a manual refresh), even after "Test completed" is logged.

Fix: when the test loop finishes after being stopped, refresh the profiles list from the saved test results, which clears the leftover placeholders.
