### PR TITLE
feat: add connection keep-alive for subscription groups

### DIFF
--- a/docs/keep-alive-plan.md
+++ b/docs/keep-alive-plan.md
@@ -1,0 +1,281 @@
+# 连接保活功能实现计划
+
+## 一、需求概述
+
+在 v2rayN 的【订阅分组设置】中为每个订阅分组增加【连接保活】开关。启用后，系统会定期检测当前活动节点的可用性；当当前节点不可用时，自动在该订阅分组内寻找真连接延迟最小的可用节点并切换；若全部分组节点均不可用，则触发订阅更新。订阅更新（自动或手动）后若当前活动节点丢失，也执行同样的检测与切换逻辑。
+
+## 二、设计确认
+
+| 项目 | 确认结果 |
+|---|---|
+| 按钮形态 | 开关（Toggle），在订阅分组编辑窗口启用/停用 |
+| 检查间隔 | 默认 10 分钟，提供输入框可配置 |
+| 最快节点 | 按**真连接延迟最小**选择 |
+| 作用范围 | 配置在 `SubItem`（订阅分组）上；只有当前活动节点属于该分组时才执行保活 |
+| 更新后兜底 | 更新后若当前节点丢失，立刻测试并切换最快可用节点；若全部不可用，**不发更新**，只告警，等下次保活检查周期再触发更新 |
+| 告警频率 | 由 `KeepAliveInterval` 控制，不会刷屏 |
+
+## 三、涉及文件清单
+
+### 新增
+- `ServiceLib/Manager/KeepAliveManager.cs`
+
+### 修改
+- `ServiceLib/Models/Entities/SubItem.cs`
+- `ServiceLib/Handler/ConfigHandler.cs`
+- `ServiceLib/Handler/ConnectionHandler.cs`
+- `ServiceLib/Services/SpeedtestService.cs`
+- `ServiceLib/Manager/ProfileExManager.cs`
+- `ServiceLib/Manager/TaskManager.cs`
+- `ServiceLib/ViewModels/MainWindowViewModel.cs`
+- `ServiceLib/Resx/ResUI.resx`、`ResUI.zh-Hans.resx`
+- `v2rayN/Views/SubEditWindow.xaml`
+- `v2rayN/Views/SubEditWindow.xaml.cs`
+- `v2rayN/Views/SubSettingWindow.xaml`
+- `v2rayN.Desktop/Views/SubEditWindow.axaml`
+- `v2rayN.Desktop/Views/SubEditWindow.axaml.cs`
+- `v2rayN.Desktop/Views/SubSettingWindow.axaml`
+
+## 四、详细修改步骤
+
+### 1. 数据模型（SubItem）
+
+在 `ServiceLib/Models/Entities/SubItem.cs` 中新增字段：
+
+```csharp
+public bool KeepAlive { get; set; }
+public int KeepAliveInterval { get; set; } = 10; // 分钟
+public long KeepAliveLastCheck { get; set; }
+public long KeepAliveLastUpdate { get; set; }
+```
+
+### 2. 持久化（ConfigHandler.AddSubItem）
+
+在 `ServiceLib/Handler/ConfigHandler.cs` 的 `AddSubItem(Config, SubItem)` 映射逻辑中增加：
+
+```csharp
+item.KeepAlive = subItem.KeepAlive;
+item.KeepAliveInterval = subItem.KeepAliveInterval;
+item.KeepAliveLastCheck = subItem.KeepAliveLastCheck;
+item.KeepAliveLastUpdate = subItem.KeepAliveLastUpdate;
+```
+
+### 3. 资源字符串
+
+在 `ServiceLib/Resx/ResUI.resx` 和 `ServiceLib/Resx/ResUI.zh-Hans.resx` 中新增：
+
+- `LvKeepAlive` → 连接保活
+- `LvKeepAliveInterval` → 保活间隔（分钟）
+- `MsgKeepAliveSwitched` → 保活：已切换至节点 {0}
+- `MsgKeepAliveAllFailed` → 保活：订阅 {0} 全部节点不可用，下次检查将尝试更新
+
+### 4. UI（SubEditWindow）
+
+在 WPF / Avalonia 的订阅分组编辑窗口中增加一行：
+- 标签：`LvKeepAlive`
+- 开关：`togKeepAlive`
+- 间隔输入框：`txtKeepAliveInterval`（仅启用保活时可用）
+
+并在 `SubSettingWindow` 列表中增加 `KeepAlive` 和 `KeepAliveInterval` 两列，方便查看状态。
+
+### 5. ConnectionHandler 暴露当前节点延迟
+
+在 `ServiceLib/Handler/ConnectionHandler.cs` 中新增公共方法：
+
+```csharp
+public static async Task<int> GetCurrentRealPingAsync()
+{
+    return await GetRealPingTimeInfo();
+}
+```
+
+用于保活服务直接测试当前活动节点。
+
+### 6. SpeedtestService 支持可等待
+
+把 `ServiceLib/Services/SpeedtestService.cs` 中现有的 `RunAsync` 重命名为 `RunInternalAsync`，新增公共方法：
+
+```csharp
+public async Task RunAsync(ESpeedActionType actionType, List<ProfileItem> selecteds)
+{
+    await RunInternalAsync(actionType, selecteds);
+    await ProfileExManager.Instance.SaveTo();
+    await UpdateFunc("", ResUI.SpeedtestingCompleted);
+}
+```
+
+`RunLoop` 改为 `Task.Run(() => RunAsync(...))` 的包装。
+
+### 7. ProfileExManager 增加读取方法
+
+在 `ServiceLib/Manager/ProfileExManager.cs` 中新增：
+
+```csharp
+public int GetTestDelay(string? indexId)
+{
+    var profileEx = _lstProfileEx.FirstOrDefault(t => t.IndexId == indexId);
+    return profileEx?.Delay ?? 0;
+}
+```
+
+保活测试完成后用此取延迟。
+
+### 8. KeepAliveManager（核心）
+
+新增 `ServiceLib/Manager/KeepAliveManager.cs`：
+
+```csharp
+public class KeepAliveManager
+{
+    public static KeepAliveManager Instance { get; }
+
+    public void Init(Config config, Func<Task> reloadFunc, Func<bool, string, Task> updateFunc)
+
+    public async Task RunKeepAliveAsync()          // 周期性入口
+    public async Task RunPostUpdateFallbackAsync(string subId) // 更新后兜底
+}
+```
+
+#### `RunKeepAliveAsync` 流程：
+1. 取当前活动节点 `activeProfile`
+2. 若为空，返回
+3. 取 `subItem = activeProfile.Subid`
+4. 若 `subItem.KeepAlive == false`，返回
+5. 判断 `now - subItem.KeepAliveLastCheck >= KeepAliveInterval * 60`
+6. 测试当前节点：`ConnectionHandler.GetCurrentRealPingAsync()`
+7. 若延迟 > 0，更新 `KeepAliveLastCheck`，返回
+8. 否则获取该分组下所有节点，执行 `SpeedtestService.RunAsync(Realping)`
+9. 取延迟 > 0 的节点，选最小值：
+   - 找到 → `SetDefaultServerIndex` + `Reload` + 通知
+   - 未找到 → 若 `now - KeepAliveLastUpdate >= interval` 则调用 `SubscriptionHandler.UpdateProcess` 并更新 `KeepAliveLastUpdate`；否则只告警
+
+#### `RunPostUpdateFallbackAsync` 流程：
+1. 若 `subItem.KeepAlive == false`，返回
+2. 获取该分组所有节点，执行 Realping
+3. 若找到可用节点，切换最快并 `Reload`
+4. 若未找到，**只告警不发更新**，等待下次 `RunKeepAliveAsync`
+
+### 9. 调度入口（TaskManager）
+
+在 `ServiceLib/Manager/TaskManager.cs` 的 `ScheduledTasks` 的 60 秒循环中，于 `UpdateTaskRunSubscription` 之后调用：
+
+```csharp
+try
+{
+    await KeepAliveManager.Instance.RunKeepAliveAsync();
+}
+catch (Exception ex)
+{
+    Logging.SaveLog("ScheduledTasks - KeepAlive", ex);
+}
+```
+
+### 10. 订阅更新回调签名扩展
+
+为了让 `UpdateTaskHandler` 知道“是哪个分组被更新了”，把 `SubscriptionHandler.UpdateProcess` 的回调从 `Func<bool, string, Task>` 改为 `Func<bool, string, string, Task>`（第三个参数为 `subId`）。
+
+同步修改：
+- `TaskManager._updateFunc`
+- `TaskManager.RegUpdateTask`
+- `MainWindowViewModel.UpdateTaskHandler`
+- `MainWindowViewModel.UpdateSubscriptionProcess`
+
+### 11. 更新后兜底（MainWindowViewModel）
+
+在 `ServiceLib/ViewModels/MainWindowViewModel.cs` 的 `UpdateTaskHandler` 中，更新成功后：
+
+```csharp
+var indexIdOld = _config.IndexId;
+await RefreshServers();
+
+var profile = await AppManager.Instance.GetProfileItem(_config.IndexId);
+if (profile == null)
+{
+    var fallbackSubId = subId.IsNullOrEmpty() ? _config.SubIndexId : subId;
+    if (fallbackSubId.IsNotEmpty())
+    {
+        await KeepAliveManager.Instance.RunPostUpdateFallbackAsync(fallbackSubId);
+    }
+}
+else if (...)
+{
+    await Reload();
+}
+```
+
+### 12. 初始化
+
+在 `ServiceLib/ViewModels/MainWindowViewModel.cs` 的 `Init` 中：
+
+```csharp
+TaskManager.Instance.RegUpdateTask(_config, UpdateTaskHandler);
+KeepAliveManager.Instance.Init(_config, Reload, UpdateTaskHandler);
+```
+
+## 五、流程图
+
+```
+开始
+  │
+  ▼
+获取当前活动节点 activeProfile
+  │
+  ▼
+activeProfile 为空？ ──是──→ 返回
+  │否
+  ▼
+activeProfile 所在 SubItem 的 KeepAlive？
+  │
+否──→ 返回
+  │
+是
+  ▼
+是否到达检查间隔？
+  │
+否──→ 返回
+  │
+是
+  ▼
+测试当前节点延迟
+  │
+  ▼
+延迟 > 0？
+  │
+是──→ 更新 lastCheck，返回
+  │
+否
+  ▼
+对该分组所有节点执行 Realping
+  │
+  ▼
+存在延迟 > 0 的节点？
+  │
+是──→ 选延迟最小者，SetDefaultServerIndex，Reload，通知
+  │
+否
+  ▼
+距离上次更新 >= 间隔？
+  │
+是──→ 触发 SubscriptionHandler.UpdateProcess，更新 lastUpdate
+  │
+否──→ 告警（通知+日志），等下次周期
+```
+
+## 六、边界与风险
+
+1. **并发**：保活测试和手动测速不能同时运行。`KeepAliveManager` 内部加 `_isRunning` 锁，避免冲突。
+2. **自定义节点**：当前活动节点若不属于任何 SubItem（`Subid` 为空），保活不执行。
+3. **告警频率**：每次失败都告警可能刷屏。由于 `KeepAliveInterval` 已控制检查周期，10 分钟内只告警一次。
+4. **Core 冲突**：`SpeedtestService` 会启动独立测试 Core，与当前运行 Core 不冲突，但要确保测试完成后再 `Reload`。
+5. **多订阅更新**：`subId = ""` 的全量更新时，回调传入的 `subId` 为空，兜底会退回到 `_config.SubIndexId`；若用户未选中分组，则无法兜底。可考虑在 `UpdateSubscriptionProcess` 调用前保存当前节点 `Subid` 作为备用。
+
+## 七、实现顺序建议
+
+1. 后端数据模型与持久化（SubItem、ConfigHandler）
+2. 资源字符串
+3. 核心服务（KeepAliveManager）
+4. 测速服务改造（SpeedtestService、ConnectionHandler、ProfileExManager）
+5. 更新回调签名调整（TaskManager、MainWindowViewModel）
+6. UI（SubEditWindow / SubSettingWindow 的 WPF 与 Avalonia）
+7. 调度接入（TaskManager）
+8. 测试与边界验证

