### PR TITLE
Fix window initialization to reduce size jump and center on startup

### DIFF
--- a/v2rayN/v2rayN.Desktop/Base/WindowBase.cs
+++ b/v2rayN/v2rayN.Desktop/Base/WindowBase.cs
@@ -2,9 +2,29 @@ namespace v2rayN.Desktop.Base;
 
 public class WindowBase<TViewModel> : ReactiveWindow<TViewModel> where TViewModel : class
 {
+    private bool _firstOpen = true; // 程序每次启动时窗口首次打开为 true
+
     public WindowBase()
     {
-        Loaded += OnLoaded;
+        // 在窗口显示后恢复大小，避免 Avalonia 12 中的初始跳变
+        Opened += (_, _) =>
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                OnWindowInitialized();
+
+                // 程序每次启动时首次打开窗口居中
+                if (_firstOpen)
+                {
+                    var screen = Screens.ScreenFromWindow(this) ?? Screens.Primary;
+                    var x = (screen.WorkingArea.Width - Width) / 2;
+                    var y = (screen.WorkingArea.Height - Height) / 2;
+                    Position = new PixelPoint((int)x, (int)y);
+                    _firstOpen = false;
+                }
+            });
+        };
+
         Loaded += (s, e) =>
         {
             if (Owner != null && !ShowInTaskbar)
@@ -14,12 +34,7 @@ public class WindowBase<TViewModel> : ReactiveWindow<TViewModel> where TViewMode
         };
     }
 
-    private void ReactiveWindowBase_Closed(object? sender, EventArgs e)
-    {
-        throw new NotImplementedException();
-    }
-
-    protected virtual void OnLoaded(object? sender, RoutedEventArgs e)
+    private void OnWindowInitialized()
     {
         try
         {
@@ -29,28 +44,35 @@ public class WindowBase<TViewModel> : ReactiveWindow<TViewModel> where TViewMode
                 return;
             }
 
-            var screen = Screens.ScreenFromWindow(this) ?? Screens.Primary;
-            var scaling = screen.Scaling > 0 ? screen.Scaling : 1.0;
-            var workingArea = screen.WorkingArea;
+            if (sizeItem.Width > 0 && !Width.Equals(sizeItem.Width))
+            {
+                Width = sizeItem.Width;
+            }
 
-            var width = Math.Min(sizeItem.Width, workingArea.Width / scaling);
-            var height = Math.Min(sizeItem.Height, workingArea.Height / scaling);
-            var x = workingArea.X + ((workingArea.Width - (width * scaling)) / 2);
-            var y = workingArea.Y + ((workingArea.Height - (height * scaling)) / 2);
-
-            Width = width;
-            Height = height;
-            Position = new PixelPoint((int)x, (int)y);
+            if (sizeItem.Height > 0 && !Height.Equals(sizeItem.Height))
+            {
+                Height = sizeItem.Height;
+            }
         }
         catch { }
+    }
+
+    protected virtual void OnLoaded(object? sender, RoutedEventArgs e)
+    {
     }
 
     protected override void OnClosed(EventArgs e)
     {
         base.OnClosed(e);
+
         try
         {
-            ConfigHandler.SaveWindowSizeItem(AppManager.Instance.Config, GetType().Name, Width, Height);
+            ConfigHandler.SaveWindowSizeItem(
+                AppManager.Instance.Config,
+                GetType().Name,
+                Bounds.Width,
+                Bounds.Height
+            );
         }
         catch { }
     }


### PR DESCRIPTION
优化窗口初始化流程：程序启动时窗口会先以默认大小居中渲染一帧，随后再居中恢复到用户设定的大小，以减少 Avalonia 12 下的跳变现象。此为 WindowBase.cs 能实现的最大优化，其他功能保持不变。