### PR TITLE
chore(deps): bump Downloader, NLog, sqlite-net-e, Repobot.SQLite and YamlDotNet

### DIFF
--- a/v2rayN/Directory.Packages.props
+++ b/v2rayN/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="IPNetwork2" Version="4.3.0" />
     <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.3" />
     <PackageVersion Include="CliWrap" Version="3.10.2" />
-    <PackageVersion Include="Downloader" Version="5.9.0" />
+    <PackageVersion Include="Downloader" Version="5.9.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="H.NotifyIcon.Wpf" Version="2.4.1" />
     <PackageVersion Include="MaterialDesignThemes" Version="5.3.2" />
@@ -25,14 +25,14 @@
     <PackageVersion Include="Semi.Avalonia" Version="12.1.0" />
     <PackageVersion Include="Semi.Avalonia.AvaloniaEdit" Version="12.0.0" />
     <PackageVersion Include="Semi.Avalonia.DataGrid" Version="12.1.0" />
-    <PackageVersion Include="NLog" Version="6.1.3" />
-    <PackageVersion Include="sqlite-net-e" Version="1.11.0" />
-    <PackageVersion Include="Repobot.SQLite.Unofficial" Version="3.53.3" />
+    <PackageVersion Include="NLog" Version="6.1.4" />
+    <PackageVersion Include="sqlite-net-e" Version="1.11.285" />
+    <PackageVersion Include="Repobot.SQLite.Unofficial" Version="3.53.3.8" />
     <PackageVersion Include="TaskScheduler" Version="2.12.2" />
     <PackageVersion Include="WebDav.Client" Version="2.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
-    <PackageVersion Include="YamlDotNet" Version="18.0.0" />
+    <PackageVersion Include="YamlDotNet" Version="18.1.0" />
     <PackageVersion Include="ZXing.Net.Bindings.SkiaSharp" Version="0.16.22" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Bumps five NuGet dependencies to their latest versions. All are centrally managed in `Directory.Packages.props`; no other files are changed.

| Package                   | From   | To       |
|---------------------------|--------|----------|
| Downloader                | 5.9.0  | 5.9.4    |
| NLog                      | 6.1.3  | 6.1.4    |
| Repobot.SQLite.Unofficial | 3.53.3 | 3.53.3.8 |
| sqlite-net-e              | 1.11.0 | 1.11.285 |
| YamlDotNet                | 18.0.0 | 18.1.0   |

`sqlite-net-e` and `Repobot.SQLite.Unofficial` are bumped together — the newer `sqlite-net-e` moves to `SQLitePCLRaw.config.e_sqlite3` 3.0.3.

## Intentionally not updated

- **SkiaSharp.NativeAssets.Linux** stays at `3.119.4`. This package must match the managed SkiaSharp version resolved through `Avalonia.Skia` 12.1.0, which pins SkiaSharp `3.119.4` (and itself brings `SkiaSharp.NativeAssets.Linux` 3.119.4). Bumping it alone to the 4.x line (Skia milestone 150, new major API surface) would compile fine but mismatch the native library at runtime on Linux. It should follow Avalonia when Avalonia moves to SkiaSharp 4.

## Testing

- `dotnet restore` and builds (WPF + Desktop): success
- Unit tests: pass
- Publish spot-checks: WPF `win-x64`; Desktop `win-x64`, `linux-x64`
