### PR TITLE
Add ProtectCoreTypeList

### DIFF
--- a/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
+++ b/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
@@ -193,12 +193,17 @@ public class CoreConfigContextBuilder
         if (preSocksItem != null)
         {
             var preSocksResult = await Build(nodeContext.AppConfig, preSocksItem);
+
+            var protectCoreTypeList = nodeContext.ProtectCoreTypeList;
+            protectCoreTypeList.Add(nodeContext.RunCoreType);
+
             return preSocksResult with
             {
                 Context = preSocksResult.Context with
                 {
                     ProtectDomainList =
                     [.. nodeContext.ProtectDomainList ?? [], .. preSocksResult.Context.ProtectDomainList ?? []],
+                    ProtectCoreTypeList = protectCoreTypeList,
                 },
             };
         }

--- a/v2rayN/ServiceLib/Models/CoreConfigs/CoreConfigContext.cs
+++ b/v2rayN/ServiceLib/Models/CoreConfigs/CoreConfigContext.cs
@@ -17,6 +17,8 @@ public record CoreConfigContext
     // TUN Compatibility
     public bool IsTunEnabled { get; init; } = false;
     public HashSet<string> ProtectDomainList { get; init; } = [];
+    // Typically, it is the core of the outbound chain
+    public HashSet<ECoreType> ProtectCoreTypeList { get; init; } = [];
 
     public bool IsWindows { get; init; }
     public bool IsMacOS { get; init; }

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
@@ -34,12 +34,12 @@ public partial class CoreConfigSingboxService
                     _coreConfig.route.rules.AddRange(tunRules);
                 }
 
-                var (lstDnsExe, lstDirectExe) = BuildRoutingDirectExe();
+                var lstDirectExe = BuildRoutingDirectExe();
                 _coreConfig.route.rules.Add(new()
                 {
                     port = [53],
                     action = "hijack-dns",
-                    process_name = lstDnsExe
+                    process_name = lstDirectExe
                 });
 
                 _coreConfig.route.rules.Add(new()
@@ -256,34 +256,33 @@ public partial class CoreConfigSingboxService
         }
     }
 
-    private static (List<string> lstDnsExe, List<string> lstDirectExe) BuildRoutingDirectExe()
+    private List<string> BuildRoutingDirectExe()
     {
-        var dnsExeSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var directExeSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        var coreInfoResult = CoreInfoManager.Instance.GetCoreInfo();
+        var allCoreInfo = CoreInfoManager.Instance.GetCoreInfo();
 
-        foreach (var coreConfig in coreInfoResult)
+        foreach (var coreConfig in allCoreInfo)
         {
+            if (!context.ProtectCoreTypeList.Contains(coreConfig.CoreType))
+            {
+                continue;
+            }
             if (coreConfig.CoreType == ECoreType.v2rayN)
             {
                 continue;
             }
-
+            if (coreConfig.CoreExes == null)
+            {
+                continue;
+            }
             foreach (var baseExeName in coreConfig.CoreExes)
             {
-                if (coreConfig.CoreType != ECoreType.sing_box)
-                {
-                    dnsExeSet.Add(Utils.GetExeName(baseExeName));
-                }
                 directExeSet.Add(Utils.GetExeName(baseExeName));
             }
         }
 
-        var lstDnsExe = new List<string>(dnsExeSet);
-        var lstDirectExe = new List<string>(directExeSet);
-
-        return (lstDnsExe, lstDirectExe);
+        return directExeSet.ToList();
     }
 
     private void GenRoutingUserRule(RulesItem? item)

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
@@ -39,13 +39,13 @@ public partial class CoreConfigSingboxService
                 {
                     port = [53],
                     action = "hijack-dns",
-                    process_name = lstDirectExe
+                    process_path = lstDirectExe
                 });
 
                 _coreConfig.route.rules.Add(new()
                 {
                     outbound = Global.DirectTag,
-                    process_name = lstDirectExe
+                    process_path = lstDirectExe
                 });
 
                 // ICMP Routing
