### PR TITLE
feat: add PostUpdateScript field to subscription settings

### DIFF
--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -2021,6 +2021,7 @@ public static class ConfigHandler
             item.NextProfile = subItem.NextProfile;
             item.PreSocksPort = subItem.PreSocksPort;
             item.Memo = subItem.Memo;
+            item.PostUpdateScript = subItem.PostUpdateScript;
         }
 
         if (item.Id.IsNullOrEmpty())

--- a/v2rayN/ServiceLib/Handler/SubscriptionHandler.cs
+++ b/v2rayN/ServiceLib/Handler/SubscriptionHandler.cs
@@ -41,6 +41,7 @@ public static class SubscriptionHandler
                 if (await ProcessDownloadResult(config, item.Id, result, hashCode, updateFunc))
                 {
                     successCount++;
+                    await ExecutePostUpdateScript(item, hashCode, updateFunc);
                 }
 
                 await updateFunc?.Invoke(false, "-------------------------------------------------------");
@@ -218,4 +219,59 @@ public static class SubscriptionHandler
 
         return ret > 0;
     }
+    private static async Task ExecutePostUpdateScript(SubItem item, string hashCode, Func<bool, string, Task> updateFunc)
+    {
+        var script = item.PostUpdateScript?.Trim();
+        if (script.IsNullOrEmpty())
+        {
+            return;
+        }
+
+        try
+        {
+            await updateFunc?.Invoke(false, $"{hashCode}{ResUI.MsgStartPostUpdateScript}: {script}");
+
+            var fileName = script;
+            var arguments = string.Empty;
+            var parts = script.Split(' ', 2);
+            if (parts.Length == 2)
+            {
+                fileName = parts[0];
+                arguments = parts[1];
+            }
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+
+            using var process = Process.Start(psi);
+            if (process != null)
+            {
+                await process.WaitForExitAsync();
+                var output = await process.StandardOutput.ReadToEndAsync();
+                var error = await process.StandardError.ReadToEndAsync();
+                if (output.IsNotEmpty())
+                {
+                    await updateFunc?.Invoke(false, $"{hashCode}{output}");
+                }
+                if (error.IsNotEmpty())
+                {
+                    await updateFunc?.Invoke(false, $"{hashCode}{error}");
+                }
+                await updateFunc?.Invoke(false, $"{hashCode}{ResUI.MsgPostUpdateScriptDone}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logging.SaveLog("PostUpdateScript", ex);
+            await updateFunc?.Invoke(false, $"{hashCode}{ResUI.MsgPostUpdateScriptFailed}: {ex.Message}");
+        }
+    }
+
 }

--- a/v2rayN/ServiceLib/Models/Entities/SubItem.cs
+++ b/v2rayN/ServiceLib/Models/Entities/SubItem.cs
@@ -33,4 +33,6 @@ public class SubItem
     public int? PreSocksPort { get; set; }
 
     public string? Memo { get; set; }
+
+    public string? PostUpdateScript { get; set; }
 }

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1347,6 +1347,21 @@
   <data name="LvMemo" xml:space="preserve">
     <value>Remarks Memo</value>
   </data>
+  <data name="LvPostUpdateScript" xml:space="preserve">
+    <value>Post-update script</value>
+  </data>
+  <data name="LvPostUpdateScriptTip" xml:space="preserve">
+    <value>Execute this script after a successful subscription update (e.g. powershell -File C:\script.ps1)</value>
+  </data>
+  <data name="MsgStartPostUpdateScript" xml:space="preserve">
+    <value>Starting post-update script</value>
+  </data>
+  <data name="MsgPostUpdateScriptDone" xml:space="preserve">
+    <value>Post-update script completed</value>
+  </data>
+  <data name="MsgPostUpdateScriptFailed" xml:space="preserve">
+    <value>Post-update script failed</value>
+  </data>
   <data name="TbSettingsLinuxSudoPassword" xml:space="preserve">
     <value>System sudo password</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1344,6 +1344,21 @@
   <data name="LvMemo" xml:space="preserve">
     <value>备注备忘</value>
   </data>
+  <data name="LvPostUpdateScript" xml:space="preserve">
+    <value>更新后脚本</value>
+  </data>
+  <data name="LvPostUpdateScriptTip" xml:space="preserve">
+    <value>订阅更新成功后执行的脚本（如 powershell -File C:\script.ps1）</value>
+  </data>
+  <data name="MsgStartPostUpdateScript" xml:space="preserve">
+    <value>开始执行更新后脚本</value>
+  </data>
+  <data name="MsgPostUpdateScriptDone" xml:space="preserve">
+    <value>更新后脚本执行完成</value>
+  </data>
+  <data name="MsgPostUpdateScriptFailed" xml:space="preserve">
+    <value>更新后脚本执行失败</value>
+  </data>
   <data name="TbSettingsLinuxSudoPassword" xml:space="preserve">
     <value>系统的 sudo 密码</value>
   </data>

--- a/v2rayN/v2rayN.Desktop/Views/SubEditWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/SubEditWindow.axaml
@@ -34,7 +34,7 @@
         </StackPanel>
         <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
 
-            <Grid ColumnDefinitions="Auto,400,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+            <Grid ColumnDefinitions="Auto,400,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
 
                 <TextBlock
                     Grid.Row="0"
@@ -265,6 +265,21 @@
                     Margin="{StaticResource Margin4}"
                     VerticalAlignment="Center"
                     TextWrapping="Wrap" />
