### PR TITLE
chore(deps): update NuGet dependencies

### DIFF
--- a/v2rayN/Directory.Packages.props
+++ b/v2rayN/Directory.Packages.props
@@ -7,13 +7,13 @@
   <ItemGroup>
     <PackageVersion Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.1.0" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.1.1" />
     <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
     <PackageVersion Include="AwesomeAssertions" Version="9.5.0" />
     <PackageVersion Include="DialogHost.Avalonia" Version="0.12.3" />
     <PackageVersion Include="IPNetwork2" Version="4.3.0" />
     <PackageVersion Include="ReactiveUI.Avalonia" Version="12.1.0" />
-    <PackageVersion Include="CliWrap" Version="3.10.2" />
+    <PackageVersion Include="CliWrap" Version="3.10.4" />
     <PackageVersion Include="Downloader" Version="5.9.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="H.NotifyIcon.Wpf" Version="2.4.1" />
@@ -22,12 +22,12 @@
     <PackageVersion Include="ReactiveUI" Version="24.0.0" />
     <PackageVersion Include="ReactiveUI.SourceGenerators" Version="3.1.0" />
     <PackageVersion Include="ReactiveUI.WPF" Version="24.0.0" />
-    <PackageVersion Include="Semi.Avalonia" Version="12.1.0" />
+    <PackageVersion Include="Semi.Avalonia" Version="12.1.0.1" />
     <PackageVersion Include="Semi.Avalonia.AvaloniaEdit" Version="12.0.0" />
-    <PackageVersion Include="Semi.Avalonia.DataGrid" Version="12.1.0" />
+    <PackageVersion Include="Semi.Avalonia.DataGrid" Version="12.1.0.1" />
     <PackageVersion Include="NLog" Version="6.1.4" />
     <PackageVersion Include="sqlite-net-e" Version="1.11.285" />
-    <PackageVersion Include="Repobot.SQLite.Unofficial" Version="3.53.3.10" />
+    <PackageVersion Include="Repobot.SQLite.Unofficial" Version="3.53.4" />
     <PackageVersion Include="TaskScheduler" Version="2.12.2" />
     <PackageVersion Include="WebDav.Client" Version="2.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/v2rayN/Directory.Packages.props
+++ b/v2rayN/Directory.Packages.props
@@ -6,13 +6,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.1.2" />
     <PackageVersion Include="Avalonia.Desktop" Version="12.1.1" />
     <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
     <PackageVersion Include="AwesomeAssertions" Version="9.5.0" />
     <PackageVersion Include="DialogHost.Avalonia" Version="0.12.3" />
     <PackageVersion Include="IPNetwork2" Version="4.3.0" />
-    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.1.0" />
+    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.1.1" />
     <PackageVersion Include="CliWrap" Version="3.10.4" />
     <PackageVersion Include="Downloader" Version="5.9.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />

--- a/v2rayN/Directory.Packages.props
+++ b/v2rayN/Directory.Packages.props
@@ -19,9 +19,9 @@
     <PackageVersion Include="H.NotifyIcon.Wpf" Version="2.4.1" />
     <PackageVersion Include="MaterialDesignThemes" Version="5.3.2" />
     <PackageVersion Include="QRCoder" Version="1.8.0" />
-    <PackageVersion Include="ReactiveUI" Version="24.0.0" />
-    <PackageVersion Include="ReactiveUI.SourceGenerators" Version="3.1.0" />
-    <PackageVersion Include="ReactiveUI.WPF" Version="24.0.0" />
+    <PackageVersion Include="ReactiveUI" Version="24.1.0" />
+    <PackageVersion Include="ReactiveUI.SourceGenerators" Version="3.2.0" />
+    <PackageVersion Include="ReactiveUI.WPF" Version="24.1.0" />
     <PackageVersion Include="Semi.Avalonia" Version="12.1.0.1" />
     <PackageVersion Include="Semi.Avalonia.AvaloniaEdit" Version="12.0.0" />
     <PackageVersion Include="Semi.Avalonia.DataGrid" Version="12.1.0.1" />


### PR DESCRIPTION
## Summary

Updates NuGet dependencies in `Directory.Packages.props` to their latest stable
versions. A single file is changed; no source changes are required.

| Package | From | To |
| --- | --- | --- |
| Avalonia.Controls.DataGrid | 12.1.0 | 12.1.2 |
| Avalonia.Desktop | 12.1.0 | 12.1.1 |
| ReactiveUI.Avalonia | 12.1.0 | 12.1.1 |
| CliWrap | 3.10.2 | 3.10.4 |
| ReactiveUI | 24.0.0 | 24.1.0 |
| ReactiveUI.SourceGenerators | 3.1.0 | 3.2.0 |
| ReactiveUI.WPF | 24.0.0 | 24.1.0 |
| Semi.Avalonia | 12.1.0 | 12.1.0.1 |
| Semi.Avalonia.DataGrid | 12.1.0 | 12.1.0.1 |
| Repobot.SQLite.Unofficial | 3.53.3.10 | 3.53.4 |

## Testing

- `dotnet restore --force-evaluate`: all projects restored
- `dotnet build v2rayN.slnx -c Release`: 0 errors, 0 warnings (WPF `v2rayN` and Avalonia `v2rayN.Desktop`)
- `dotnet test ServiceLib.Tests -c Release`: 62/62 passed