### PR TITLE
fix(core): track every elevated core PID so none is orphaned

### DIFF
--- a/v2rayN/ServiceLib.Tests/Manager/CoreAdminManagerTests.cs
+++ b/v2rayN/ServiceLib.Tests/Manager/CoreAdminManagerTests.cs
@@ -1,0 +1,41 @@
+using AwesomeAssertions;
+using ServiceLib.Manager;
+using Xunit;
+
+namespace ServiceLib.Tests.Manager;
+
+public class CoreAdminManagerTests
+{
+    [Fact]
+    public void TrackSudoPid_TwoElevatedCores_KeepsBothPids()
+    {
+        // Regression guard for the leaked root-owned core: with TUN enabled on
+        // non-Windows, LoadCore elevates the main core and then the pre core, so
+        // RunProcessAsLinuxSudo runs twice per launch. Keeping only the most recent
+        // PID orphans the other launcher, and the unelevated app can never kill a
+        // root-owned process afterwards.
+        var manager = new CoreAdminManager();
+
+        manager.TrackSudoPid(1001); // main core, e.g. Xray
+        manager.TrackSudoPid(1002); // pre core, e.g. sing-box
+
+        // Reverse order: the most recently started core is terminated first.
+        manager.DrainSudoPids().Should().Equal([1002, 1001]);
+    }
+
+    [Fact]
+    public void DrainSudoPids_SecondCall_ReturnsEmpty()
+    {
+        var manager = new CoreAdminManager();
+        manager.TrackSudoPid(1001);
+
+        manager.DrainSudoPids().Should().Equal([1001]);
+        manager.DrainSudoPids().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DrainSudoPids_NothingTracked_ReturnsEmpty()
+    {
+        new CoreAdminManager().DrainSudoPids().Should().BeEmpty();
+    }
+}

--- a/v2rayN/ServiceLib/Manager/CoreAdminManager.cs
+++ b/v2rayN/ServiceLib/Manager/CoreAdminManager.cs
@@ -9,7 +9,8 @@ public class CoreAdminManager
     public static CoreAdminManager Instance => _instance.Value;
     private Config _config;
     private Func<bool, string, Task>? _updateFunc;
-    private int _linuxSudoPid = -1;
+    private readonly List<int> _linuxSudoPids = new();
+    private readonly object _linuxSudoPidsLock = new();
     private const string _tag = "CoreAdminHandler";
 
     public async Task Init(Config config, Func<bool, string, Task> updateFunc)
@@ -64,14 +65,49 @@ public class CoreAdminManager
         {
             throw new Exception(ResUI.FailedToRunCore);
         }
-        _linuxSudoPid = procService.Id;
+        TrackSudoPid(procService.Id);
 
         return procService;
     }
 
+    /// <summary>
+    ///     Remembers a root-owned launcher PID so it can be terminated later.
+    ///     A TUN launch elevates the main core and then the pre core, so this runs more than once
+    ///     per launch and every PID must be kept: the app itself runs unelevated and can only reach
+    ///     these processes through the sudo helper script.
+    /// </summary>
+    public void TrackSudoPid(int pid)
+    {
+        if (pid < 0)
+        {
+            return;
+        }
+
+        lock (_linuxSudoPidsLock)
+        {
+            _linuxSudoPids.Add(pid);
+        }
+    }
+
+    /// <summary>
+    ///     Returns every tracked PID and clears the list, most recently started first so the pre
+    ///     core is torn down before the main core it depends on.
+    /// </summary>
+    public IReadOnlyList<int> DrainSudoPids()
+    {
+        lock (_linuxSudoPidsLock)
+        {
+            var pids = new List<int>(_linuxSudoPids);
+            pids.Reverse();
+            _linuxSudoPids.Clear();
+            return pids;
+        }
+    }
+
     public async Task KillProcessAsLinuxSudo()
     {
-        if (_linuxSudoPid < 0)
+        var pids = DrainSudoPids();
+        if (pids.Count == 0)
         {
             return;
         }
@@ -84,19 +120,30 @@ public class CoreAdminManager
             {
                 shFilePath = shFilePath.AppendQuotes();
             }
-            var arg = new List<string>() { "-c", $"sudo -S {shFilePath} {_linuxSudoPid}" };
-            var result = await Cli.Wrap(Global.LinuxBash)
-                .WithArguments(arg)
-                .WithStandardInputPipe(PipeSource.FromString(AppManager.Instance.LinuxSudoPwd))
-                .ExecuteBufferedAsync();
 
-            await UpdateFunc(false, result.StandardOutput.ToString());
+            foreach (var pid in pids)
+            {
+                // Each PID is terminated independently: one failure must not strand the others,
+                // since a surviving root-owned core keeps holding the TUN device and its routes.
+                try
+                {
+                    var arg = new List<string>() { "-c", $"sudo -S {shFilePath} {pid}" };
+                    var result = await Cli.Wrap(Global.LinuxBash)
+                        .WithArguments(arg)
+                        .WithStandardInputPipe(PipeSource.FromString(AppManager.Instance.LinuxSudoPwd))
+                        .ExecuteBufferedAsync();
+
+                    await UpdateFunc(false, result.StandardOutput.ToString());
+                }
+                catch (Exception ex)
+                {
+                    Logging.SaveLog(_tag, ex);
+                }
+            }
         }
         catch (Exception ex)
         {
             Logging.SaveLog(_tag, ex);
         }
