### PR TITLE
Use the TUN context snapshot in remaining launch-path reads

### DIFF
--- a/v2rayN/ServiceLib/Handler/CoreConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/CoreConfigHandler.cs
@@ -17,7 +17,7 @@ public static class CoreConfigHandler
         {
             result = node.CoreType switch
             {
-                ECoreType.mihomo => await new CoreConfigClashService(config).GenerateClientCustomConfig(node, fileName),
+                ECoreType.mihomo => await new CoreConfigClashService(config, context.IsTunEnabled).GenerateClientCustomConfig(node, fileName),
                 _ => await GenerateClientCustomConfig(node, fileName)
             };
         }

--- a/v2rayN/ServiceLib/Manager/CoreManager.cs
+++ b/v2rayN/ServiceLib/Manager/CoreManager.cs
@@ -85,7 +85,7 @@ public class CoreManager
         await CoreStop();
         await Task.Delay(100);
 
-        if (Utils.IsWindows() && _config.TunModeItem.EnableTun)
+        if (Utils.IsWindows() && (mainContext?.IsTunEnabled == true || preContext?.IsTunEnabled == true))
         {
             await Task.Delay(100);
             await WindowsUtils.RemoveTunDevice();
@@ -222,7 +222,7 @@ public class CoreManager
         {
             return;
         }
-        if (!preContext.AppConfig.TunModeItem.EnableTun)
+        if (!preContext.IsTunEnabled)
         {
             return;
         }

--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigClashService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigClashService.cs
@@ -1,9 +1,11 @@
 namespace ServiceLib.Services.CoreConfig;
 
 /// <summary>
-/// Core configuration file processing class
+/// Core configuration file processing class.
+/// The TUN state is taken as a snapshot so the generated config always agrees
+/// with the launch elevation decision (see CoreManager.ShouldRunAsSudo).
 /// </summary>
-public class CoreConfigClashService(Config config)
+public class CoreConfigClashService(Config config, bool isTunEnabled)
 {
     private static readonly string _tag = "CoreConfigClashService";
 
@@ -102,7 +104,7 @@ public class CoreConfigClashService(Config config)
             }
 
             //enable tun mode
-            if (config.TunModeItem.EnableTun)
+            if (isTunEnabled)
             {
                 var tun = EmbedUtils.GetEmbedText(Global.ClashTunYaml);
                 if (tun.IsNotEmpty())
@@ -171,7 +173,7 @@ public class CoreConfigClashService(Config config)
         }
         foreach (var item in mixinContent)
         {
-            if (!config.TunModeItem.EnableTun && item.Key == "tun")
+            if (!isTunEnabled && item.Key == "tun")
             {
                 continue;
             }


### PR DESCRIPTION
## Summary

Follow-up to #9830, answering the review question there: audited **all** `TunModeItem.EnableTun` usages for the same live-config-vs-snapshot problem. Result: 3 more launch-path reads fixed here; the rest are correct as-is (analysis below).

## Fixed (same class as #9830)

| Site | Problem |
|---|---|
| `CoreConfigClashService` (mihomo custom config, 2 reads) | The generated `tun:` section was decided from the **live** config while the mihomo launch elevation now uses the **snapshot** (`ShouldRunAsSudo`). A mid-reload toggle could produce a config containing tun launched without sudo — the exact failure fixed in #9830, just for mihomo custom nodes. The tun state is now passed into the service as a snapshot (`context.IsTunEnabled`). |
| `CoreManager.LoadCore` (Windows `RemoveTunDevice`) | Pre-start cleanup read the live config; now checks `mainContext`/`preContext` snapshots so it matches the session actually being started. |
| `CoreManager.WaitForProxyPort` | Checked `preContext.AppConfig.TunModeItem.EnableTun` — but `AppConfig` is a shared live reference, so this was effectively a live read. Now uses `preContext.IsTunEnabled`. |

## Audited and intentionally left reading the live config

- `CoreConfigContextBuilder.cs:45` — this **is** the snapshot capture point.
- `ConfigHandler.GetPreSocksItem` (2 reads) — called during snapshot construction inside `BuildAll`; whatever it reads becomes part of the snapshot decision, and every combination it can produce is self-consistent with the launch mode.
- `StatusBarViewModel` (6 reads) — the UI is the source of truth for the toggle; it must read/write the live config.
- `AppManager.StatePort2` — live read by design; a toggle triggers a reload which regenerates configs with the new value, so any skew is transient mid-reload and self-heals. Threading a snapshot through its consumers (Clash API etc.) would be a much larger change for no practical gain.

## Tests

`dotnet test ServiceLib.Tests`: 62 passed, 0 failed. `ServiceLib` and `v2rayN.Desktop` build clean (net10.0, macOS arm64). Diff is 3 files, +9/−7.

Yujie He