+
+                <TextBlock
+                    Grid.Row="13"
+                    Grid.Column="0"
+                    Margin="{StaticResource Margin4}"
+                    VerticalAlignment="Center"
+                    Text="{x:Static resx:ResUI.LvPostUpdateScript}" />
+                <TextBox
+                    x:Name="txtPostUpdateScript"
+                    Grid.Row="13"
+                    Grid.Column="1"
+                    Margin="{StaticResource Margin4}"
+                    VerticalAlignment="Center"
+                    TextWrapping="Wrap"
+                    PlaceholderText="{x:Static resx:ResUI.LvPostUpdateScriptTip}" />
 
             </Grid>
         </ScrollViewer>

--- a/v2rayN/v2rayN.Desktop/Views/SubEditWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/SubEditWindow.axaml.cs
@@ -28,6 +28,7 @@ public partial class SubEditWindow : WindowBase<SubEditViewModel>
             this.Bind(ViewModel, vm => vm.SelectedSource.NextProfile, v => v.txtNextProfile.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.PreSocksPort, v => v.txtPreSocksPort.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Memo, v => v.txtMemo.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SelectedSource.PostUpdateScript, v => v.txtPostUpdateScript.Text).DisposeWith(disposables);
 
             this.BindCommand(ViewModel, vm => vm.SelectPrevProfileCmd, v => v.btnSelectPrevProfile).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.SelectNextProfileCmd, v => v.btnSelectNextProfile).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/SubEditWindow.xaml
+++ b/v2rayN/v2rayN/Views/SubEditWindow.xaml
@@ -64,6 +64,7 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
@@ -324,6 +325,24 @@
                     Grid.Column="1"
                     Margin="{StaticResource Margin4}"
                     VerticalAlignment="Center"
+                    AcceptsReturn="True"
+                    Style="{StaticResource MyOutlinedTextBox}"
+                    TextWrapping="Wrap" />
+
+                <TextBlock
+                    Grid.Row="13"
+                    Grid.Column="0"
+                    Margin="{StaticResource Margin4}"
+                    VerticalAlignment="Center"
+                    Style="{StaticResource ToolbarTextBlock}"
+                    Text="{x:Static resx:ResUI.LvPostUpdateScript}" />
+                <TextBox
+                    x:Name="txtPostUpdateScript"
+                    Grid.Row="13"
+                    Grid.Column="1"
+                    Margin="{StaticResource Margin4}"
+                    VerticalAlignment="Center"
+                    materialDesign:HintAssist.Hint="{x:Static resx:ResUI.LvPostUpdateScriptTip}"
                     AcceptsReturn="True"
                     Style="{StaticResource MyOutlinedTextBox}"
                     TextWrapping="Wrap" />

--- a/v2rayN/v2rayN/Views/SubEditWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/SubEditWindow.xaml.cs
@@ -25,6 +25,7 @@ public partial class SubEditWindow
             this.Bind(ViewModel, vm => vm.SelectedSource.NextProfile, v => v.txtNextProfile.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.PreSocksPort, v => v.txtPreSocksPort.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Memo, v => v.txtMemo.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SelectedSource.PostUpdateScript, v => v.txtPostUpdateScript.Text).DisposeWith(disposables);
 
             this.BindCommand(ViewModel, vm => vm.SelectPrevProfileCmd, v => v.btnSelectPrevProfile).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.SelectNextProfileCmd, v => v.btnSelectNextProfile).DisposeWith(disposables);


### PR DESCRIPTION
## Feature: Post-Update Script for Subscriptions

### Motivation

Currently, v2rayN has no built-in mechanism to run a custom script after a subscription update completes. Users who need to post-process subscription data (e.g., organizing policy groups, filtering nodes, updating routing rules) must rely on external polling solutions or manual execution.

This PR adds a **PostUpdateScript** field to the subscription settings, allowing users to specify a script/command that executes automatically after each successful subscription update.

### Changes

#### Model
- `SubItem.cs`: Added `PostUpdateScript` property (nullable string)

#### Logic
- `ConfigHandler.cs`: Copy `PostUpdateScript` field in `AddSubItem()` (for edit/save)
- `SubscriptionHandler.cs`: Added `ExecutePostUpdateScript()` method — after a successful `ProcessDownloadResult()`, if the subscription has a `PostUpdateScript` configured, it executes the script with output redirected to the update log

#### UI (WPF + Avalonia)
- `SubEditWindow.xaml` / `SubEditWindow.axaml`: Added text input field for PostUpdateScript in the subscription edit dialog
- `SubEditWindow.xaml.cs` / `SubEditWindow.axaml.cs`: Added data binding for the new field

#### Localization
- `ResUI.resx`: Added English strings (`LvPostUpdateScript`, `LvPostUpdateScriptTip`, `MsgStartPostUpdateScript`, `MsgPostUpdateScriptDone`, `MsgPostUpdateScriptFailed`)
- `ResUI.zh-Hans.resx`: Added Chinese translations

### Usage

1. Open **Subscription Settings** -> edit a subscription
2. Fill in the **Post-update script** field, e.g.:
   - `powershell -File C:\scripts\organize.ps1`
   - `/bin/bash /home/user/organize.sh`
3. Save. The script will execute automatically after each successful subscription update (both manual and scheduled auto-update)

### Notes

- The script runs asynchronously after the subscription is successfully parsed and servers are imported
- Script stdout/stderr are captured and displayed in the update log
- If the script fails, the error is logged but does not affect the subscription update itself
- Empty field = no script executed (backward compatible)