--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -2011,6 +2011,10 @@ public static class ConfigHandler
             item.Url = subItem.Url;
             item.MoreUrl = subItem.MoreUrl;
             item.Enabled = subItem.Enabled;
+            item.KeepAlive = subItem.KeepAlive;
+            item.KeepAliveInterval = subItem.KeepAliveInterval;
+            item.KeepAliveLastCheck = subItem.KeepAliveLastCheck;
+            item.KeepAliveLastUpdate = subItem.KeepAliveLastUpdate;
             item.AutoUpdateInterval = subItem.AutoUpdateInterval;
             item.UserAgent = subItem.UserAgent;
             item.Sort = subItem.Sort;

--- a/v2rayN/ServiceLib/Handler/ConnectionHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConnectionHandler.cs
@@ -16,6 +16,14 @@ public static class ConnectionHandler
     }
 
     /// <summary>
+    /// Gets real ping time for the currently active proxy connection.
+    /// </summary>
+    public static async Task<int> GetCurrentRealPingAsync()
+    {
+        return await GetRealPingTimeInfo();
+    }
+
+    /// <summary>
     /// Gets IP information using the default local proxy.
     /// </summary>
     private static async Task<string?> GetIPInfo()

--- a/v2rayN/ServiceLib/Manager/KeepAliveManager.cs
+++ b/v2rayN/ServiceLib/Manager/KeepAliveManager.cs
@@ -1,0 +1,190 @@
+namespace ServiceLib.Manager;
+
+public class KeepAliveManager
+{
+    private static readonly Lazy<KeepAliveManager> _instance = new(() => new());
+    public static KeepAliveManager Instance => _instance.Value;
+
+    private static readonly string _tag = "KeepAliveManager";
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+
+    private Config _config = null!;
+    private Func<Task> _reloadFunc = null!;
+    private Func<bool, string, Task> _updateFunc = null!;
+
+    public void Init(Config config, Func<Task> reloadFunc, Func<bool, string, Task> updateFunc)
+    {
+        _config = config;
+        _reloadFunc = reloadFunc;
+        _updateFunc = updateFunc;
+    }
+
+    public async Task RunKeepAliveAsync()
+    {
+        if (!await _semaphore.WaitAsync(0))
+        {
+            return;
+        }
+
+        try
+        {
+            await RunKeepAliveInternalAsync();
+        }
+        catch (Exception ex)
+        {
+            Logging.SaveLog(_tag, ex);
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    public async Task RunPostUpdateFallbackAsync(string subId)
+    {
+        await _semaphore.WaitAsync();
+
+        try
+        {
+            await RunPostUpdateFallbackInternalAsync(subId);
+        }
+        catch (Exception ex)
+        {
+            Logging.SaveLog(_tag, ex);
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    private async Task RunKeepAliveInternalAsync()
+    {
+        var activeProfile = await AppManager.Instance.GetProfileItem(_config.IndexId);
+        if (activeProfile == null)
+        {
+            return;
+        }
+
+        var subId = activeProfile.Subid;
+        if (subId.IsNullOrEmpty())
+        {
+            return;
+        }
+
+        var subItem = await AppManager.Instance.GetSubItem(subId);
+        if (subItem == null || !subItem.KeepAlive)
+        {
+            return;
+        }
+
+        var now = DateTimeOffset.Now.ToUnixTimeSeconds();
+        if (now - subItem.KeepAliveLastCheck < subItem.KeepAliveInterval * 60)
+        {
+            return;
+        }
+
+        subItem.KeepAliveLastCheck = now;
+        await ConfigHandler.AddSubItem(_config, subItem);
+
+        var delay = await ConnectionHandler.GetCurrentRealPingAsync();
+        if (delay > 0)
+        {
+            Logging.SaveLog($"{_tag}: current node {activeProfile.Remarks} is alive, delay {delay}");
+            return;
+        }
+
+        Logging.SaveLog($"{_tag}: current node {activeProfile.Remarks} failed, testing all nodes in subscription {subItem.Remarks}");
+
+        var bestIndexId = await FindBestNodeAsync(subId);
+        if (bestIndexId.IsNotEmpty())
+        {
+            await SwitchToBestNodeAsync(bestIndexId);
+            return;
+        }
+
+        if (now - subItem.KeepAliveLastUpdate >= subItem.KeepAliveInterval * 60)
+        {
+            Logging.SaveLog($"{_tag}: all nodes in subscription {subItem.Remarks} failed, triggering subscription update");
+            subItem.KeepAliveLastUpdate = now;
+            await ConfigHandler.AddSubItem(_config, subItem);
+            await SubscriptionHandler.UpdateProcess(_config, subId, true, _updateFunc);
+        }
+        else
+        {
+            var message = string.Format(ResUI.MsgKeepAliveAllFailed, subItem.Remarks);
+            NoticeManager.Instance.Enqueue(message);
+            Logging.SaveLog($"{_tag}: {message}");
+        }
+    }
+
+    private async Task RunPostUpdateFallbackInternalAsync(string subId)
+    {
+        if (subId.IsNullOrEmpty())
+        {
+            return;
+        }
+
+        var subItem = await AppManager.Instance.GetSubItem(subId);
+        if (subItem == null || !subItem.KeepAlive)
+        {
+            return;
+        }
+
+        Logging.SaveLog($"{_tag}: running post-update fallback for subscription {subItem.Remarks}");
+
+        var bestIndexId = await FindBestNodeAsync(subId);
+        if (bestIndexId.IsNotEmpty())
+        {
+            await SwitchToBestNodeAsync(bestIndexId);
+            return;
+        }
+
+        var message = string.Format(ResUI.MsgKeepAliveAllFailed, subItem.Remarks);
+        NoticeManager.Instance.Enqueue(message);
+        Logging.SaveLog($"{_tag}: {message}");
+    }
+
+    private async Task<string> FindBestNodeAsync(string subId)
+    {
+        var nodes = await AppManager.Instance.ProfileItems(subId);
+        if (nodes == null || nodes.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        foreach (var node in nodes)
+        {
+            ProfileExManager.Instance.SetTestDelay(node.IndexId, 0);
+        }
+
+        var speedtestService = new SpeedtestService(_config, _ => Task.CompletedTask);
+        await speedtestService.RunAsync(ESpeedActionType.Realping, nodes);
+
+        var bestIndexId = string.Empty;
+        var bestDelay = int.MaxValue;
+
+        foreach (var node in nodes)
+        {
+            var delay = ProfileExManager.Instance.GetTestDelay(node.IndexId);
+            if (delay > 0 && delay < bestDelay)
+            {
+                bestDelay = delay;
+                bestIndexId = node.IndexId;
+            }
+        }
+
+        return bestIndexId;
+    }
+
+    private async Task SwitchToBestNodeAsync(string indexId)
+    {
+        var profile = await AppManager.Instance.GetProfileItem(indexId);
+        await ConfigHandler.SetDefaultServerIndex(_config, indexId);
+        await _reloadFunc();
+
+        var message = string.Format(ResUI.MsgKeepAliveSwitched, profile?.Remarks ?? indexId);
+        NoticeManager.Instance.Enqueue(message);
+        Logging.SaveLog($"{_tag}: {message}");
+    }
+}

--- a/v2rayN/ServiceLib/Manager/KeepAliveManager.cs
+++ b/v2rayN/ServiceLib/Manager/KeepAliveManager.cs
@@ -87,25 +87,27 @@ public class KeepAliveManager
         subItem.KeepAliveLastCheck = now;
         await ConfigHandler.AddSubItem(_config, subItem);
 
+        SendLog(ResUI.MsgKeepAliveStartCheck);
+
         var delay = await ConnectionHandler.GetCurrentRealPingAsync();
         if (delay > 0)
         {
-            Logging.SaveLog($"{_tag}: current node {activeProfile.Remarks} is alive, delay {delay}");
+            SendLog(string.Format(ResUI.MsgKeepAliveCurrentNodeAlive, delay));
             return;
         }
 
-        Logging.SaveLog($"{_tag}: current node {activeProfile.Remarks} failed, testing all nodes in subscription {subItem.Remarks}");
+        SendLog(string.Format(ResUI.MsgKeepAliveCurrentNodeFailed, subItem.Remarks));
 
-        var bestIndexId = await FindBestNodeAsync(subId);
+        var (bestIndexId, bestDelay) = await FindBestNodeAsync(subId);
         if (bestIndexId.IsNotEmpty())
         {
-            await SwitchToBestNodeAsync(bestIndexId);
+            await SwitchToBestNodeAsync(bestIndexId, bestDelay);
             return;
         }
 
         if (now - subItem.KeepAliveLastUpdate >= subItem.KeepAliveInterval * 60)
         {
-            Logging.SaveLog($"{_tag}: all nodes in subscription {subItem.Remarks} failed, triggering subscription update");
+            SendLog(string.Format(ResUI.MsgKeepAliveUpdateTriggered, subItem.Remarks));
             subItem.KeepAliveLastUpdate = now;
             await ConfigHandler.AddSubItem(_config, subItem);
             await SubscriptionHandler.UpdateProcess(_config, subId, true, _updateFunc);
@@ -113,8 +115,8 @@ public class KeepAliveManager
         else
         {
             var message = string.Format(ResUI.MsgKeepAliveAllFailed, subItem.Remarks);
+            SendLog(message);
             NoticeManager.Instance.Enqueue(message);
-            Logging.SaveLog($"{_tag}: {message}");
         }
     }
 
@@ -131,26 +133,26 @@ public class KeepAliveManager
             return;
         }
 
-        Logging.SaveLog($"{_tag}: running post-update fallback for subscription {subItem.Remarks}");
+        SendLog(string.Format(ResUI.MsgKeepAliveCurrentNodeFailed, subItem.Remarks));
 
-        var bestIndexId = await FindBestNodeAsync(subId);
+        var (bestIndexId, bestDelay) = await FindBestNodeAsync(subId);
         if (bestIndexId.IsNotEmpty())
         {
-            await SwitchToBestNodeAsync(bestIndexId);
+            await SwitchToBestNodeAsync(bestIndexId, bestDelay);
             return;
         }
 
         var message = string.Format(ResUI.MsgKeepAliveAllFailed, subItem.Remarks);
+        SendLog(message);
         NoticeManager.Instance.Enqueue(message);
-        Logging.SaveLog($"{_tag}: {message}");
     }
 
-    private async Task<string> FindBestNodeAsync(string subId)
+    private async Task<(string IndexId, int Delay)> FindBestNodeAsync(string subId)
     {
         var nodes = await AppManager.Instance.ProfileItems(subId);
         if (nodes == null || nodes.Count == 0)
         {
-            return string.Empty;
+            return (string.Empty, 0);
         }
 
         foreach (var node in nodes)
@@ -174,17 +176,23 @@ public class KeepAliveManager
             }
         }
 
-        return bestIndexId;
+        return (bestIndexId, bestDelay == int.MaxValue ? 0 : bestDelay);
     }
 
-    private async Task SwitchToBestNodeAsync(string indexId)
+    private async Task SwitchToBestNodeAsync(string indexId, int delay)
     {
         var profile = await AppManager.Instance.GetProfileItem(indexId);
         await ConfigHandler.SetDefaultServerIndex(_config, indexId);
         await _reloadFunc();
 
-        var message = string.Format(ResUI.MsgKeepAliveSwitched, profile?.Remarks ?? indexId);
+        var message = string.Format(ResUI.MsgKeepAliveSwitched, profile?.Remarks ?? indexId, delay);
+        SendLog(message);
         NoticeManager.Instance.Enqueue(message);
+    }
+
+    private void SendLog(string message)
+    {
+        NoticeManager.Instance.SendMessageEx(message);
         Logging.SaveLog($"{_tag}: {message}");
     }
 }

