### PR TITLE
Persist Check Update window selection when toggled

### DIFF
--- a/v2rayN/ServiceLib/Models/Dto/CheckUpdateModel.cs
+++ b/v2rayN/ServiceLib/Models/Dto/CheckUpdateModel.cs
@@ -2,7 +2,7 @@ namespace ServiceLib.Models.Dto;
 
 public class CheckUpdateModel : ReactiveObject
 {
-    public bool? IsSelected { get; set; }
+    [Reactive] public bool? IsSelected { get; set; }
     public ECoreType? CoreType { get; set; }
     [Reactive] public string? Remarks { get; set; }
     public string? FileName { get; set; }

--- a/v2rayN/ServiceLib/ViewModels/CheckUpdateViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/CheckUpdateViewModel.cs
@@ -51,6 +51,13 @@ public class CheckUpdateViewModel : MyReactiveObject
 
         CheckUpdateModels.Clear();
         CheckUpdateModels.AddRange(models);
+
+        foreach (var model in models)
+        {
+            model.WhenAnyValue(x => x.IsSelected)
+                .Skip(1)
+                .Subscribe(c => _ = SaveSelectedCoreTypes());
+        }
     }
 
     private CheckUpdateModel GetCheckUpdateModel(ECoreType coreType)


### PR DESCRIPTION
### What this PR does

In the Check Update window, the per-item toggles (v2rayN, Xray, sing-box, mihomo, GeoFiles) are only persisted when one of the check/update buttons is pressed (`CheckOnlyTask`/`CheckUpdateTask` call `SaveSelectedCoreTypes`). If the user just toggles the switches and closes the window, the selection is silently lost and reverts to the previous state on the next launch.

### Changes

- Make `CheckUpdateModel.IsSelected` reactive.
- Subscribe to selection changes in `CheckUpdateViewModel` and save the selection immediately when a toggle is changed (`.Skip(1)` avoids a redundant save of the initial values).

### How to reproduce (before)

1. Open Check Update window, turn off a few items.
2. Close the window without pressing any button.
3. Restart the app and open the window again: the toggles are back to their previous state.
