### PR TITLE
Loosen minimum OS versions in packaging scripts

### DIFF
--- a/package-debian-loong.sh
+++ b/package-debian-loong.sh
@@ -597,7 +597,7 @@ package_binary() {
   write_desktop_file "$stage"
   write_maintainer_scripts "$debian_dir"
 
-  extra_depends="libc6 (>= 2.39), fontconfig (>= 2.15.0), desktop-file-utils (>= 0.26), xdg-utils (>= 1.2.0), coreutils (>= 9.5), bash (>= 5.2.26), libfreetype6 (>= 2.13)"
+  extra_depends="libc6 (>= 2.34), fontconfig (>= 2.13.1), desktop-file-utils (>= 0.26), xdg-utils (>= 1.1.3), coreutils (>= 8.32), bash (>= 5.1), libfreetype6 (>= 2.11)"
 
   mkdir -p "$workdir/debian"
   cat > "$workdir/debian/control" <<EOF

--- a/package-debian-riscv.sh
+++ b/package-debian-riscv.sh
@@ -595,7 +595,7 @@ package_binary() {
   write_desktop_file "$stage"
   write_maintainer_scripts "$debian_dir"
 
-  extra_depends="libc6 (>= 2.39), fontconfig (>= 2.15.0), desktop-file-utils (>= 0.26), xdg-utils (>= 1.2.0), coreutils (>= 9.5), bash (>= 5.2.26), libfreetype6 (>= 2.13)"
+  extra_depends="libc6 (>= 2.34), fontconfig (>= 2.13.1), desktop-file-utils (>= 0.26), xdg-utils (>= 1.1.3), coreutils (>= 8.32), bash (>= 5.1), libfreetype6 (>= 2.11)"
 
   mkdir -p "$workdir/debian"
   cat > "$workdir/debian/control" <<EOF

--- a/package-debian.sh
+++ b/package-debian.sh
@@ -609,7 +609,7 @@ package_binary() {
   write_desktop_file "$stage"
   write_maintainer_scripts "$debian_dir"
 
-  extra_depends="libc6 (>= 2.39), fontconfig (>= 2.15.0), desktop-file-utils (>= 0.26), xdg-utils (>= 1.2.0), coreutils (>= 9.5), bash (>= 5.2.26), libfreetype6 (>= 2.13)"
+  extra_depends="libc6 (>= 2.34), fontconfig (>= 2.13.1), desktop-file-utils (>= 0.26), xdg-utils (>= 1.1.3), coreutils (>= 8.32), bash (>= 5.1), libfreetype6 (>= 2.11)"
 
   mkdir -p "$workdir/debian"
   cat > "$workdir/debian/control" <<EOF

--- a/package-osx.sh
+++ b/package-osx.sh
@@ -54,7 +54,7 @@ cat >"$PackagePath/v2rayN.app/Contents/Info.plist" <<-EOF
   <key>NSHighResolutionCapable</key>
   <true/>
   <key>LSMinimumSystemVersion</key>
-  <string>13.7</string>
+  <string>12.7</string>
 </dict>
 </plist>
 EOF

--- a/package-rhel-loong.sh
+++ b/package-rhel-loong.sh
@@ -510,13 +510,13 @@ ExclusiveArch:  loongarch64
 Source0:        __PKGROOT__.tar.gz
 
 Requires:       cairo, pango, openssl, mesa-libEGL, mesa-libGL
-Requires:       glibc >= 2.39
-Requires:       fontconfig >= 2.15.0
+Requires:       glibc >= 2.34
+Requires:       fontconfig >= 2.13.1
 Requires:       desktop-file-utils >= 0.26
-Requires:       xdg-utils >= 1.2.0
-Requires:       coreutils >= 9.5
-Requires:       bash >= 5.2.26
-Requires:       freetype >= 2.13
+Requires:       xdg-utils >= 1.1.3
+Requires:       coreutils >= 8.32
+Requires:       bash >= 5.1
+Requires:       freetype >= 2.10
 
 %description
 v2rayN Linux for Red Hat Enterprise Linux

--- a/package-rhel-riscv.sh
+++ b/package-rhel-riscv.sh
@@ -509,13 +509,13 @@ ExclusiveArch:  riscv64
 Source0:        __PKGROOT__.tar.gz
 
 Requires:       cairo, pango, openssl, mesa-libEGL, mesa-libGL
-Requires:       glibc >= 2.39
-Requires:       fontconfig >= 2.15.0
+Requires:       glibc >= 2.34
+Requires:       fontconfig >= 2.13.1
 Requires:       desktop-file-utils >= 0.26
-Requires:       xdg-utils >= 1.2.0
-Requires:       coreutils >= 9.5
-Requires:       bash >= 5.2.26
-Requires:       freetype >= 2.13
+Requires:       xdg-utils >= 1.1.3
+Requires:       coreutils >= 8.32
+Requires:       bash >= 5.1
+Requires:       freetype >= 2.10
 
 %description
 v2rayN Linux for Red Hat Enterprise Linux

--- a/package-rhel.sh
+++ b/package-rhel.sh
@@ -498,13 +498,13 @@ ExclusiveArch:  aarch64 x86_64
 Source0:        __PKGROOT__.tar.gz
 
 Requires:       cairo, pango, openssl, mesa-libEGL, mesa-libGL
-Requires:       glibc >= 2.39
-Requires:       fontconfig >= 2.15.0
+Requires:       glibc >= 2.34
+Requires:       fontconfig >= 2.13.1
 Requires:       desktop-file-utils >= 0.26
-Requires:       xdg-utils >= 1.2.0
-Requires:       coreutils >= 9.5
-Requires:       bash >= 5.2.26
-Requires:       freetype >= 2.13
+Requires:       xdg-utils >= 1.1.3
+Requires:       coreutils >= 8.32
+Requires:       bash >= 5.1
+Requires:       freetype >= 2.10
 
 %description
 v2rayN Linux for Red Hat Enterprise Linux


### PR DESCRIPTION
## 背景

#9710 将 Debian/Ubuntu 系打包脚本（package-debian.sh 等）的最低依赖版本
从 xdg-utils (>= 1.1.3) / coreutils (>= 8.32) / bash (>= 5.1)
上调至对应 Debian 13 / Ubuntu 26.04 的版本水平。

在原 PR 的 review 中，@2dust 曾提出疑问"好处是什么？"，
有人回复给出的理由是"至少 Native AOT 可以考虑"，但没有进一步说明：
- 具体是哪个功能点依赖了这些新版本才有的特性
- 是否有实际测试验证旧版本会导致功能异常

## 这次改动的问题

1. **抬高门槛没有对应的功能依赖证据**
   xdg-utils/coreutils/bash 在这次提升的版本区间内  （1.1.3→更新版本、8.32→更新版本、5.1→更新版本），   接口层面（xdg-open、基础文件操作命令、bash 脚本语法）没有变化，   v2rayN 目前的调用方式不依赖这个区间内新增的任何特性。

2. **把大量仍在官方安全支持期内的用户挡在门外**
   Ubuntu 24.04 LTS 标准支持到 2029 年 5 月，   Debian 12 也仍在支持期内，这些系统的 bash/coreutils/xdg-utils 版本天然达不到 Debian 13 / Ubuntu 26.04 的门槛，   但功能上完全没有问题——我本人在 Ubuntu 24.04 上用 equivs 虚拟包绕过依赖检查后实测均正常。如果只是“考虑将来可能用到 Native AOT”，不应该现在就以此为由抬高所有用户的门槛，等真正需要时再针对性提升更合理。

## 建议

回退这几个版本号门槛，改回：
xdg-utils (>= 1.1.3), coreutils (>= 8.32), bash (>= 5.1)
