### PR TITLE
Add UI options for SpeedTestPageSize and SpeedTestDelayInterval

### DIFF
--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -4708,6 +4708,46 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Speed Test Page Size 的本地化字符串。
+        /// </summary>
+
+        public static string TbSettingsSpeedTestPageSize {
+            get {
+                return ResourceManager.GetString("TbSettingsSpeedTestPageSize", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   查找类似 Speed Test Page Size Tip 的本地化字符串。
+        /// </summary>
+        
+        public static string TbSettingsSpeedTestPageSizeTip {
+            get {
+                return ResourceManager.GetString("TbSettingsSpeedTestPageSizeTip", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   查找类似 Speed Test Delay Interval 的本地化字符串。
+        /// </summary>
+        
+        public static string TbSettingsSpeedTestDelayInterval {
+            get {
+                return ResourceManager.GetString("TbSettingsSpeedTestDelayInterval", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   查找类似 Speed Test Delay Interval Tip 的本地化字符串。
+        /// </summary>
+
+        public static string TbSettingsSpeedTestDelayIntervalTip {
+            get {
+                return ResourceManager.GetString("TbSettingsSpeedTestDelayIntervalTip", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   查找类似 Auth user 的本地化字符串。
         /// </summary>
         public static string TbSettingsUser {

--- a/v2rayN/ServiceLib/Resx/ResUI.fa.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fa.resx
@@ -949,10 +949,10 @@
     <value>اندازه فونت</value>
   </data>
   <data name="TbSettingsSpeedTestTimeout" xml:space="preserve">
-    <value>یمقدار تاخیر تست سرعت منفرد</value>
+    <value>مقدار تاخیر تست سرعت منفرد</value>
   </data>
   <data name="TbSettingsSpeedTestUrl" xml:space="preserve">
-    <value>/آدرس اینترنتی SpeedTest</value>
+    <value>آدرس اینترنتی SpeedTest</value>
   </data>
   <data name="menuMoveTo" xml:space="preserve">
     <value>بالا و پایین حرکت کنید</value>
@@ -1294,7 +1294,7 @@
     <value>فیلتر هسته</value>
   </data>
   <data name="TipActiveServer" xml:space="preserve">
-    <value>فعال سازی</value>
+    <value>فعال</value>
   </data>
   <data name="TbSettingsGeoFilesSource" xml:space="preserve">
     <value>منبع فایل های جغرافیایی (اختیاری)</value>
@@ -1732,10 +1732,22 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
     <value>XHTTP Extra</value>
   </data>
   <data name="menuUdpTestServer" xml:space="preserve">
-    <value>Test Configurations UDP Delay</value>
+    <value>تست تاخیر کانفیگ ها از طریق UDP</value>
   </data>
   <data name="TbSettingsUdpTestUrl" xml:space="preserve">
-    <value>UDP Test Url</value>
+    <value>آدرس تست تاخیر UDP</value>
+  </data>
+  <data name="TbSettingsSpeedTestPageSize" xml:space="preserve">
+    <value>تعداد تست همزمان در هر دسته</value>
+  </data>
+  <data name="TbSettingsSpeedTestPageSizeTip" xml:space="preserve">
+    <value>تعداد کانفیگ هایی که به صورت همزمان در هر دسته تست می شوند. مقدار 0 یا خالی یعنی بدون محدودیت</value>
+  </data>
+  <data name="TbSettingsSpeedTestDelayInterval" xml:space="preserve">
+    <value>تأخیر بین دسته ها بر حسب ثانیه</value>
+  </data>
+  <data name="TbSettingsSpeedTestDelayIntervalTip" xml:space="preserve">
+    <value>مدت زمان انتظار قبل از شروع دسته بعدی. مقدار 0 یا خالی یعنی بدون تأخیر</value>
   </data>
   <data name="TbSettingsSendThrough" xml:space="preserve">
     <value>Local outbound address (SendThrough)</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1746,6 +1746,18 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
   <data name="TbSettingsUdpTestUrl" xml:space="preserve">
     <value>UDP Test Url</value>
   </data>
+    <data name="TbSettingsSpeedTestPageSize" xml:space="preserve">
+    <value>Concurrent Tests Per Batch</value>
+  </data>
+  <data name="TbSettingsSpeedTestPageSizeTip" xml:space="preserve">
+    <value>Number of configurations tested simultaneously in each batch. Set 0 or leave blank for unlimited.</value>
+  </data>
+  <data name="TbSettingsSpeedTestDelayInterval" xml:space="preserve">
+    <value>Delay Between Batches (seconds)</value>
+  </data>
+  <data name="TbSettingsSpeedTestDelayIntervalTip" xml:space="preserve">
+    <value>Wait time before starting the next batch. Set 0 or leave blank to disable delay.</value>
+  </data>
   <data name="TbSettingsSendThrough" xml:space="preserve">
     <value>Local outbound address (SendThrough)</value>
   </data>

--- a/v2rayN/ServiceLib/Services/SpeedtestService.cs
+++ b/v2rayN/ServiceLib/Services/SpeedtestService.cs
@@ -8,8 +8,8 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
     private readonly Config? _config = config;
     private readonly Func<SpeedTestResult, Task>? _updateFunc = updateFunc;
     private static readonly ConcurrentBag<string> _lstExitLoop = [];
-    private readonly int _speedTestPageSize = config.SpeedTestItem.SpeedTestPageSize ?? Global.SpeedTestPageSize;
-    private readonly TimeSpan _delayInterval = TimeSpan.FromSeconds(config.SpeedTestItem.SpeedTestDelayInterval ?? 1);
+    private int SpeedTestPageSize => _config.SpeedTestItem.SpeedTestPageSize is > 0 ? _config.SpeedTestItem.SpeedTestPageSize.Value : Global.SpeedTestPageSize;
+    private TimeSpan DelayInterval => TimeSpan.FromSeconds(_config.SpeedTestItem.SpeedTestDelayInterval is > 0 ? _config.SpeedTestItem.SpeedTestDelayInterval.Value : 1);
 
     public void RunLoop(ESpeedActionType actionType, List<ProfileItem> selecteds)
     {
@@ -137,7 +137,7 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
 
     private async Task RunTcpingAsync(List<ServerTestItem> selecteds, string exitLoopKey)
     {
-        var pageSize = Math.Min(selecteds.Count, _speedTestPageSize);
+        var pageSize = Math.Min(selecteds.Count, SpeedTestPageSize);
         var lstBatch = GetTestBatchItem(selecteds, pageSize);
 
         foreach (var lst in lstBatch)
@@ -180,7 +180,7 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
                 return;
             }
 
-            await Task.Delay(_delayInterval);
+            await Task.Delay(DelayInterval);
         }
     }
 
@@ -188,7 +188,7 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
     {
         if (pageSize <= 0)
         {
-            pageSize = Math.Min(lstSelected.Count, _speedTestPageSize);
+            pageSize = Math.Min(lstSelected.Count, SpeedTestPageSize);
         }
         var lstTest = GetTestBatchItem(lstSelected, pageSize);
 
@@ -200,7 +200,7 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
             {
                 lstFailed.AddRange(lst);
             }
-            await Task.Delay(_delayInterval);
+            await Task.Delay(DelayInterval);
         }
 
         //Retest the failed part
@@ -277,7 +277,7 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
     {
         if (pageSize <= 0)
         {
-            pageSize = Math.Min(lstSelected.Count, _speedTestPageSize);
+            pageSize = Math.Min(lstSelected.Count, SpeedTestPageSize);
         }
         var lstTest = GetTestBatchItem(lstSelected, pageSize);
 
@@ -289,7 +289,7 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
             {
                 lstFailed.AddRange(lst);
             }
-            await Task.Delay(_delayInterval);
+            await Task.Delay(DelayInterval);
         }
 
         //Retest the failed part

--- a/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
@@ -67,6 +67,8 @@ public class OptionSettingViewModel : MyReactiveObject, ICloseable
     [Reactive] public string SpeedPingTestUrl { get; set; }
     [Reactive] public string UdpTestTarget { get; set; }
     [Reactive] public int MixedConcurrencyCount { get; set; }
+    [Reactive] public int? SpeedTestPageSize { get; set; }
+    [Reactive] public int? SpeedTestDelayInterval { get; set; }
     [Reactive] public bool EnableHWA { get; set; }
     [Reactive] public string SubConvertUrl { get; set; }
     [Reactive] public int MainGirdOrientation { get; set; }
@@ -206,6 +208,8 @@ public class OptionSettingViewModel : MyReactiveObject, ICloseable
         MixedConcurrencyCount = _config.SpeedTestItem.MixedConcurrencyCount;
         SpeedPingTestUrl = _config.SpeedTestItem.SpeedPingTestUrl;
         UdpTestTarget = _config.SpeedTestItem.UdpTestTarget;
+        SpeedTestPageSize = _config.SpeedTestItem.SpeedTestPageSize;
+        SpeedTestDelayInterval = _config.SpeedTestItem.SpeedTestDelayInterval;
         EnableHWA = _config.GuiItem.EnableHWA;
         SubConvertUrl = _config.ConstItem.SubConvertUrl;
         MainGirdOrientation = (int)_config.UiItem.MainGirdOrientation;
@@ -395,6 +399,8 @@ public class OptionSettingViewModel : MyReactiveObject, ICloseable
         _config.SpeedTestItem.SpeedTestUrl = SpeedTestUrl;
         _config.SpeedTestItem.SpeedPingTestUrl = SpeedPingTestUrl;
         _config.SpeedTestItem.UdpTestTarget = UdpTestTarget;
+        _config.SpeedTestItem.SpeedTestPageSize = SpeedTestPageSize;
+        _config.SpeedTestItem.SpeedTestDelayInterval = SpeedTestDelayInterval;
         _config.GuiItem.EnableHWA = EnableHWA;
         _config.ConstItem.SubConvertUrl = SubConvertUrl;
         _config.UiItem.MainGirdOrientation = (EGirdOrientation)MainGirdOrientation;

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
@@ -480,7 +480,7 @@
                     <Grid
                         Margin="{StaticResource Margin4}"
                         ColumnDefinitions="Auto,Auto,*"
-                        RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                        RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
 
                         <TextBlock
                             x:Name="tbAutoRun"
@@ -760,57 +760,107 @@
                             Grid.Column="0"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
+                            Text="{x:Static resx:ResUI.TbSettingsSpeedTestPageSize}" />
+                        
+                        <TextBox
+                            x:Name="txtSpeedTestPageSize"
+                            Grid.Row="22"
+                            Grid.Column="1"
+                            Width="200"
+                            Margin="{StaticResource Margin4}"
+                            HorizontalAlignment="Left"
+                            Text="{Binding SpeedTestPageSize}"
+                            Watermark="0" />
+
+                        <TextBlock
+                            Grid.Row="22"
+                            Grid.Column="2"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            Text="{x:Static resx:ResUI.TbSettingsSpeedTestPageSizeTip}"
+                            TextWrapping="Wrap" />
+                        
+                        <TextBlock
+                            Grid.Row="23"
+                            Grid.Column="0"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            Text="{x:Static resx:ResUI.TbSettingsSpeedTestDelayInterval}" />
+                        
+                        <TextBox
+                            x:Name="txtSpeedTestDelayInterval"
+                            Grid.Row="23"
+                            Grid.Column="1"
+                            Width="200"
+                            Margin="{StaticResource Margin4}"
+                            HorizontalAlignment="Left"
+                            Text="{Binding SpeedTestDelayInterval}"
+                            Watermark="0" />
+
+                        <TextBlock
+                            Grid.Row="23"
+                            Grid.Column="2"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            Text="{x:Static resx:ResUI.TbSettingsSpeedTestDelayIntervalTip}"
+                            TextWrapping="Wrap" />
+
+                        <TextBlock
+                            Grid.Row="24"
+                            Grid.Column="0"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
                             Text="{x:Static resx:ResUI.TbSettingsIPAPIUrl}" />
                         <ComboBox
                             x:Name="cmbIPAPIUrl"
-                            Grid.Row="22"
+                            Grid.Row="24"
                             Grid.Column="1"
                             Width="300"
                             Margin="{StaticResource Margin4}"
                             IsEditable="True" />
 
                         <TextBlock
-                            Grid.Row="23"
+                            Grid.Row="25"
                             Grid.Column="0"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
                             Text="{x:Static resx:ResUI.TbSettingsSubConvert}" />
                         <ComboBox
                             x:Name="cmbSubConvertUrl"
-                            Grid.Row="23"
+                            Grid.Row="25"
                             Grid.Column="1"
                             Width="300"
                             Margin="{StaticResource Margin4}"
                             IsEditable="True" />
 
                         <TextBlock
-                            Grid.Row="24"
+                            Grid.Row="26"
                             Grid.Column="0"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
                             Text="{x:Static resx:ResUI.TbSettingsMainGirdOrientation}" />
                         <ComboBox
                             x:Name="cmbMainGirdOrientation"
-                            Grid.Row="24"
+                            Grid.Row="26"
                             Grid.Column="1"
                             Width="200"
                             Margin="{StaticResource Margin4}" />
 
                         <TextBlock
-                            Grid.Row="25"
+                            Grid.Row="27"
                             Grid.Column="0"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
                             Text="{x:Static resx:ResUI.TbSettingsGeoFilesSource}" />
                         <ComboBox
                             x:Name="cmbGetFilesSourceUrl"
-                            Grid.Row="25"
+                            Grid.Row="27"
                             Grid.Column="1"
                             Width="300"
                             Margin="{StaticResource Margin4}"
                             IsEditable="True" />
                         <TextBlock
-                            Grid.Row="25"
+                            Grid.Row="27"
                             Grid.Column="2"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
@@ -818,20 +868,20 @@
                             TextWrapping="Wrap" />
 
                         <TextBlock
-                            Grid.Row="26"
+                            Grid.Row="28"
                             Grid.Column="0"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
                             Text="{x:Static resx:ResUI.TbSettingsSrsFilesSource}" />
                         <ComboBox
                             x:Name="cmbSrsFilesSourceUrl"
-                            Grid.Row="26"
+                            Grid.Row="28"
                             Grid.Column="1"
                             Width="300"
                             Margin="{StaticResource Margin4}"
                             IsEditable="True" />
                         <TextBlock
-                            Grid.Row="26"
+                            Grid.Row="28"
                             Grid.Column="2"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
@@ -839,20 +889,20 @@
                             TextWrapping="Wrap" />
 
                         <TextBlock
-                            Grid.Row="27"
+                            Grid.Row="29"
                             Grid.Column="0"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
                             Text="{x:Static resx:ResUI.TbSettingsRoutingRulesSource}" />
                         <ComboBox
                             x:Name="cmbRoutingRulesSourceUrl"
-                            Grid.Row="27"
+                            Grid.Row="29"
                             Grid.Column="1"
                             Width="300"
                             Margin="{StaticResource Margin4}"
                             IsEditable="True" />
                         <TextBlock
-                            Grid.Row="27"
+                            Grid.Row="29"
                             Grid.Column="2"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
@@ -106,6 +106,8 @@ public partial class OptionSettingWindow : WindowBase<OptionSettingViewModel>
             this.Bind(ViewModel, vm => vm.SpeedPingTestUrl, v => v.cmbSpeedPingTestUrl.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.UdpTestTarget, v => v.cmbUdpTestTarget.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.MixedConcurrencyCount, v => v.cmbMixedConcurrencyCount.SelectedValue).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SpeedTestPageSize, v => v.txtSpeedTestPageSize.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SpeedTestDelayInterval, v => v.txtSpeedTestDelayInterval.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SubConvertUrl, v => v.cmbSubConvertUrl.Text).DisposeWith(disposables);
             this.Bind<OptionSettingViewModel, OptionSettingWindow, int, int>(ViewModel,
                 vm => vm.MainGirdOrientation, view => view.cmbMainGirdOrientation.SelectedIndex).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
@@ -691,6 +691,8 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
@@ -996,15 +998,24 @@
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"
                             Style="{StaticResource ToolbarTextBlock}"
-                            Text="{x:Static resx:ResUI.TbSettingsIPAPIUrl}" />
-                        <ComboBox
-                            x:Name="cmbIPAPIUrl"
+                            Text="{x:Static resx:ResUI.TbSettingsSpeedTestPageSize}" />
+                        <TextBox
+                            x:Name="txtSpeedTestPageSize"
                             Grid.Row="22"
                             Grid.Column="1"
-                            Width="300"
+                            Width="200"
                             Margin="{StaticResource Margin8}"
-                            IsEditable="True"
-                            Style="{StaticResource DefComboBox}" />
+                            HorizontalAlignment="Left"
+                            Style="{StaticResource DefTextBox}"
+                            materialDesign:HintAssist.Hint="0" />
+                        <TextBlock
+                            Grid.Row="22"
+                            Grid.Column="2"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            Style="{StaticResource ToolbarTextBlock}"
+                            Text="{x:Static resx:ResUI.TbSettingsSpeedTestPageSizeTip}"
+                            TextWrapping="Wrap" />
 
                         <TextBlock
                             Grid.Row="23"
@@ -1012,10 +1023,51 @@
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"
                             Style="{StaticResource ToolbarTextBlock}"
+                            Text="{x:Static resx:ResUI.TbSettingsSpeedTestDelayInterval}" />
+                        <TextBox
+                            x:Name="txtSpeedTestDelayInterval"
+                            Grid.Row="23"
+                            Grid.Column="1"
+                            Width="200"
+                            Margin="{StaticResource Margin8}"
+                            HorizontalAlignment="Left"
+                            Style="{StaticResource DefTextBox}"
+                            materialDesign:HintAssist.Hint="0" />
+                        <TextBlock
+                            Grid.Row="23"
+                            Grid.Column="2"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            Style="{StaticResource ToolbarTextBlock}"
+                            Text="{x:Static resx:ResUI.TbSettingsSpeedTestDelayIntervalTip}"
+                            TextWrapping="Wrap" />
+
+                        <TextBlock
+                            Grid.Row="24"
+                            Grid.Column="0"
+                            Margin="{StaticResource Margin8}"
+                            VerticalAlignment="Center"
+                            Style="{StaticResource ToolbarTextBlock}"
+                            Text="{x:Static resx:ResUI.TbSettingsIPAPIUrl}" />
+                        <ComboBox
+                            x:Name="cmbIPAPIUrl"
+                            Grid.Row="24"
+                            Grid.Column="1"
+                            Width="300"
+                            Margin="{StaticResource Margin8}"
+                            IsEditable="True"
+                            Style="{StaticResource DefComboBox}" />
+
+                        <TextBlock
+                            Grid.Row="25"
+                            Grid.Column="0"
+                            Margin="{StaticResource Margin8}"
+                            VerticalAlignment="Center"
+                            Style="{StaticResource ToolbarTextBlock}"
                             Text="{x:Static resx:ResUI.TbSettingsSubConvert}" />
                         <ComboBox
                             x:Name="cmbSubConvertUrl"
-                            Grid.Row="23"
+                            Grid.Row="25"
                             Grid.Column="1"
                             Width="300"
                             Margin="{StaticResource Margin8}"
@@ -1024,7 +1076,7 @@
                             Style="{StaticResource DefComboBox}" />
 
                         <TextBlock
-                            Grid.Row="24"
+                            Grid.Row="26"
                             Grid.Column="0"
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"
@@ -1032,14 +1084,14 @@
                             Text="{x:Static resx:ResUI.TbSettingsMainGirdOrientation}" />
                         <ComboBox
                             x:Name="cmbMainGirdOrientation"
-                            Grid.Row="24"
+                            Grid.Row="26"
                             Grid.Column="1"
                             Width="200"
                             Margin="{StaticResource Margin8}"
                             Style="{StaticResource DefComboBox}" />
 
                         <TextBlock
-                            Grid.Row="25"
+                            Grid.Row="27"
                             Grid.Column="0"
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"
@@ -1047,14 +1099,14 @@
                             Text="{x:Static resx:ResUI.TbSettingsGeoFilesSource}" />
                         <ComboBox
                             x:Name="cmbGetFilesSourceUrl"
-                            Grid.Row="25"
+                            Grid.Row="27"
                             Grid.Column="1"
                             Width="300"
                             Margin="{StaticResource Margin8}"
                             IsEditable="True"
                             Style="{StaticResource DefComboBox}" />
                         <TextBlock
-                            Grid.Row="25"
+                            Grid.Row="27"
                             Grid.Column="2"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
@@ -1063,7 +1115,7 @@
                             TextWrapping="Wrap" />
 
                         <TextBlock
-                            Grid.Row="26"
+                            Grid.Row="28"
                             Grid.Column="0"
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"
@@ -1071,14 +1123,14 @@
                             Text="{x:Static resx:ResUI.TbSettingsSrsFilesSource}" />
                         <ComboBox
                             x:Name="cmbSrsFilesSourceUrl"
-                            Grid.Row="26"
+                            Grid.Row="28"
                             Grid.Column="1"
                             Width="300"
                             Margin="{StaticResource Margin8}"
                             IsEditable="True"
                             Style="{StaticResource DefComboBox}" />
                         <TextBlock
-                            Grid.Row="26"
+                            Grid.Row="28"
                             Grid.Column="2"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
@@ -1087,7 +1139,7 @@
                             TextWrapping="Wrap" />
 
                         <TextBlock
-                            Grid.Row="27"
+                            Grid.Row="29"
                             Grid.Column="0"
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"
@@ -1095,14 +1147,14 @@
                             Text="{x:Static resx:ResUI.TbSettingsRoutingRulesSource}" />
                         <ComboBox
                             x:Name="cmbRoutingRulesSourceUrl"
-                            Grid.Row="27"
+                            Grid.Row="29"
                             Grid.Column="1"
                             Width="300"
                             Margin="{StaticResource Margin8}"
                             IsEditable="True"
                             Style="{StaticResource DefComboBox}" />
                         <TextBlock
-                            Grid.Row="27"
+                            Grid.Row="29"
                             Grid.Column="2"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
@@ -110,6 +110,8 @@ public partial class OptionSettingWindow
             this.Bind(ViewModel, vm => vm.SpeedPingTestUrl, v => v.cmbSpeedPingTestUrl.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.UdpTestTarget, v => v.cmbUdpTestTarget.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.MixedConcurrencyCount, v => v.cmbMixedConcurrencyCount.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SpeedTestPageSize, v => v.txtSpeedTestPageSize.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SpeedTestDelayInterval, v => v.txtSpeedTestDelayInterval.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.EnableHWA, v => v.togEnableHWA.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SubConvertUrl, v => v.cmbSubConvertUrl.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.MainGirdOrientation, v => v.cmbMainGirdOrientation.SelectedIndex).DisposeWith(disposables);


### PR DESCRIPTION
### Summary

This PR exposes the existing `SpeedTestPageSize` and `SpeedTestDelayInterval` configuration options in the Settings UI.

These options are already implemented and fully supported by the application, but they can currently only be modified by manually editing the configuration file. This PR simply provides a UI for configuring them.

### Motivation

There are situations where users may want to adjust these values:

* Reduce the number of simultaneous speed test batches on systems with limited resources.
* Increase the delay between batches to reduce network load or avoid triggering server-side rate limits.
* Tune speed test behavior without manually editing the configuration file.

At the moment, users have to know that these options exist and modify the config manually, which is not very discoverable.

### Changes

* Added `Concurrent Tests Per Batch` to the Settings UI.
* Added `Delay Between Batches (seconds)` to the Settings UI.

### Compatibility

This PR does **not** change the default behavior.

* Existing users who never modify these settings will see exactly the same behavior as before.
* Existing configuration files remain fully compatible.
* The underlying implementation is unchanged; this PR only exposes existing configuration options through the UI.

### Benefits

* Improves discoverability of existing functionality.
* Eliminates the need for manual configuration file editing.
* Makes advanced speed test tuning available to users who prefer the graphical interface.
* Introduces no behavioral changes or breaking changes.
