### PR TITLE
Refactor password check to use string.IsNullOrEmpty

### DIFF
--- a/v2rayN/v2rayN.Desktop/Views/SudoPasswordInputView.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/SudoPasswordInputView.axaml.cs
@@ -21,7 +21,7 @@ public partial class SudoPasswordInputView : UserControl
 
     private async Task SavePasswordAsync()
     {
-        if (txtPassword.Text.IsNullOrEmpty())
+        if (string.IsNullOrEmpty(txtPassword.Text))
         {
             txtPassword.Focus();
             return;


### PR DESCRIPTION
fix: eliminate the impact of string.IsNullOrWhiteSpace to allow whitespace passwords