### PR TITLE
Fix missing IPv6 default route for Xray TUN

### DIFF
--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayInboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayInboundService.cs
@@ -66,15 +66,14 @@ public partial class CoreConfigV2rayService
 
                 var address = _config.TunModeItem.IPv4Address.NullIfEmpty() ?? Global.TunIPv4Address.First();
                 tunInbound.settings.gateway = [address];
+                tunInbound.settings.autoSystemRoutingTable = ["0.0.0.0/0"];
                 if (_config.TunModeItem.EnableIPv6Address == true)
                 {
                     var address6 = _config.TunModeItem.IPv6Address.NullIfEmpty() ?? Global.TunIPv6Address.First();
                     tunInbound.settings.gateway.Add(address6);
+                    tunInbound.settings.autoSystemRoutingTable.Add("::/0");
                 }
-
-                tunInbound.settings.autoSystemRoutingTable = _config.TunModeItem.EnableIPv6Address
-                    ? ["0.0.0.0/0", "::/0"]
-                    : ["0.0.0.0/0"];
+           
                 var bindInterface = _config.CoreBasicItem.BindInterface?.TrimEx();
                 if (!bindInterface.IsNullOrEmpty())
                 {

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayInboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayInboundService.cs
@@ -72,7 +72,9 @@ public partial class CoreConfigV2rayService
                     tunInbound.settings.gateway.Add(address6);
                 }
 
-                tunInbound.settings.autoSystemRoutingTable = ["0.0.0.0/0"];
+                tunInbound.settings.autoSystemRoutingTable = _config.TunModeItem.EnableIPv6Address
+                    ? ["0.0.0.0/0", "::/0"]
+                    : ["0.0.0.0/0"];
                 var bindInterface = _config.CoreBasicItem.BindInterface?.TrimEx();
                 if (!bindInterface.IsNullOrEmpty())
                 {


### PR DESCRIPTION
## Summary

When IPv6 is enabled for Xray TUN without route exclusions, v2rayN assigns an IPv6 address to the TUN interface but only generates the IPv4 default route:

```json
"autoSystemRoutingTable": ["0.0.0.0/0"]
```

As a result, IPv6 traffic does not enter the tunnel.

This regression was introduced in commit [`e749b81`](https://github.com/2dust/v2rayN/commit/e749b81ecf522a67a59a96d03db948b98ce10dec).

## Changes

Add `::/0` to `autoSystemRoutingTable` when `EnableIPv6Address` is enabled, while preserving IPv4-only behavior when it is disabled.