### PR TITLE
fix: 修复回归的窗口启动时偏右下偏移

### DIFF
--- a/v2rayN/v2rayN.Desktop/Base/WindowBase.cs
+++ b/v2rayN/v2rayN.Desktop/Base/WindowBase.cs
@@ -35,11 +35,16 @@ public class WindowBase<TViewModel> : ReactiveWindow<TViewModel> where TViewMode
 
             var width = Math.Min(sizeItem.Width, workingArea.Width / scaling);
             var height = Math.Min(sizeItem.Height, workingArea.Height / scaling);
-            var x = workingArea.X + ((workingArea.Width - (width * scaling)) / 2);
-            var y = workingArea.Y + ((workingArea.Height - (height * scaling)) / 2);
 
             Width = width;
             Height = height;
+
+            var frameDiff = (FrameSize ?? ClientSize) - ClientSize;
+            var totalWidth = (width + frameDiff.Width) * scaling;
+            var totalHeight = (height + frameDiff.Height) * scaling;
+
+            var x = workingArea.X + ((workingArea.Width - totalWidth) / 2);
+            var y = workingArea.Y + ((workingArea.Height - totalHeight) / 2);
             Position = new PixelPoint((int)x, (int)y);
         }
         catch { }


### PR DESCRIPTION
ref #9498 #9740

修复居中计算未包含窗口边框（FrameSize - ClientSize）导致的偏右下偏移，
窗口大小记忆行为保持不变。