--- a/v2rayN/ServiceLib/Manager/ProfileExManager.cs
+++ b/v2rayN/ServiceLib/Manager/ProfileExManager.cs
@@ -134,6 +134,12 @@ public class ProfileExManager
         IndexIdEnqueue(indexId);
     }
 
+    public int GetTestDelay(string? indexId)
+    {
+        var profileEx = _lstProfileEx.FirstOrDefault(t => t.IndexId == indexId);
+        return profileEx?.Delay ?? 0;
+    }
+
     public void SetTestSpeed(string indexId, decimal speed)
     {
         var profileEx = GetProfileExItem(indexId);

--- a/v2rayN/ServiceLib/Manager/TaskManager.cs
+++ b/v2rayN/ServiceLib/Manager/TaskManager.cs
@@ -35,6 +35,15 @@ public class TaskManager
                 Logging.SaveLog("ScheduledTasks - UpdateTaskRunSubscription", ex);
             }
 
+            try
+            {
+                await KeepAliveManager.Instance.RunKeepAliveAsync();
+            }
+            catch (Exception ex)
+            {
+                Logging.SaveLog("ScheduledTasks - KeepAlive", ex);
+            }
+
             //Execute once 20 minute
             if (numOfExecuted % 20 == 0)
             {
@@ -103,12 +112,24 @@ public class TaskManager
 
         foreach (var item in lstSubs)
         {
+            var activeProfile = await AppManager.Instance.GetProfileItem(_config.IndexId);
+            var activeSubId = activeProfile?.Subid;
+
             await SubscriptionHandler.UpdateProcess(_config, item.Id, true, async (success, msg) =>
             {
                 await _updateFunc?.Invoke(success, msg);
                 if (success)
                 {
                     Logging.SaveLog($"Update subscription end. {msg}");
+
+                    if (activeSubId == item.Id)
+                    {
+                        var profile = await AppManager.Instance.GetProfileItem(_config.IndexId);
+                        if (profile == null)
+                        {
+                            await KeepAliveManager.Instance.RunPostUpdateFallbackAsync(item.Id);
+                        }
+                    }
                 }
             });
             item.UpdateTime = updateTime;

--- a/v2rayN/ServiceLib/Models/Entities/SubItem.cs
+++ b/v2rayN/ServiceLib/Models/Entities/SubItem.cs
@@ -14,6 +14,14 @@ public class SubItem
 
     public bool Enabled { get; set; } = true;
 
+    public bool KeepAlive { get; set; }
+
+    public int KeepAliveInterval { get; set; } = 10;
+
+    public long KeepAliveLastCheck { get; set; }
+
+    public long KeepAliveLastUpdate { get; set; }
+
     public string UserAgent { get; set; } = string.Empty;
 
     public int Sort { get; set; }

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -673,6 +673,24 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Keep Alive 的本地化字符串。
+        /// </summary>
+        public static string LvKeepAlive {
+            get {
+                return ResourceManager.GetString("LvKeepAlive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Keep Alive Interval (minutes) 的本地化字符串。
+        /// </summary>
+        public static string LvKeepAliveInterval {
+            get {
+                return ResourceManager.GetString("LvKeepAliveInterval", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 WebDAV Check 的本地化字符串。
         /// </summary>
         public static string LvWebDavCheck {
@@ -2100,6 +2118,24 @@ namespace ServiceLib.Resx {
         public static string MsgInvalidProperty {
             get {
                 return ResourceManager.GetString("MsgInvalidProperty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Keep Alive: switched to {0} 的本地化字符串。
+        /// </summary>
+        public static string MsgKeepAliveSwitched {
+            get {
+                return ResourceManager.GetString("MsgKeepAliveSwitched", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Keep Alive: all nodes in {0} are unavailable, will try update subscription next check 的本地化字符串。
+        /// </summary>
+        public static string MsgKeepAliveAllFailed {
+            get {
+                return ResourceManager.GetString("MsgKeepAliveAllFailed", resourceCulture);
             }
         }
         

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -691,6 +691,15 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 启用后，系统会定期检测当前活动节点的可用性。当当前节点不可用时，自动在该订阅分组内寻找延迟最小的可用节点并切换；若全部分组节点均不可用，则触发订阅更新。 的本地化字符串。
+        /// </summary>
+        public static string TipKeepAlive {
+            get {
+                return ResourceManager.GetString("TipKeepAlive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   查找类似 WebDAV Check 的本地化字符串。
         /// </summary>
         public static string LvWebDavCheck {
@@ -2122,7 +2131,7 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
-        ///   查找类似 Keep Alive: switched to {0} 的本地化字符串。
+        ///   查找类似 Keep Alive: switched to {0}, delay {1}ms 的本地化字符串。
         /// </summary>
         public static string MsgKeepAliveSwitched {
             get {
@@ -2131,7 +2140,43 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
-        ///   查找类似 Keep Alive: all nodes in {0} are unavailable, will try update subscription next check 的本地化字符串。
+        ///   查找类似 Keep Alive: checking current node 的本地化字符串。
+        /// </summary>
+        public static string MsgKeepAliveStartCheck {
+            get {
+                return ResourceManager.GetString("MsgKeepAliveStartCheck", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Keep Alive: current node is alive, delay {0}ms 的本地化字符串。
+        /// </summary>
+        public static string MsgKeepAliveCurrentNodeAlive {
+            get {
+                return ResourceManager.GetString("MsgKeepAliveCurrentNodeAlive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Keep Alive: current node failed, testing all nodes in subscription {0} 的本地化字符串。
+        /// </summary>
+        public static string MsgKeepAliveCurrentNodeFailed {
+            get {
+                return ResourceManager.GetString("MsgKeepAliveCurrentNodeFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Keep Alive: all nodes in {0} unavailable, triggering subscription update 的本地化字符串。
+        /// </summary>
+        public static string MsgKeepAliveUpdateTriggered {
+            get {
+                return ResourceManager.GetString("MsgKeepAliveUpdateTriggered", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   查找类似 Keep Alive: all nodes in {0} unavailable, will try update next check 的本地化字符串。
         /// </summary>
         public static string MsgKeepAliveAllFailed {
             get {

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -564,6 +564,18 @@
   <data name="LvUserAgent" xml:space="preserve">
     <value>User Agent</value>
   </data>
+  <data name="LvKeepAlive" xml:space="preserve">
+    <value>Keep Alive</value>
+  </data>
+  <data name="LvKeepAliveInterval" xml:space="preserve">
+    <value>Keep Alive Interval (minutes)</value>
+  </data>
+  <data name="MsgKeepAliveSwitched" xml:space="preserve">
+    <value>Keep Alive: switched to {0}</value>
+  </data>
+  <data name="MsgKeepAliveAllFailed" xml:space="preserve">
+    <value>Keep Alive: all nodes in {0} are unavailable, will try update subscription next check</value>
+  </data>
   <data name="TbCancel" xml:space="preserve">
     <value>Cancel</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -570,11 +570,26 @@
   <data name="LvKeepAliveInterval" xml:space="preserve">
     <value>Keep Alive Interval (minutes)</value>
   </data>
+  <data name="TipKeepAlive" xml:space="preserve">
+    <value>启用后，系统会定期检测当前活动节点的可用性。当当前节点不可用时，自动在该订阅分组内寻找延迟最小的可用节点并切换；若全部分组节点均不可用，则触发订阅更新。</value>
+  </data>
+  <data name="MsgKeepAliveStartCheck" xml:space="preserve">
+    <value>Keep Alive: checking current node</value>
+  </data>
+  <data name="MsgKeepAliveCurrentNodeAlive" xml:space="preserve">
+    <value>Keep Alive: current node is alive, delay {0}ms</value>
+  </data>
+  <data name="MsgKeepAliveCurrentNodeFailed" xml:space="preserve">
+    <value>Keep Alive: current node failed, testing all nodes in subscription {0}</value>
+  </data>
   <data name="MsgKeepAliveSwitched" xml:space="preserve">
-    <value>Keep Alive: switched to {0}</value>
+    <value>Keep Alive: switched to {0}, delay {1}ms</value>
+  </data>
+  <data name="MsgKeepAliveUpdateTriggered" xml:space="preserve">
+    <value>Keep Alive: all nodes in {0} unavailable, triggering subscription update</value>
   </data>
   <data name="MsgKeepAliveAllFailed" xml:space="preserve">
-    <value>Keep Alive: all nodes in {0} are unavailable, will try update subscription next check</value>
+    <value>Keep Alive: all nodes in {0} unavailable, will try update next check</value>
   </data>
   <data name="TbCancel" xml:space="preserve">
     <value>Cancel</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -564,6 +564,18 @@
   <data name="LvUserAgent" xml:space="preserve">
     <value>User Agent (可选)</value>
   </data>
+  <data name="LvKeepAlive" xml:space="preserve">
+    <value>连接保活</value>
+  </data>
+  <data name="LvKeepAliveInterval" xml:space="preserve">
+    <value>保活间隔（分钟）</value>
+  </data>
+  <data name="MsgKeepAliveSwitched" xml:space="preserve">
+    <value>保活：已切换至节点 {0}</value>
+  </data>
+  <data name="MsgKeepAliveAllFailed" xml:space="preserve">
+    <value>保活：订阅 {0} 全部节点不可用，下次检查将尝试更新</value>
+  </data>
   <data name="TbCancel" xml:space="preserve">
     <value>取消</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -570,8 +570,23 @@
   <data name="LvKeepAliveInterval" xml:space="preserve">
     <value>保活间隔（分钟）</value>
   </data>
+  <data name="TipKeepAlive" xml:space="preserve">
+    <value>启用后，系统会定期检测当前活动节点的可用性。当当前节点不可用时，自动在该订阅分组内寻找延迟最小的可用节点并切换；若全部分组节点均不可用，则触发订阅更新。</value>
+  </data>
+  <data name="MsgKeepAliveStartCheck" xml:space="preserve">
+    <value>保活：开始检测当前节点</value>
+  </data>
+  <data name="MsgKeepAliveCurrentNodeAlive" xml:space="preserve">
+    <value>保活：当前节点可用，延迟 {0}ms</value>
+  </data>
+  <data name="MsgKeepAliveCurrentNodeFailed" xml:space="preserve">
+    <value>保活：当前节点不可用，开始检测订阅 {0} 下所有节点</value>
+  </data>
   <data name="MsgKeepAliveSwitched" xml:space="preserve">
-    <value>保活：已切换至节点 {0}</value>
+    <value>保活：已切换至节点 {0}，延迟 {1}ms</value>
+  </data>
+  <data name="MsgKeepAliveUpdateTriggered" xml:space="preserve">
+    <value>保活：订阅 {0} 全部节点不可用，触发订阅更新</value>
   </data>
   <data name="MsgKeepAliveAllFailed" xml:space="preserve">
     <value>保活：订阅 {0} 全部节点不可用，下次检查将尝试更新</value>

--- a/v2rayN/ServiceLib/Services/SpeedtestService.cs
+++ b/v2rayN/ServiceLib/Services/SpeedtestService.cs
@@ -13,12 +13,14 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
 
     public void RunLoop(ESpeedActionType actionType, List<ProfileItem> selecteds)
     {
-        Task.Run(async () =>
-        {
-            await RunAsync(actionType, selecteds);
-            await ProfileExManager.Instance.SaveTo();
-            await UpdateFunc("", ResUI.SpeedtestingCompleted);
-        });
+        Task.Run(async () => await RunAsync(actionType, selecteds));
+    }
+
+    public async Task RunAsync(ESpeedActionType actionType, List<ProfileItem> selecteds)
+    {
+        await RunInternalAsync(actionType, selecteds);
+        await ProfileExManager.Instance.SaveTo();
+        await UpdateFunc("", ResUI.SpeedtestingCompleted);
     }
 
     public void ExitLoop()
@@ -36,7 +38,7 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
         return _lstExitLoop.All(p => p != exitLoopKey);
     }
 
-    private async Task RunAsync(ESpeedActionType actionType, List<ProfileItem> selecteds)
+    private async Task RunInternalAsync(ESpeedActionType actionType, List<ProfileItem> selecteds)
     {
         var exitLoopKey = Utils.GetGuid(false);
         _lstExitLoop.Add(exitLoopKey);

--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -273,6 +273,7 @@ public class MainWindowViewModel : MyReactiveObject
         await ProfileExManager.Instance.Init();
         await CoreManager.Instance.Init(_config, UpdateHandler);
         await CertPemManager.Instance.Init(_config);
+        KeepAliveManager.Instance.Init(_config, Reload, UpdateTaskHandler);
         TaskManager.Instance.RegUpdateTask(_config, UpdateTaskHandler);
 
         if (_config.GuiItem.EnableStatistics || _config.GuiItem.DisplayRealTimeSpeed)
@@ -475,7 +476,21 @@ public class MainWindowViewModel : MyReactiveObject
 
     public async Task UpdateSubscriptionProcess(string subId, bool blProxy)
     {
-        await Task.Run(async () => await SubscriptionHandler.UpdateProcess(_config, subId, blProxy, UpdateTaskHandler));
+        var activeProfile = await AppManager.Instance.GetProfileItem(_config.IndexId);
+        var activeSubId = activeProfile?.Subid;
+
+        await Task.Run(async () => await SubscriptionHandler.UpdateProcess(_config, subId, blProxy, async (success, msg) =>
+        {
+            await UpdateTaskHandler(success, msg);
+            if (success && activeSubId.IsNotEmpty())
+            {
+                var profile = await AppManager.Instance.GetProfileItem(_config.IndexId);
+                if (profile == null)
+                {
+                    await KeepAliveManager.Instance.RunPostUpdateFallbackAsync(activeSubId);
+                }
+            }
+        }));
     }
 
     #endregion Subscription

--- a/v2rayN/v2rayN.Desktop/Views/SubEditWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/SubEditWindow.axaml
@@ -138,6 +138,38 @@
                 </DockPanel>
 
                 <TextBlock
+                    Grid.Row="4"
+                    Grid.Column="0"
+                    Margin="{StaticResource Margin4}"
+                    VerticalAlignment="Center"
+                    Text="{x:Static resx:ResUI.LvKeepAlive}" />
+
+                <DockPanel
+                    Grid.Row="4"
+                    Grid.Column="1"
+                    Margin="{StaticResource Margin4}">
+                    <ToggleSwitch
+                        x:Name="togKeepAlive"
+                        Margin="{StaticResource Margin4}"
+                        HorizontalAlignment="Center"
+                        DockPanel.Dock="Left" />
+
+                    <TextBox
+                        x:Name="txtKeepAliveInterval"
+                        Width="100"
+                        Margin="{StaticResource Margin4}"
+                        VerticalAlignment="Center"
+                        DockPanel.Dock="Right"
+                        Watermark="{x:Static resx:ResUI.SubUrlTips}" />
+
+                    <TextBlock
+                        Margin="{StaticResource Margin4}"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Text="{x:Static resx:ResUI.LvKeepAliveInterval}" />
+                </DockPanel>
+
+                <TextBlock
                     Grid.Row="5"
                     Grid.Column="0"
                     Margin="{StaticResource Margin4}"

--- a/v2rayN/v2rayN.Desktop/Views/SubEditWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/SubEditWindow.axaml
@@ -137,12 +137,21 @@
                         Text="{x:Static resx:ResUI.LvAutoUpdateInterval}" />
                 </DockPanel>
 
-                <TextBlock
+                <StackPanel
                     Grid.Row="4"
                     Grid.Column="0"
                     Margin="{StaticResource Margin4}"
-                    VerticalAlignment="Center"
-                    Text="{x:Static resx:ResUI.LvKeepAlive}" />
+                    Orientation="Horizontal"
+                    VerticalAlignment="Center">
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Text="{x:Static resx:ResUI.LvKeepAlive}" />
+                    <TextBlock
+                        Margin="4,0,0,0"
+                        VerticalAlignment="Center"
+                        Text="?"
+                        ToolTip.Tip="{x:Static resx:ResUI.TipKeepAlive}" />
+                </StackPanel>
 
                 <DockPanel
                     Grid.Row="4"

--- a/v2rayN/v2rayN.Desktop/Views/SubEditWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/SubEditWindow.axaml.cs
@@ -27,6 +27,8 @@ public partial class SubEditWindow : WindowBase<SubEditViewModel>
             this.Bind(ViewModel, vm => vm.SelectedSource.MoreUrl, v => v.txtMoreUrl.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Enabled, v => v.togEnable.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.AutoUpdateInterval, v => v.txtAutoUpdateInterval.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SelectedSource.KeepAlive, v => v.togKeepAlive.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SelectedSource.KeepAliveInterval, v => v.txtKeepAliveInterval.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.UserAgent, v => v.txtUserAgent.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Sort, v => v.txtSort.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Filter, v => v.txtFilter.Text).DisposeWith(disposables);

--- a/v2rayN/v2rayN.Desktop/Views/SubSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/SubSettingWindow.axaml
@@ -65,6 +65,14 @@
                         Width="150"
                         Binding="{Binding AutoUpdateInterval}"
                         Header="{x:Static resx:ResUI.LvAutoUpdateInterval}" />
+                    <DataGridCheckBoxColumn
+                        Width="100"
+                        Binding="{Binding KeepAlive}"
+                        Header="{x:Static resx:ResUI.LvKeepAlive}" />
+                    <DataGridTextColumn
+                        Width="150"
+                        Binding="{Binding KeepAliveInterval}"
+                        Header="{x:Static resx:ResUI.LvKeepAliveInterval}" />
                     <DataGridTextColumn
                         Width="150"
                         Binding="{Binding UserAgent}"

--- a/v2rayN/v2rayN/Views/SubEditWindow.xaml
+++ b/v2rayN/v2rayN/Views/SubEditWindow.xaml
@@ -176,6 +176,42 @@
                 </DockPanel>
 
                 <TextBlock
+                    Grid.Row="4"
+                    Grid.Column="0"
+                    Margin="{StaticResource Margin4}"
+                    VerticalAlignment="Center"
+                    Style="{StaticResource ToolbarTextBlock}"
+                    Text="{x:Static resx:ResUI.LvKeepAlive}" />
+
+                <DockPanel
+                    Grid.Row="4"
+                    Grid.Column="1"
+                    Margin="{StaticResource Margin4}">
+                    <ToggleButton
+                        x:Name="togKeepAlive"
+                        Margin="{StaticResource Margin4}"
+                        HorizontalAlignment="Left"
+                        DockPanel.Dock="Left" />
+
+                    <TextBox
+                        x:Name="txtKeepAliveInterval"
+                        Width="100"
+                        Margin="{StaticResource Margin4}"
+                        VerticalAlignment="Center"
+                        materialDesign:HintAssist.Hint="{x:Static resx:ResUI.SubUrlTips}"
+                        AcceptsReturn="True"
+                        DockPanel.Dock="Right"
+                        Style="{StaticResource MyOutlinedTextBox}" />
+
+                    <TextBlock
+                        Margin="{StaticResource Margin4}"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource ToolbarTextBlock}"
+                        Text="{x:Static resx:ResUI.LvKeepAliveInterval}" />
+                </DockPanel>
+
+                <TextBlock
                     Grid.Row="5"
                     Grid.Column="0"
                     Margin="{StaticResource Margin4}"

--- a/v2rayN/v2rayN/Views/SubEditWindow.xaml
+++ b/v2rayN/v2rayN/Views/SubEditWindow.xaml
@@ -175,13 +175,22 @@
                         Text="{x:Static resx:ResUI.LvAutoUpdateInterval}" />
                 </DockPanel>
 
-                <TextBlock
+                <StackPanel
                     Grid.Row="4"
                     Grid.Column="0"
                     Margin="{StaticResource Margin4}"
-                    VerticalAlignment="Center"
-                    Style="{StaticResource ToolbarTextBlock}"
-                    Text="{x:Static resx:ResUI.LvKeepAlive}" />
+                    Orientation="Horizontal"
+                    VerticalAlignment="Center">
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Style="{StaticResource ToolbarTextBlock}"
+                        Text="{x:Static resx:ResUI.LvKeepAlive}" />
+                    <materialDesign:PackIcon
+                        Margin="4,0,0,0"
+                        VerticalAlignment="Center"
+                        Kind="HelpCircleOutline"
+                        ToolTip="{x:Static resx:ResUI.TipKeepAlive}" />
+                </StackPanel>
 
                 <DockPanel
                     Grid.Row="4"

--- a/v2rayN/v2rayN/Views/SubEditWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/SubEditWindow.xaml.cs
@@ -20,6 +20,8 @@ public partial class SubEditWindow
             this.Bind(ViewModel, vm => vm.SelectedSource.MoreUrl, v => v.txtMoreUrl.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Enabled, v => v.togEnable.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.AutoUpdateInterval, v => v.txtAutoUpdateInterval.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SelectedSource.KeepAlive, v => v.togKeepAlive.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SelectedSource.KeepAliveInterval, v => v.txtKeepAliveInterval.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.UserAgent, v => v.txtUserAgent.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Sort, v => v.txtSort.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Filter, v => v.txtFilter.Text).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/SubSettingWindow.xaml
+++ b/v2rayN/v2rayN/Views/SubSettingWindow.xaml
@@ -130,6 +130,14 @@
                         Width="150"
                         Binding="{Binding AutoUpdateInterval}"
                         Header="{x:Static resx:ResUI.LvAutoUpdateInterval}" />
+                    <DataGridCheckBoxColumn
+                        Width="100"
+                        Binding="{Binding KeepAlive}"
+                        Header="{x:Static resx:ResUI.LvKeepAlive}" />
+                    <DataGridTextColumn
+                        Width="150"
+                        Binding="{Binding KeepAliveInterval}"
+                        Header="{x:Static resx:ResUI.LvKeepAliveInterval}" />
                     <DataGridTextColumn
                         Width="150"
                         Binding="{Binding UserAgent}"


### PR DESCRIPTION
## 功能介绍

为订阅分组增加【连接保活】功能。启用后，系统会定期检测当前活动节点的可用性；当节点失效时，自动在该订阅分组内寻找真连接延迟最小的可用节点并切换；若分组内全部节点均不可用，则触发订阅更新。

## 主要改动

- 在 `SubItem` 中新增 `KeepAlive`、`KeepAliveInterval`、`KeepAliveLastCheck`、`KeepAliveLastUpdate` 字段
- 新增 `KeepAliveManager` 服务，统一处理保活检测、节点切换和订阅更新兜底
- 在 `TaskManager` 的每分钟调度中接入保活任务
- 自动/手动订阅更新后，若当前活动节点在更新后无法匹配，自动执行保活兜底
- 订阅分组编辑窗口增加保活开关与间隔输入框（默认 10 分钟）
- 订阅分组列表增加【连接保活】与【保活间隔】列
- 保活关键步骤输出摘要日志到日志框，便于排查
- 保活开关旁增加问号图标，悬浮显示功能说明

## 设计说明

- 保活仅对当前活动节点所属的订阅分组生效
- 切换目标按真连接延迟最小选择
- 全部节点不可用时，首次直接触发订阅更新；若仍未恢复，则发出告警并等待下次检查周期，避免死循环
- 复用现有 `SpeedtestService` 执行节点测速，避免重复实现

## 测试情况

- `ServiceLib` 和 `v2rayN.Desktop` 均已编译通过
- 桌面版可正常启动运行
