### PR TITLE
Add upload speed test for profiles

### DIFF
--- a/v2rayN/ServiceLib/Enums/ESpeedActionType.cs
+++ b/v2rayN/ServiceLib/Enums/ESpeedActionType.cs
@@ -6,6 +6,7 @@ public enum ESpeedActionType
     Realping,
     UdpTest,
     Speedtest,
+    UploadSpeedtest,
     Mixedtest,
     FastRealping
 }

--- a/v2rayN/ServiceLib/Global.cs
+++ b/v2rayN/ServiceLib/Global.cs
@@ -161,6 +161,13 @@ public class Global
         @"https://speed.cloudflare.com/__down?bytes=99999999",
     ];
 
+    public static readonly List<string> SpeedUploadTestUrls =
+    [
+        @"https://speed.cloudflare.com/__up?bytes=10000000",
+        @"https://speed.cloudflare.com/__up?bytes=25000000",
+        @"https://speed.cloudflare.com/__up?bytes=50000000",
+    ];
+
     public static readonly List<string> SpeedPingTestUrls =
     [
         @"https://www.google.com/generate_204",

--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -131,6 +131,10 @@ public static class ConfigHandler
         {
             config.SpeedTestItem.SpeedTestUrl = Global.SpeedTestUrls.First();
         }
+        if (config.SpeedTestItem.SpeedUploadTestUrl.IsNullOrEmpty())
+        {
+            config.SpeedTestItem.SpeedUploadTestUrl = Global.SpeedUploadTestUrls.First();
+        }
         if (config.SpeedTestItem.SpeedPingTestUrl.IsNullOrEmpty())
         {
             config.SpeedTestItem.SpeedPingTestUrl = Global.SpeedPingTestUrls.First();

--- a/v2rayN/ServiceLib/Helper/DownloaderHelper.cs
+++ b/v2rayN/ServiceLib/Helper/DownloaderHelper.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 using System.Security.Authentication;
 using Downloader;
 
@@ -7,6 +8,7 @@ public class DownloaderHelper
 {
     private static readonly Lazy<DownloaderHelper> _instance = new(() => new());
     public static DownloaderHelper Instance => _instance.Value;
+    private const long DefaultUploadTestBytes = 10_000_000;
 
     public async Task<string?> DownloadStringAsync(IWebProxy? webProxy, string url, string? userAgent, int timeout)
     {
@@ -130,6 +132,45 @@ public class DownloaderHelper
         await using var stream = await downloader.DownloadFileTaskAsync(address: url, cts.Token);
 
         downloadOpt = null;
+    }
+
+    public async Task UploadDataAsync4Speed(IWebProxy webProxy, string url, IProgress<string> progress, int timeout)
+    {
+        if (url.IsNullOrEmpty())
+        {
+            throw new ArgumentNullException(nameof(url));
+        }
+
+        var uploadBytes = GetUploadTestBytes(url);
+        var connectTimeout = Math.Clamp(timeout / 5, 2, 5);
+        var requestConfiguration = new RequestConfiguration()
+        {
+            ConnectTimeout = connectTimeout * 1000,
+            Proxy = webProxy
+        };
+
+        using var handler = GetSocketsHttpHandler(requestConfiguration);
+        using var client = new HttpClient(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan
+        };
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(TimeSpan.FromSeconds(timeout));
+
+        var content = new SpeedTestUploadContent(uploadBytes, progress);
+        using var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = content
+        };
+        using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+        content.StopTiming();
+        response.EnsureSuccessStatusCode();
+
+        if (content.Elapsed.TotalSeconds > 0)
+        {
+            var speed = uploadBytes / content.Elapsed.TotalSeconds;
+            progress?.Report((speed / 1000 / 1000).ToString("#0.0"));
+        }
     }
 
     public async Task DownloadFileAsync(IWebProxy? webProxy, string url, string fileName, IProgress<double> progress, int timeout)
@@ -265,5 +306,98 @@ public class DownloaderHelper
         }
 
         return handler;
+    }
+
+    private static long GetUploadTestBytes(string url)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return DefaultUploadTestBytes;
+        }
+
+        var query = Utils.ParseQueryString(uri.Query);
+        if (long.TryParse(query["bytes"], out var bytes) && bytes > 0)
+        {
+            return bytes;
+        }
+
+        return DefaultUploadTestBytes;
+    }
+
+    private sealed class SpeedTestUploadContent : HttpContent
+    {
+        private const int BufferSize = 81920;
+        private readonly long _length;
+        private readonly IProgress<string>? _progress;
+        private readonly byte[] _buffer = new byte[BufferSize];
+        private readonly Stopwatch _timer = new();
+
+        public TimeSpan Elapsed => _timer.Elapsed;
+
+        public SpeedTestUploadContent(long length, IProgress<string>? progress)
+        {
+            _length = length;
+            _progress = progress;
+            Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        }
+
+        public void StopTiming()
+        {
+            _timer.Stop();
+        }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+        {
+            return SerializeToStreamAsync(stream, context, CancellationToken.None);
+        }
+
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
+        {
+            _timer.Restart();
+            var lastUpdateTime = _timer.Elapsed;
+            long lastUpdateBytes = 0;
+            long written = 0;
+            double maxSpeed = 0;
+
+            while (written < _length)
+            {
+                var count = (int)Math.Min(BufferSize, _length - written);
+                await stream.WriteAsync(_buffer.AsMemory(0, count), cancellationToken);
+                written += count;
+
+                var elapsed = _timer.Elapsed;
+                if ((elapsed - lastUpdateTime).TotalMilliseconds < 1000)
+                {
+                    continue;
+                }
+
+                maxSpeed = ReportSpeed(_progress, written, lastUpdateBytes, elapsed - lastUpdateTime, maxSpeed);
+                lastUpdateBytes = written;
+                lastUpdateTime = elapsed;
+            }
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = _length;
+            return true;
+        }
+
+        private static double ReportSpeed(IProgress<string>? progress, long written, long lastWritten, TimeSpan elapsed, double maxSpeed)
+        {
+            if (elapsed.TotalSeconds <= 0)
+            {
+                return maxSpeed;
+            }
+
+            var speed = (written - lastWritten) / elapsed.TotalSeconds;
+            if (speed > maxSpeed)
+            {
+                maxSpeed = speed;
+            }
+
+            progress?.Report((maxSpeed / 1000 / 1000).ToString("#0.0"));
+            return maxSpeed;
+        }
     }
 }

