### PR TITLE
docs: link minimum OS requirements from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Read the Wiki for usage guides and configuration details.
 | Linux | ✅ | - | ✅ | ✅ | ✅ |
 | macOS | ✅ | - | ✅ | - | - |
 
+Minimum OS requirements: [Release files introduction](https://github.com/2dust/v2rayN/wiki/Release-files-introduction) / 最低系统要求：[发布文件介绍](https://github.com/2dust/v2rayN/wiki/Release-files-introduction)
+
 ---
 
 ## GPG Verification / GPG 签名校验


### PR DESCRIPTION
## Summary

Replaces the earlier requirements table with a single bilingual line under "Supported Platforms" that links to the wiki page [Release files introduction](https://github.com/2dust/v2rayN/wiki/Release-files-introduction), following the review feedback: the README stays minimal and the wiki remains the single source of truth for minimum OS requirements.

Ready-to-paste wiki text for the two outdated blocks (Linux distributions and macOS version) is posted in the comments below.

## Testing

- `git diff` vs master: two added lines in `README.md`, no existing lines changed
