### PR TITLE
Fix infinite TUN routing loop on traffic to the TUN's own addresses

### DIFF
--- a/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
+++ b/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
@@ -626,4 +626,36 @@ public class CoreConfigSingboxServiceTests
         }
     }
 
+    [Fact]
+    public void GenerateClientConfigContent_TunEnabled_ShouldKeepEmbeddedTunRules()
+    {
+        // The embedded tun rules reject local-network noise (NetBIOS/mDNS, multicast).
+        // They are deserialized into List<Rule4Sbox>, so a schema mismatch in the
+        // embedded template makes JsonUtils.Deserialize return null and silently
+        // drops every one of them.
+        var config = CoreConfigTestFactory.CreateConfig(ECoreType.sing_box);
+        config.TunModeItem.EnableTun = true;
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+
+        var node = CoreConfigTestFactory.CreateVmessNode(ECoreType.sing_box);
+        var context = CoreConfigTestFactory.CreateContext(config, node, ECoreType.sing_box) with
+        {
+            IsTunEnabled = true,
+        };
+
+        var result = new CoreConfigSingboxService(context).GenerateClientConfigContent();
+
+        result.Success.Should().BeTrue($"ret msg: {result.Msg}");
+        var cfg = JsonUtils.Deserialize<SingboxConfig>(result.Data!.ToString())!;
+
+        cfg.route.rules.Should().Contain(
+            r => r.action == "reject"
+                && r.network != null && r.network.Contains("udp")
+                && r.port != null && r.port.Contains(5353),
+            "the embedded tun rules must reject mDNS/NetBIOS noise");
+        cfg.route.rules.Should().Contain(
+            r => r.action == "reject"
+                && r.ip_cidr != null && r.ip_cidr.Contains("224.0.0.0/3"),
+            "the embedded tun rules must reject multicast traffic");
+    }
 }

--- a/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
+++ b/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
@@ -658,4 +658,39 @@ public class CoreConfigSingboxServiceTests
                 && r.ip_cidr != null && r.ip_cidr.Contains("224.0.0.0/3"),
             "the embedded tun rules must reject multicast traffic");
     }
+
+    [Fact]
+    public void GenerateClientConfigContent_TunEnabled_ShouldRejectTrafficToTunOwnAddresses()
+    {
+        // Regression test: traffic addressed to the TUN interface's own addresses must
+        // never reach an outbound. auto_route hijacks the default route, so `direct`
+        // writes such a packet straight back into the TUN, which routes it to the
+        // outbound again - an infinite loop that pins a CPU core. Observed in the wild
+        // with WebRTC ICE connectivity checks against the TUN's own fc00::/7 ULA
+        // address, sustaining ~8k packets/s out of the TUN interface.
+        var config = CoreConfigTestFactory.CreateConfig(ECoreType.sing_box);
+        config.TunModeItem.EnableTun = true;
+        config.TunModeItem.EnableIPv6Address = true;
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+
+        var node = CoreConfigTestFactory.CreateVmessNode(ECoreType.sing_box);
+        var context = CoreConfigTestFactory.CreateContext(config, node, ECoreType.sing_box) with
+        {
+            IsTunEnabled = true,
+        };
+
+        var result = new CoreConfigSingboxService(context).GenerateClientConfigContent();
+
+        result.Success.Should().BeTrue($"ret msg: {result.Msg}");
+        var cfg = JsonUtils.Deserialize<SingboxConfig>(result.Data!.ToString())!;
+        var tun = cfg.inbounds.First(i => i.type == "tun");
+        tun.address.Should().NotBeNullOrEmpty();
+
+        foreach (var address in tun.address!)
+        {
+            cfg.route.rules.Should().Contain(
+                r => r.action == "reject" && r.ip_cidr != null && r.ip_cidr.Contains(address),
+                $"traffic to the TUN's own address '{address}' must be rejected, not routed");
+        }
+    }
 }