@@ -278,7 +278,12 @@ public partial class CoreConfigSingboxService
             }
             foreach (var baseExeName in coreConfig.CoreExes)
             {
-                directExeSet.Add(Utils.GetExeName(baseExeName));
+                //directExeSet.Add(Utils.GetExeName(baseExeName));
+                var exePath = CoreInfoManager.Instance.GetCoreExecFile(coreConfig, out _);
+                if (!exePath.IsNullOrEmpty())
+                {
+                    directExeSet.Add(exePath);
+                }
             }
         }
 

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayRoutingService.cs
@@ -13,11 +13,11 @@ public partial class CoreConfigV2rayService
                 {
                     _coreConfig.routing.rules.AddRange(tunRules);
                 }
-                var (lstDnsExe, lstDirectExe) = BuildRoutingDirectExe();
+                var lstDirectExe = BuildRoutingDirectExe();
                 _coreConfig.routing.rules.Add(new()
                 {
                     port = "53",
-                    process = lstDnsExe,
+                    process = lstDirectExe,
                     outboundTag = Global.DnsOutboundTag,
                 });
                 _coreConfig.routing.rules.Add(new()
@@ -232,36 +232,39 @@ public partial class CoreConfigV2rayService
         return finalRule;
     }
 
-    private static (List<string> lstDnsExe, List<string> lstDirectExe) BuildRoutingDirectExe()
+    private List<string> BuildRoutingDirectExe()
     {
-        var dnsExeSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var directExeSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        var coreInfoResult = CoreInfoManager.Instance.GetCoreInfo();
+        var allCoreInfo = CoreInfoManager.Instance.GetCoreInfo();
 
-        foreach (var coreConfig in coreInfoResult)
+        foreach (var coreConfig in allCoreInfo)
         {
+            if (!context.ProtectCoreTypeList.Contains(coreConfig.CoreType))
+            {
+                continue;
+            }
             if (coreConfig.CoreType == ECoreType.v2rayN)
             {
                 continue;
             }
-
+            if (coreConfig.CoreExes == null)
+            {
+                continue;
+            }
+            if (coreConfig.CoreType == ECoreType.Xray)
+            {
+                directExeSet.Add("xray/");
+                continue;
+            }
             foreach (var baseExeName in coreConfig.CoreExes)
             {
-                if (coreConfig.CoreType != ECoreType.Xray)
-                {
-                    dnsExeSet.Add(Utils.GetExeName(baseExeName));
-                }
                 directExeSet.Add(Utils.GetExeName(baseExeName));
             }
         }
-
-        directExeSet.Add("xray/");
+        //directExeSet.Add("xray/");
         directExeSet.Add("self/");
 
-        var lstDnsExe = new List<string>(dnsExeSet);
-        var lstDirectExe = new List<string>(directExeSet);
-
-        return (lstDnsExe, lstDirectExe);
+        return directExeSet.ToList();
     }
 }

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayRoutingService.cs
@@ -259,7 +259,12 @@ public partial class CoreConfigV2rayService
             }
             foreach (var baseExeName in coreConfig.CoreExes)
             {
-                directExeSet.Add(Utils.GetExeName(baseExeName));
+                //directExeSet.Add(Utils.GetExeName(baseExeName));
+                var exePath = CoreInfoManager.Instance.GetCoreExecFile(coreConfig, out _);
+                if (!exePath.IsNullOrEmpty())
+                {
+                    directExeSet.Add(exePath);
+                }
             }
         }
         //directExeSet.Add("xray/");


### PR DESCRIPTION
在 context build 阶段偷看下运行核心，避免那一长串未使用到的进程保护

添加进程路径限制，避免多开 v2rayN 错误匹配

删除 DNS Direct 保护，默认即为劫持