### PR TITLE
fix: sanitize system proxy exceptions to avoid macOS ExceptionsList b…

### DIFF
--- a/v2rayN/ServiceLib/Handler/SysProxy/SysProxyHandler.cs
+++ b/v2rayN/ServiceLib/Handler/SysProxy/SysProxyHandler.cs
@@ -16,7 +16,7 @@ public static class SysProxyHandler
         try
         {
             var port = AppManager.Instance.GetLocalPort(EInboundProtocol.socks);
-            var exceptions = config.SystemProxyItem.SystemProxyExceptions.Replace(" ", "");
+            var exceptions = SanitizeExceptions(config.SystemProxyItem.SystemProxyExceptions);
             if (port <= 0)
             {
                 return false;
@@ -64,6 +64,29 @@ public static class SysProxyHandler
             Logging.SaveLog(_tag, ex);
         }
         return true;
+    }
+
+    /// <summary>
+    /// Normalizes a user-entered proxy exception list (comma-separated, used by the
+    /// Linux and macOS proxy tools). Trims surrounding whitespace on each entry
+    /// (including stray line breaks and tabs), drops empty entries left by trailing
+    /// commas, and strips any remaining inner spaces. A single malformed entry
+    /// (e.g. an embedded newline or a trailing comma) otherwise causes macOS configd
+    /// to reject the whole ExceptionsList silently.
+    /// </summary>
+    private static string SanitizeExceptions(string? exceptions)
+    {
+        if (exceptions.IsNullOrEmpty())
+        {
+            return string.Empty;
+        }
+
+        var items = exceptions
+            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            .Select(item => item.Replace(" ", string.Empty))
+            .Where(item => item.Length > 0);
+
+        return string.Join(',', items);
     }
 
     private static void GetWindowsProxyString(Config config, int port, out string strProxy, out string strExceptions)

--- a/v2rayN/ServiceLib/Handler/SysProxy/SysProxyHandler.cs
+++ b/v2rayN/ServiceLib/Handler/SysProxy/SysProxyHandler.cs
@@ -16,7 +16,6 @@ public static class SysProxyHandler
         try
         {
             var port = AppManager.Instance.GetLocalPort(EInboundProtocol.socks);
-            var exceptions = SanitizeExceptions(config.SystemProxyItem.SystemProxyExceptions);
             if (port <= 0)
             {
                 return false;
@@ -24,17 +23,18 @@ public static class SysProxyHandler
             switch (type)
             {
                 case ESysProxyType.ForcedChange when Utils.IsWindows():
-                    {
-                        GetWindowsProxyString(config, port, out var strProxy, out var strExceptions);
-                        ProxySettingWindows.SetProxy(strProxy, strExceptions, 2);
-                        break;
-                    }
+                    var (strProxy, strExceptions) = GetWindowsProxyString(config, port);
+                    ProxySettingWindows.SetProxy(strProxy, strExceptions, 2);
+                    break;
+
                 case ESysProxyType.ForcedChange when Utils.IsLinux():
+                    var exceptions = SanitizeExceptions(config);
                     await ProxySettingLinux.SetProxy(Global.Loopback, port, exceptions);
                     break;
 
                 case ESysProxyType.ForcedChange when Utils.IsMacOS():
-                    await ProxySettingOSX.SetProxy(Global.Loopback, port, exceptions);
+                    var exceptions2 = SanitizeExceptions(config);
+                    await ProxySettingOSX.SetProxy(Global.Loopback, port, exceptions2);
                     break;
 
                 case ESysProxyType.ForcedClear when Utils.IsWindows():
@@ -66,16 +66,9 @@ public static class SysProxyHandler
         return true;
     }
 
-    /// <summary>
-    /// Normalizes a user-entered proxy exception list (comma-separated, used by the
-    /// Linux and macOS proxy tools). Trims surrounding whitespace on each entry
-    /// (including stray line breaks and tabs), drops empty entries left by trailing
-    /// commas, and strips any remaining inner spaces. A single malformed entry
-    /// (e.g. an embedded newline or a trailing comma) otherwise causes macOS configd
-    /// to reject the whole ExceptionsList silently.
-    /// </summary>
-    private static string SanitizeExceptions(string? exceptions)
+    private static string SanitizeExceptions(Config config)
     {
+        var exceptions = config.SystemProxyItem.SystemProxyExceptions;
         if (exceptions.IsNullOrEmpty())
         {
             return string.Empty;
@@ -89,15 +82,15 @@ public static class SysProxyHandler
         return string.Join(',', items);
     }
 
-    private static void GetWindowsProxyString(Config config, int port, out string strProxy, out string strExceptions)
+    private static (string strProxy, string strExceptions) GetWindowsProxyString(Config config, int port)
     {
-        strExceptions = config.SystemProxyItem.SystemProxyExceptions.Replace(" ", "");
+        var strExceptions = config.SystemProxyItem.SystemProxyExceptions.Replace(" ", "");
         if (config.SystemProxyItem.NotProxyLocalAddress)
         {
             strExceptions = $"<local>;{strExceptions}";
         }
 
-        strProxy = string.Empty;
+        var strProxy = string.Empty;
         if (config.SystemProxyItem.SystemProxyAdvancedProtocol.IsNullOrEmpty())
         {
             strProxy = $"{Global.Loopback}:{port}";
@@ -109,6 +102,8 @@ public static class SysProxyHandler
                 .Replace("{http_port}", port.ToString())
                 .Replace("{socks_port}", port.ToString());
         }
+
+        return (strProxy, strExceptions);
     }
 
     [SupportedOSPlatform("windows")]


### PR DESCRIPTION
Fixes #9809

### Problem

On macOS/Linux the system-proxy exception list is comma-separated and passed to `networksetup -setproxybypassdomains`. In `SysProxyHandler.UpdateSysProxy` it was only stripped of spaces (`.Replace(" ", "")`), so a stray newline or a trailing comma left a malformed or empty entry.

`networksetup` accepts these into the preference layer, but macOS `configd` then **silently rejects the whole `ExceptionsList`** when publishing to the dynamic store. Result: `scutil --proxy` shows no `ExceptionsList` at all, the bypass never takes effect, and the user sees the exceptions "still there" in the UI with no error.

A visible knock-on effect: v2rayN's own per-second metrics poll to `127.0.0.1/debug/vars` (via .NET `HttpClient` → system proxy) then loops back through the proxy inbound, spamming `app/router: process not found` errors under TUN + Xray.

### Fix

Introduce `SanitizeExceptions(...)` and use it on the non-Windows path: split on `,` with `StringSplitOptions.TrimEntries | RemoveEmptyEntries`, strip inner spaces, and rejoin. This drops empty entries and trims embedded whitespace/newlines so `configd` accepts the list.

- Behavior-preserving for well-formed input (a clean single-line list rejoins unchanged).
- Windows path (`;`-separated) is intentionally left unchanged.

Verified locally: the exact malformed input `localhost,127.0.0.0/8,::1,\n191.0.0.0,` normalizes to `localhost,127.0.0.0/8,::1,191.0.0.0`, and after applying, `scutil --proxy` publishes the full `ExceptionsList`.

> Note: not built locally (no .NET SDK on this machine); relying on CI to confirm the build.