--- a/v2rayN/ServiceLib/Sample/tun_singbox_rules
+++ b/v2rayN/ServiceLib/Sample/tun_singbox_rules
@@ -1,6 +1,8 @@
 [
   {
-    "network": "udp",
+    "network": [
+      "udp"
+    ],
     "port": [
       135,
       137,

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
@@ -43,6 +43,22 @@ public partial class CoreConfigSingboxService
                     _coreConfig.route.rules.AddRange(tunRules);
                 }
 
+                // Traffic addressed to the TUN interface's own addresses must never reach an
+                // outbound. auto_route hijacks the default route, so `direct` writes such a
+                // packet straight back into the TUN, which hands it to the outbound again -
+                // an infinite loop that pins a CPU core. Drop instead of rejecting so no
+                // ICMP unreachable is generated back towards the same addresses.
+                var tunAddresses = _coreConfig.inbounds.FirstOrDefault(i => i.type == "tun")?.address;
+                if (tunAddresses?.Count > 0)
+                {
+                    _coreConfig.route.rules.Add(new()
+                    {
+                        ip_cidr = [.. tunAddresses],
+                        action = "reject",
+                        method = "drop",
+                    });
+                }
+
                 var lstDirectExe = BuildRoutingDirectExe();
                 if (lstDirectExe.Count > 0)
                 {


### PR DESCRIPTION
## Problem

On macOS with TUN enabled, the sing-box core spun at **1222% CPU** and had burned
**353 minutes of CPU time** in under 5 hours. The give-away was the TUN interface
counter asymmetry:

```
utun23  9000  172.18/30  172.18.0.1  Ipkts 3173692  Ibytes 3053847176  Opkts 138336049  Obytes 21243071922
```

138M packets out against 3.1M in — a ratio of **43.6** — and 21 GB written into a
TUN that only read 3 GB. `nettop` confirmed the traffic never left the box: the
core wrote 7421 MiB while receiving 4575 KiB, and the downstream xray was
perfectly symmetric (8486 KiB in / 8810 KiB out), so nothing was being proxied.

`tcpdump -i utun23 -Q out` showed what the packets were:

```
IP6 fc00::172:18:0:1.53964 > fc00::172:18:0:1.54097: UDP, length 100
	0x0030:  0001 0050 2112 a442 4a75 5974 6642 4d67  ...P!..BJuYtfBMg
	0x0040:  3661 304d 0006 0009 4174 7742 3a44 7761  6a0M....AtwB:Dwa
	0x0050:  6400 0000 c057 0004 0000 03e7 802a 0008  d....W.......*..
```

`2112a442` is the STUN magic cookie, `0006 0009` a USERNAME attribute holding
`AtwB:Dwad`, followed by PRIORITY, ICE-CONTROLLED and FINGERPRINT — WebRTC ICE
connectivity checks. Source and destination are both `fc00::172:18:0:1`, the TUN
interface's **own** address: a WebRTC client had offered the TUN's ULA as a local
ICE candidate.

That is enough to loop forever. `auto_route` hijacks the default route, so a packet
destined for the TUN's own address is handed to sing-box instead of being looped
back by the kernel. Routing matches `ip_is_private` and sends it to `direct`, whose
interface `auto_detect_interface` resolves to the TUN again — so the packet is
written straight back into the TUN and re-enters routing. Sustained ~8k packets/s,
pinning a core.

While tracing this I found the generated `configPre.json` was also missing both
rules from the embedded `tun_singbox_rules` template. The template declares:

```json
{ "network": "udp", "port": [135, 137, 138, 139, 5353], "action": "reject" }
```

`network` is a bare string, but `Rule4Sbox.network` is a `List<string>`.
`System.Text.Json` throws on the first rule, `JsonUtils.Deserialize` swallows the
exception and returns `default`, and `GenRouting` only null-checks before
`AddRange` — so the entire rule set is dropped without a trace. Neither the
NetBIOS/mDNS reject nor the multicast reject has ever reached a generated config;
the template has used the string form since the rules file was introduced, which
predates the sing-box 1.12 migration.

## Fix

- `tun_singbox_rules`: declare `network` as an array so the template matches
  `Rule4Sbox`, restoring the two rules that were being dropped.
- `SingboxRoutingService`: reject the TUN inbound's own addresses before any
  outbound rule can match. The addresses are read back from the already-generated
  inbound (`GenInbounds` runs before `GenRouting`) so the two cannot drift apart
  when a user overrides `TunModeItem.IPv4Address`/`IPv6Address`. Uses
  `method: "drop"` rather than the default ICMP unreachable, whose destination
  would be the looping address itself.

## Verification

Unit tests — two new cases, both watched failing first:

```
$ dotnet test ServiceLib.Tests/ServiceLib.Tests.csproj --filter 'FullyQualifiedName~ShouldKeepEmbeddedTunRules|FullyQualifiedName~ShouldRejectTrafficToTunOwnAddresses'
失败!  - 失败:     2，通过:     0，已跳过:     0，总计:     2
                domain_suffix = <null>,  to have an item matching (((((r.action == "reject") AndAlso (r.network != null)) AndAlso r.network.Contains("udp")) AndAlso (r.port != null)) AndAlso r.port.Contains(5353)) because the embedded tun rules must reject mDNS/NetBIOS noise.
```

After the fix, full suite:

```
$ dotnet test ServiceLib.Tests/ServiceLib.Tests.csproj
已通过! - 失败:     0，通过:    64，已跳过:     0，总计:    64，持续时间: 246 ms - ServiceLib.Tests.dll (net10.0)
```

Deployed a local build (macOS 15.7.7, arm64, osx-arm64 self-contained) over the
affected setup. Generated `configPre.json` now carries all four reject rules,
including the two that had never appeared before:

```
tun interface_name: utun57
tun address: ['172.18.0.1/30', 'fc00::172:18:0:1/126']
reject rules (4):
   {"network": ["udp"], "port": [135, 137, 138, 139, 5353], "action": "reject"}
   {"ip_cidr": ["224.0.0.0/3", "ff00::/8"], "action": "reject"}
   {"ip_cidr": ["172.18.0.1/30", "fc00::172:18:0:1/126"], "action": "reject", "method": "drop"}
   {"network": ["udp"], "port": [443], "action": "reject"}

TUN self-addresses rejected: ['172.18.0.1/30', 'fc00::172:18:0:1/126']
all TUN addresses covered  : True
embedded mDNS reject present: True
embedded multicast present  : True
```

Loop gone. CPU dropped from 1222.8% to 2.6% (11.75s of CPU time over 1m55s of
uptime), and the packet asymmetry inverted to a normal download-heavy profile:

```
interface: utun57   (sampled over 20s)
  in :   68158 pkts ->   77412   (  463 pkt/s)
  out:   37997 pkts ->   42650   (  233 pkt/s)

  cumulative out/in packet ratio: 0.55
  (before the fix: 138,336,049 out / 3,173,692 in = 43.59)
```

300 consecutive packets captured on the new TUN contain zero self-addressed
frames, and proxying is unaffected:

```
抓到总包数: 300
TUN 自身地址自环包 (fc00::172:18:0:1 -> fc00::172:18:0:1): 0
IP 104.156.226.115.26212 > 172.18.0.1.63598: Flags [.], ack 3511952766, win 65535, ...
IP 172.18.0.1.63901 > 104.156.226.115.26212: Flags [P.], seq 1:65, ack 5287, win 4253, ...
```