-
-        _linuxSudoPid = -1;
     }
 }


### PR DESCRIPTION
## Problem

A TUN launch on non-Windows elevates **two** cores, not one:

```csharp
// CoreManager.LoadCore
await CoreStart(mainContext);          // elevated -> RunProcessAsLinuxSudo
await WaitForProxyPort(preContext);
await CoreStartPreService(preContext); // elevated -> RunProcessAsLinuxSudo
```

`ShouldRunAsSudo` returns `true` for `Xray`, `sing_box` and `mihomo` alike, so
`RunProcessAsLinuxSudo` is reached twice per launch. But `CoreAdminManager` kept a
single field:

```csharp
private int _linuxSudoPid = -1;
...
_linuxSudoPid = procService.Id;   // second call overwrites the first PID
```

The first PID is lost, so `CoreStop` can only `sudo kill` the most recently started
launcher. The other core is root-owned while the app itself runs unelevated, so the
`_processService.StopAsync()` fallback cannot reach it either — its `_process.Kill(true)`
fails with `operation not permitted`.

The result is an orphaned root-owned core that still owns the TUN device and its
routes. It is invisible to the GUI and survives subsequent restarts, so the user has to
locate and `sudo kill` it by hand.

## Fix

- keep every elevated PID in a list instead of a single field, and terminate all of
  them on stop
- terminate most recent first, so the pre core is torn down before the main core it
  forwards into
- isolate each termination in its own `try/catch`, so one failure cannot strand the
  remaining PIDs

No behaviour change on Windows, and none for single-core (non-TUN) launches.

## Verification

`ServiceLib.Tests`, .NET SDK 10.0.302 on macOS arm64 (`DOTNET_CLI_UI_LANGUAGE=en`).

**1. Baseline on upstream `master`** (fix reverted, new tests removed):

```
Passed!  - Failed:     0, Passed:    62, Skipped:     0, Total:    62, Duration: 217 ms - ServiceLib.Tests.dll (net10.0)
```

**2. New tests against the old single-field implementation** — they fail to compile,
which is exactly the regression they guard:

```
ServiceLib.Tests/Manager/CoreAdminManagerTests.cs(19,17): error CS1061: 'CoreAdminManager' does not contain a definition for 'TrackSudoPid' and no accessible extension method 'TrackSudoPid' accepting a first argument of type 'CoreAdminManager' could be found (are you missing a using directive or an assembly reference?)
ServiceLib.Tests/Manager/CoreAdminManagerTests.cs(23,17): error CS1061: 'CoreAdminManager' does not contain a definition for 'DrainSudoPids' and no accessible extension method 'DrainSudoPids' accepting a first argument of type 'CoreAdminManager' could be found (are you missing a using directive or an assembly reference?)
```

**3. With the fix applied:**

```
Passed!  - Failed:     0, Passed:    65, Skipped:     0, Total:    65, Duration: 219 ms - ServiceLib.Tests.dll (net10.0)
```

**4. `v2rayN.Desktop` builds clean:**

```
    0 Warning(s)
    0 Error(s)
```

### What I did not verify

To be upfront about the limits of the above:

- The new tests cover PID bookkeeping only. The `KillProcessAsLinuxSudo` loop itself is
  not covered, since it needs root and live processes.
- I have not run an end-to-end check that no orphan is left behind after a TUN restart.
- What led me here was an orphaned root-owned sing-box on macOS that survived several
  v2rayN restarts. I have **not** proven that particular orphan came from this code path
  — by the ordering above the leaked core should have been Xray — so please read the
  motivation as "this class of leak is reachable", not as a diagnosis of that incident.
  The defect itself is plain from the code: two elevated launches, one PID field.

### Possible follow-ups (not in this PR)

- `CoreManager.cs` sets `_linuxSudo = true` *before* calling `RunProcessAsLinuxSudo`,
  which throws `FailedToRunCore` when the launcher has already exited — and it throws
  before the PID is tracked. A failed elevated launch can therefore still leave an
  untracked process behind.
- Terminating N PIDs now issues N `sudo -S` calls. The sudo timestamp cache makes this a
  non-issue in the normal path, but teaching the helper script to accept several PIDs
  would collapse it back to a single call. Happy to fold that in if you prefer.