--- a/v2rayN/ServiceLib/Models/Configs/ConfigItems.cs
+++ b/v2rayN/ServiceLib/Models/Configs/ConfigItems.cs
@@ -158,6 +158,7 @@ public class SpeedTestItem
 {
     public int SpeedTestTimeout { get; set; }
     public string SpeedTestUrl { get; set; }
+    public string SpeedUploadTestUrl { get; set; }
     public string SpeedPingTestUrl { get; set; }
     public int MixedConcurrencyCount { get; set; }
     public string IPAPIUrl { get; set; }

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -1762,6 +1762,15 @@ namespace ServiceLib.Resx {
         }
         
         /// <summary>
+        ///   查找类似 Test upload speed 的本地化字符串。
+        /// </summary>
+        public static string menuUploadSpeedServer {
+            get {
+                return ResourceManager.GetString("menuUploadSpeedServer", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   查找类似 Add 的本地化字符串。
         /// </summary>
         public static string menuSubAdd {
@@ -4635,6 +4644,15 @@ namespace ServiceLib.Resx {
             }
         }
         
+        /// <summary>
+        ///   查找类似 Upload Speed Test URL 的本地化字符串。
+        /// </summary>
+        public static string TbSettingsSpeedUploadTestUrl {
+            get {
+                return ResourceManager.GetString("TbSettingsSpeedUploadTestUrl", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   查找类似 sing-box ruleset files source (optional) 的本地化字符串。
         /// </summary>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -501,6 +501,9 @@
   <data name="menuSpeedServer" xml:space="preserve">
     <value>Test download speed</value>
   </data>
+  <data name="menuUploadSpeedServer" xml:space="preserve">
+    <value>Test upload speed</value>
+  </data>
   <data name="menuTcpingServer" xml:space="preserve">
     <value>Test tcping</value>
   </data>
@@ -953,6 +956,9 @@
   </data>
   <data name="TbSettingsSpeedTestUrl" xml:space="preserve">
     <value>Speed Test URL</value>
+  </data>
+  <data name="TbSettingsSpeedUploadTestUrl" xml:space="preserve">
+    <value>Upload Speed Test URL</value>
   </data>
   <data name="menuMoveTo" xml:space="preserve">
     <value>Move up and down</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -501,6 +501,9 @@
   <data name="menuSpeedServer" xml:space="preserve">
     <value>测试速度 (多选)</value>
   </data>
+  <data name="menuUploadSpeedServer" xml:space="preserve">
+    <value>测试上传速度 (多选)</value>
+  </data>
   <data name="menuTcpingServer" xml:space="preserve">
     <value>测试延迟 Tcping (多选)</value>
   </data>
@@ -953,6 +956,9 @@
   </data>
   <data name="TbSettingsSpeedTestUrl" xml:space="preserve">
     <value>测速文件地址</value>
+  </data>
+  <data name="TbSettingsSpeedUploadTestUrl" xml:space="preserve">
+    <value>上传测速地址</value>
   </data>
   <data name="menuMoveTo" xml:space="preserve">
     <value>移至上下</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -501,6 +501,9 @@
   <data name="menuSpeedServer" xml:space="preserve">
     <value>測試速度 (多選)</value>
   </data>
+  <data name="menuUploadSpeedServer" xml:space="preserve">
+    <value>測試上傳速度 (多選)</value>
+  </data>
   <data name="menuTcpingServer" xml:space="preserve">
     <value>測試延遲 Tcping (多選)</value>
   </data>
@@ -953,6 +956,9 @@
   </data>
   <data name="TbSettingsSpeedTestUrl" xml:space="preserve">
     <value>測速檔案位址</value>
+  </data>
+  <data name="TbSettingsSpeedUploadTestUrl" xml:space="preserve">
+    <value>上傳測速網址</value>
   </data>
   <data name="menuMoveTo" xml:space="preserve">
     <value>移至上下</value>

--- a/v2rayN/ServiceLib/Services/DownloadService.cs
+++ b/v2rayN/ServiceLib/Services/DownloadService.cs
@@ -40,6 +40,32 @@ public class DownloadService
     }
 
     /// <summary>
+    /// Uploads generated data with the specified proxy and reports progress messages.
+    /// </summary>
+    public async Task<int> UploadDataAsync(string url, IWebProxy webProxy, int downloadTimeout, Func<bool, string, Task> updateFunc)
+    {
+        try
+        {
+            var progress = new Progress<string>();
+            progress.ProgressChanged += (sender, value) => updateFunc?.Invoke(false, $"{value}");
+
+            await DownloaderHelper.Instance.UploadDataAsync4Speed(webProxy,
+                  url,
+                  progress,
+                  downloadTimeout);
+        }
+        catch (Exception ex)
+        {
+            await updateFunc?.Invoke(false, ex.Message);
+            if (ex.InnerException != null)
+            {
+                await updateFunc?.Invoke(false, ex.InnerException.Message);
+            }
+        }
+        return 0;
+    }
+
+    /// <summary>
     /// Downloads a file and reports progress through events.
     /// </summary>
     public async Task DownloadFileAsync(string url, string fileName, bool blProxy, int downloadTimeout)

--- a/v2rayN/ServiceLib/Services/SpeedtestService.cs
+++ b/v2rayN/ServiceLib/Services/SpeedtestService.cs
@@ -61,6 +61,10 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
                 await RunMixedTestAsync(lstSelected, 1, true, exitLoopKey);
                 break;
 
+            case ESpeedActionType.UploadSpeedtest:
+                await RunMixedTestAsync(lstSelected, 1, true, exitLoopKey, blUploadTest: true);
+                break;
+
             case ESpeedActionType.Mixedtest:
                 await RunMixedTestAsync(lstSelected, _config.SpeedTestItem.MixedConcurrencyCount, true, exitLoopKey);
                 break;
@@ -115,6 +119,7 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
                     break;
 
                 case ESpeedActionType.Speedtest:
+                case ESpeedActionType.UploadSpeedtest:
                     await UpdateFunc(it.IndexId, "", ResUI.SpeedtestingWait);
                     ProfileExManager.Instance.SetTestSpeed(it.IndexId, 0);
                     break;
@@ -127,7 +132,7 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
             }
         }
 
-        if (lstSelected.Count > 1 && (actionType == ESpeedActionType.Speedtest || actionType == ESpeedActionType.Mixedtest))
+        if (lstSelected.Count > 1 && (actionType == ESpeedActionType.Speedtest || actionType == ESpeedActionType.UploadSpeedtest || actionType == ESpeedActionType.Mixedtest))
         {
             NoticeManager.Instance.Enqueue(ResUI.SpeedtestingPressEscToExit);
         }
@@ -353,7 +358,7 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
         return true;
     }
 
-    private async Task RunMixedTestAsync(List<ServerTestItem> selecteds, int concurrencyCount, bool blSpeedTest, string exitLoopKey)
+    private async Task RunMixedTestAsync(List<ServerTestItem> selecteds, int concurrencyCount, bool blSpeedTest, string exitLoopKey, bool blUploadTest = false)
     {
         using var concurrencySemaphore = new SemaphoreSlim(concurrencyCount);
         var downloadHandle = new DownloadService();
@@ -392,7 +397,14 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
 
                         if (delay > 0)
                         {
-                            await DoSpeedTest(downloadHandle, it);
+                            if (blUploadTest)
+                            {
+                                await DoUploadSpeedTest(downloadHandle, it);
+                            }
+                            else
+                            {
+                                await DoSpeedTest(downloadHandle, it);
+                            }
                         }
                         else
                         {
@@ -448,6 +460,24 @@ public class SpeedtestService(Config config, Func<SpeedTestResult, Task> updateF
         var url = _config.SpeedTestItem.SpeedTestUrl;
         var timeout = _config.SpeedTestItem.SpeedTestTimeout;
         await downloadHandle.DownloadDataAsync(url, webProxy, timeout, async (success, msg) =>
+        {
+            decimal.TryParse(msg, out var dec);
+            if (dec > 0)
+            {
+                ProfileExManager.Instance.SetTestSpeed(it.IndexId, dec);
+            }
+            await UpdateFunc(it.IndexId, "", msg);
+        });
+    }
+
+    private async Task DoUploadSpeedTest(DownloadService downloadHandle, ServerTestItem it)
+    {
+        await UpdateFunc(it.IndexId, "", ResUI.Speedtesting);
+
+        var webProxy = new WebProxy($"socks5://{Global.Loopback}:{it.Port}");
+        var url = _config.SpeedTestItem.SpeedUploadTestUrl;
+        var timeout = _config.SpeedTestItem.SpeedTestTimeout;
+        await downloadHandle.UploadDataAsync(url, webProxy, timeout, async (success, msg) =>
         {
             decimal.TryParse(msg, out var dec);
             if (dec > 0)

--- a/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
@@ -52,6 +52,7 @@ public class OptionSettingViewModel : MyReactiveObject, ICloseable
     [Reactive] public string CurrentFontFamily { get; set; }
     [Reactive] public int SpeedTestTimeout { get; set; }
     [Reactive] public string SpeedTestUrl { get; set; }
+    [Reactive] public string SpeedUploadTestUrl { get; set; }
     [Reactive] public string SpeedPingTestUrl { get; set; }
     [Reactive] public string UdpTestTarget { get; set; }
     [Reactive] public int MixedConcurrencyCount { get; set; }
@@ -182,6 +183,7 @@ public class OptionSettingViewModel : MyReactiveObject, ICloseable
         CurrentFontFamily = _config.UiItem.CurrentFontFamily;
         SpeedTestTimeout = _config.SpeedTestItem.SpeedTestTimeout;
         SpeedTestUrl = _config.SpeedTestItem.SpeedTestUrl;
+        SpeedUploadTestUrl = _config.SpeedTestItem.SpeedUploadTestUrl;
         MixedConcurrencyCount = _config.SpeedTestItem.MixedConcurrencyCount;
         SpeedPingTestUrl = _config.SpeedTestItem.SpeedPingTestUrl;
         UdpTestTarget = _config.SpeedTestItem.UdpTestTarget;
@@ -355,6 +357,7 @@ public class OptionSettingViewModel : MyReactiveObject, ICloseable
         _config.SpeedTestItem.SpeedTestTimeout = SpeedTestTimeout;
         _config.SpeedTestItem.MixedConcurrencyCount = MixedConcurrencyCount;
         _config.SpeedTestItem.SpeedTestUrl = SpeedTestUrl;
+        _config.SpeedTestItem.SpeedUploadTestUrl = SpeedUploadTestUrl;
         _config.SpeedTestItem.SpeedPingTestUrl = SpeedPingTestUrl;
         _config.SpeedTestItem.UdpTestTarget = UdpTestTarget;
         _config.GuiItem.EnableHWA = EnableHWA;

--- a/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
@@ -73,6 +73,7 @@ public class ProfilesViewModel : MyReactiveObject
     public ReactiveCommand<Unit, Unit> RealPingServerCmd { get; }
     public ReactiveCommand<Unit, Unit> UdpTestServerCmd { get; }
     public ReactiveCommand<Unit, Unit> SpeedServerCmd { get; }
+    public ReactiveCommand<Unit, Unit> UploadSpeedServerCmd { get; }
     public ReactiveCommand<Unit, Unit> SortServerResultCmd { get; }
     public ReactiveCommand<Unit, Unit> RemoveInvalidServerResultCmd { get; }
     public ReactiveCommand<Unit, Unit> FastRealPingCmd { get; }
@@ -197,6 +198,10 @@ public class ProfilesViewModel : MyReactiveObject
         SpeedServerCmd = ReactiveCommand.CreateFromTask(async () =>
         {
             await ServerSpeedtest(ESpeedActionType.Speedtest);
+        }, canEditRemove);
+        UploadSpeedServerCmd = ReactiveCommand.CreateFromTask(async () =>
+        {
+            await ServerSpeedtest(ESpeedActionType.UploadSpeedtest);
         }, canEditRemove);
         SortServerResultCmd = ReactiveCommand.CreateFromTask(async () =>
         {

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
@@ -732,9 +732,9 @@
                             Grid.Column="0"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
-                            Text="{x:Static resx:ResUI.TbSettingsSpeedPingTestUrl}" />
+                            Text="{x:Static resx:ResUI.TbSettingsSpeedUploadTestUrl}" />
                         <ComboBox
-                            x:Name="cmbSpeedPingTestUrl"
+                            x:Name="cmbSpeedUploadTestUrl"
                             Grid.Row="19"
                             Grid.Column="1"
                             Width="300"
@@ -746,10 +746,24 @@
                             Grid.Column="0"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
+                            Text="{x:Static resx:ResUI.TbSettingsSpeedPingTestUrl}" />
+                        <ComboBox
+                            x:Name="cmbSpeedPingTestUrl"
+                            Grid.Row="20"
+                            Grid.Column="1"
+                            Width="300"
+                            Margin="{StaticResource Margin4}"
+                            IsEditable="True" />
+
+                        <TextBlock
+                            Grid.Row="21"
+                            Grid.Column="0"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
                             Text="{x:Static resx:ResUI.TbSettingsUdpTestUrl}" />
                         <ComboBox
                             x:Name="cmbUdpTestTarget"
-                            Grid.Row="20"
+                            Grid.Row="21"
                             Grid.Column="1"
                             Width="200"
                             Margin="{StaticResource Margin4}"

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
@@ -49,6 +49,7 @@ public partial class OptionSettingWindow : WindowBase<OptionSettingViewModel>
         cmbMixedConcurrencyCount.ItemsSource = Enumerable.Range(2, 7).ToList();
         cmbSpeedTestTimeout.ItemsSource = Enumerable.Range(2, 5).Select(i => i * 5).ToList();
         cmbSpeedTestUrl.ItemsSource = Global.SpeedTestUrls;
+        cmbSpeedUploadTestUrl.ItemsSource = Global.SpeedUploadTestUrls;
         cmbSpeedPingTestUrl.ItemsSource = Global.SpeedPingTestUrls;
         cmbUdpTestTarget.ItemsSource = Global.UdpTestTargets;
         cmbSubConvertUrl.ItemsSource = Global.SubConvertUrls;
@@ -105,6 +106,7 @@ public partial class OptionSettingWindow : WindowBase<OptionSettingViewModel>
             this.Bind(ViewModel, vm => vm.CurrentFontFamily, v => v.cmbcurrentFontFamily.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SpeedTestTimeout, v => v.cmbSpeedTestTimeout.SelectedValue).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SpeedTestUrl, v => v.cmbSpeedTestUrl.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SpeedUploadTestUrl, v => v.cmbSpeedUploadTestUrl.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SpeedPingTestUrl, v => v.cmbSpeedPingTestUrl.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.UdpTestTarget, v => v.cmbUdpTestTarget.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.MixedConcurrencyCount, v => v.cmbMixedConcurrencyCount.SelectedValue).DisposeWith(disposables);

--- a/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml
@@ -144,6 +144,10 @@
                             x:Name="menuSpeedServer"
                             Header="{x:Static resx:ResUI.menuSpeedServer}"
                             InputGesture="Ctrl+T" />
+                        <MenuItem
+                            x:Name="menuUploadSpeedServer"
+                            Header="{x:Static resx:ResUI.menuUploadSpeedServer}"
+                            InputGesture="Ctrl+U" />
                         <MenuItem x:Name="menuUdpTestServer" Header="{x:Static resx:ResUI.menuUdpTestServer}" />
                         <MenuItem x:Name="menuSortServerResult" Header="{x:Static resx:ResUI.menuSortServerResult}" />
                         <Separator />

--- a/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/ProfilesView.axaml.cs
@@ -72,6 +72,7 @@ public partial class ProfilesView : ReactiveUserControl<ProfilesViewModel>
             this.BindCommand(ViewModel, vm => vm.RealPingServerCmd, v => v.menuRealPingServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.UdpTestServerCmd, v => v.menuUdpTestServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.SpeedServerCmd, v => v.menuSpeedServer).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.UploadSpeedServerCmd, v => v.menuUploadSpeedServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.SortServerResultCmd, v => v.menuSortServerResult).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.RemoveInvalidServerResultCmd, v => v.menuRemoveInvalidServerResult).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.FastRealPingCmd, v => v.btnFastRealPing).DisposeWith(disposables);
@@ -269,6 +270,10 @@ public partial class ProfilesView : ReactiveUserControl<ProfilesViewModel>
 
                 case Key.T:
                     ViewModel?.ServerSpeedtest(ESpeedActionType.Speedtest);
+                    break;
+
+                case Key.U:
+                    ViewModel?.ServerSpeedtest(ESpeedActionType.UploadSpeedtest);
                     break;
 
                 case Key.E:

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml
@@ -964,9 +964,9 @@
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"
                             Style="{StaticResource ToolbarTextBlock}"
-                            Text="{x:Static resx:ResUI.TbSettingsSpeedPingTestUrl}" />
+                            Text="{x:Static resx:ResUI.TbSettingsSpeedUploadTestUrl}" />
                         <ComboBox
-                            x:Name="cmbSpeedPingTestUrl"
+                            x:Name="cmbSpeedUploadTestUrl"
                             Grid.Row="19"
                             Grid.Column="1"
                             Width="300"
@@ -980,10 +980,26 @@
                             Margin="{StaticResource Margin8}"
                             VerticalAlignment="Center"
                             Style="{StaticResource ToolbarTextBlock}"
+                            Text="{x:Static resx:ResUI.TbSettingsSpeedPingTestUrl}" />
+                        <ComboBox
+                            x:Name="cmbSpeedPingTestUrl"
+                            Grid.Row="20"
+                            Grid.Column="1"
+                            Width="300"
+                            Margin="{StaticResource Margin8}"
+                            IsEditable="True"
+                            Style="{StaticResource DefComboBox}" />
+
+                        <TextBlock
+                            Grid.Row="21"
+                            Grid.Column="0"
+                            Margin="{StaticResource Margin8}"
+                            VerticalAlignment="Center"
+                            Style="{StaticResource ToolbarTextBlock}"
                             Text="{x:Static resx:ResUI.TbSettingsUdpTestUrl}" />
                         <ComboBox
                             x:Name="cmbUdpTestTarget"
-                            Grid.Row="20"
+                            Grid.Row="21"
                             Grid.Column="1"
                             Width="200"
                             Margin="{StaticResource Margin8}"

--- a/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/OptionSettingWindow.xaml.cs
@@ -45,6 +45,7 @@ public partial class OptionSettingWindow
         cmbMixedConcurrencyCount.ItemsSource = Enumerable.Range(2, 7).ToList();
         cmbSpeedTestTimeout.ItemsSource = Enumerable.Range(2, 5).Select(i => i * 5).ToList();
         cmbSpeedTestUrl.ItemsSource = Global.SpeedTestUrls;
+        cmbSpeedUploadTestUrl.ItemsSource = Global.SpeedUploadTestUrls;
         cmbSpeedPingTestUrl.ItemsSource = Global.SpeedPingTestUrls;
         cmbUdpTestTarget.ItemsSource = Global.UdpTestTargets;
         cmbSubConvertUrl.ItemsSource = Global.SubConvertUrls;
@@ -101,6 +102,7 @@ public partial class OptionSettingWindow
             this.Bind(ViewModel, vm => vm.CurrentFontFamily, v => v.cmbcurrentFontFamily.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SpeedTestTimeout, v => v.cmbSpeedTestTimeout.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SpeedTestUrl, v => v.cmbSpeedTestUrl.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.SpeedUploadTestUrl, v => v.cmbSpeedUploadTestUrl.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SpeedPingTestUrl, v => v.cmbSpeedPingTestUrl.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.UdpTestTarget, v => v.cmbUdpTestTarget.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.MixedConcurrencyCount, v => v.cmbMixedConcurrencyCount.Text).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/ProfilesView.xaml
+++ b/v2rayN/v2rayN/Views/ProfilesView.xaml
@@ -168,6 +168,11 @@
                             Header="{x:Static resx:ResUI.menuSpeedServer}"
                             InputGestureText="Ctrl+T" />
                         <MenuItem
+                            x:Name="menuUploadSpeedServer"
+                            Height="{StaticResource MenuItemHeight}"
+                            Header="{x:Static resx:ResUI.menuUploadSpeedServer}"
+                            InputGestureText="Ctrl+U" />
+                        <MenuItem
                             x:Name="menuSortServerResult"
                             Height="{StaticResource MenuItemHeight}"
                             Header="{x:Static resx:ResUI.menuSortServerResult}" />

--- a/v2rayN/v2rayN/Views/ProfilesView.xaml.cs
+++ b/v2rayN/v2rayN/Views/ProfilesView.xaml.cs
@@ -71,6 +71,7 @@ public partial class ProfilesView
             this.BindCommand(ViewModel, vm => vm.RealPingServerCmd, v => v.menuRealPingServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.UdpTestServerCmd, v => v.menuUdpTestServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.SpeedServerCmd, v => v.menuSpeedServer).DisposeWith(disposables);
+            this.BindCommand(ViewModel, vm => vm.UploadSpeedServerCmd, v => v.menuUploadSpeedServer).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.SortServerResultCmd, v => v.menuSortServerResult).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.RemoveInvalidServerResultCmd, v => v.menuRemoveInvalidServerResult).DisposeWith(disposables);
             this.BindCommand(ViewModel, vm => vm.FastRealPingCmd, v => v.btnFastRealPing).DisposeWith(disposables);
@@ -249,6 +250,10 @@ public partial class ProfilesView
 
                 case Key.T:
                     ViewModel?.ServerSpeedtest(ESpeedActionType.Speedtest);
+                    break;
+
+                case Key.U:
+                    ViewModel?.ServerSpeedtest(ESpeedActionType.UploadSpeedtest);
                     break;
 
                 case Key.E:


### PR DESCRIPTION
## Summary

Adds an upload speed test for selected profiles alongside the existing download speed test.

The existing download test does not show uplink performance. This change adds a separate, user-triggered upload test while preserving the current download and mixed-test behavior.

Upload testing was previously requested in #3779, #4250, #4820, and #9583. This implementation is intentionally narrow and follows the existing profile speed-test architecture instead of introducing a separate testing system.

Users can:

- run **Test upload speed** from the profile context menu;
- use `Ctrl+U` as the keyboard shortcut;
- configure the upload test URL in Settings; and
- view the result in the existing speed column.

## Implementation

- Adds `UploadSpeedtest` to the existing speed-test action flow.
- Reuses the same temporary per-profile core, connectivity check, SOCKS proxy, timeout, progress updates, and result storage used by the download test.
- Sends a streamed HTTP `POST` body through the selected profile. The body uses a fixed 80 KiB buffer, so the configured test size is not allocated in memory.
- Reads the upload size from the URL's `bytes` query parameter and falls back to 10 MB when it is absent or invalid.
- Uses Cloudflare's documented `https://speed.cloudflare.com/__up` endpoint, with 10 MB, 25 MB, and 50 MB defaults.
- Reports live progress during the transfer and a final completion-based average when the request completes and response headers are received, avoiding inflated results caused by local socket buffering.
- Adds the setting, command binding, menu item, shortcut, and resources to both the WPF and Avalonia frontends.
- Initializes the new setting for existing configurations and adds English, Simplified Chinese, and Traditional Chinese resources.

## Scope

- Existing download, ping, UDP, and mixed tests keep their current behavior.
- Results reuse the existing generic speed field and column; no profile schema or additional result column is introduced.
- No new package dependencies, project-file changes, workflow changes, or unrelated refactoring are included.

## Verification

- Full solution build succeeds in Debug and Release with .NET SDK 10.0.110.
- `ServiceLib.Tests` passes in Debug and Release: 53 passed, 0 failed.
- Changed C# files pass whitespace and style formatting checks.
- Analyzer validation at error severity passes.
- All changed XAML, AXAML, and RESX files parse successfully.
- Resource keys contain no duplicates, and `ResUI.resx` matches `ResUI.Designer.cs` exactly.
- A throttled loopback receiver verified that the complete request body is transmitted and that the final reported speed matches the completed transfer.
- `git diff --check` passes.
