### PR TITLE
Harden untrusted-input parsers against crashes, hangs and a memory bomb

### DIFF
--- a/v2rayN/ServiceLib/Common/JsonUtils.cs
+++ b/v2rayN/ServiceLib/Common/JsonUtils.cs
@@ -40,7 +40,12 @@ public class JsonUtils
 
     private static readonly JsonDocumentOptions _defaultDocumentOptions = new()
     {
-        CommentHandling = JsonCommentHandling.Skip
+        CommentHandling = JsonCommentHandling.Skip,
+        // Reject duplicate property names during parsing. Without this, JsonNode.Parse accepts
+        // them and a JsonObject throws ArgumentException lazily when it builds its dictionary on
+        // first property access - outside this try/catch, at the parser call sites. With it, the
+        // failure surfaces here as a JsonException and ParseJson returns null gracefully.
+        AllowDuplicateProperties = false
     };
 
     /// <summary>

--- a/v2rayN/ServiceLib/Common/QRCodeUtils.cs
+++ b/v2rayN/ServiceLib/Common/QRCodeUtils.cs
@@ -59,8 +59,8 @@ public class QRCodeUtils
 
         try
         {
-            var image = SKImage.FromEncodedData(fileName);
-            var bitmap = SKBitmap.FromImage(image);
+            using var data = SKData.Create(fileName);
+            var bitmap = DecodeWithinLimit(data);
 
             return ReaderBarcode(bitmap);
         }
@@ -72,15 +72,42 @@ public class QRCodeUtils
         return null;
     }
 
+    // A QR code from a screen capture or an image file is at most a few megapixels. A crafted
+    // image header can declare enormous dimensions (e.g. a 26-byte GIF claiming 4097x65529 =
+    // ~268 MP), making SKBitmap.Decode allocate gigabytes; the reader then scans a flipped copy
+    // too, so the process hangs on ~8s of CPU and multiple GB of RAM. Cap the pixel count well
+    // above any real QR before decoding.
+    private const long MaxBarcodeImagePixels = 4096L * 4096L;
+
+    private static SKBitmap? DecodeWithinLimit(SKData data)
+    {
+        if (data == null)
+        {
+            return null;
+        }
+        using var codec = SKCodec.Create(data);
+        if (codec == null)
+        {
+            return null;
+        }
+        var info = codec.Info;
+        if ((long)info.Width * info.Height > MaxBarcodeImagePixels)
+        {
+            return null;
+        }
+        return SKBitmap.Decode(codec);
+    }
+
     public static string? ParseBarcode(byte[]? bytes)
     {
+        if (bytes == null)
+        {
+            return null;
+        }
         try
         {
-            var bitmap = SKBitmap.Decode(bytes);
-            //using var stream = new FileStream("test2.png", FileMode.Create, FileAccess.Write);
-            //using var image = SKImage.FromBitmap(bitmap);
-            //using var encodedImage = image.Encode();
-            //encodedImage.SaveTo(stream);
+            using var data = SKData.CreateCopy(bytes);
+            var bitmap = DecodeWithinLimit(data);
             return ReaderBarcode(bitmap);
         }
         catch
@@ -93,6 +120,10 @@ public class QRCodeUtils
 
     private static string? ReaderBarcode(SKBitmap? bitmap)
     {
+        if (bitmap == null)
+        {
+            return null;
+        }
         var reader = new BarcodeReader();
         var result = reader.Decode(bitmap);
 

--- a/v2rayN/ServiceLib/Common/Utils.cs
+++ b/v2rayN/ServiceLib/Common/Utils.cs
@@ -596,7 +596,13 @@ public class Utils
     {
         try
         {
-            return new Uri(url);
+            var uri = new Uri(url);
+            // Uri computes the IDN host lazily, so an invalid host (e.g. a soft hyphen U+00AD,
+            // zero-width space U+200B, or replacement char U+FFFD produced by decoding garbage
+            // bytes) does not fail here but throws UriFormatException later at every uri.IdnHost
+            // access. Force the evaluation now so such URIs are rejected in this single guard.
+            _ = uri.IdnHost;
+            return uri;
         }
         catch (UriFormatException)
         {

--- a/v2rayN/ServiceLib/Handler/Fmt/ShadowsocksFmt.cs
+++ b/v2rayN/ServiceLib/Handler/Fmt/ShadowsocksFmt.cs
@@ -296,6 +296,12 @@ public class ShadowsocksFmt : BaseFmt
             List<ProfileItem> lst = [];
             foreach (var it in lstSsServer)
             {
+                // A JSON array like [null] deserializes to a list with a null element; skip it
+                // to avoid a NullReferenceException dereferencing it.remarks/server/etc. below.
+                if (it is null)
+                {
+                    continue;
+                }
                 var ssItem = new ProfileItem()
                 {
                     Remarks = it.remarks,

--- a/v2rayN/ServiceLib/Models/Dto/HyRealm.cs
+++ b/v2rayN/ServiceLib/Models/Dto/HyRealm.cs
@@ -42,6 +42,15 @@ public record HyRealm(
             var uri = new Uri(str);
             var token = Utils.UrlDecode(uri.UserInfo);
             var rendezvousHost = uri.Host;
+            // Reject a host that is empty or not a valid host name / IP literal. For an unknown
+            // scheme new Uri(...) parses the host leniently (e.g. "realm://.?vu/..." yields
+            // Host="."), but ToUri() later feeds it to UriBuilder, whose Uri getter then throws
+            // UriFormatException ("The hostname could not be parsed"). CheckHostName screens out
+            // both the empty and the malformed cases.
+            if (Uri.CheckHostName(rendezvousHost) == UriHostNameType.Unknown)
+            {
+                return false;
+            }
             var rendezvousPort = uri.IsDefaultPort ? (isHttp ? 80 : 443) : uri.Port;
             var realmName = uri.AbsolutePath.TrimStart('/');
             var stunList = new List<string>();


### PR DESCRIPTION
## Harden untrusted-input parsers against crashes, hangs and a memory bomb

This series fixes five defects in the share-link / subscription / QR import
parsers, all reachable from untrusted input (a malicious subscription provider,
a crafted QR code, or a share link pasted from a chat). They were found by
coverage-guided fuzzing (SharpFuzz + libFuzzer) of the ServiceLib parsers and
each is confirmed reproducible in a normal Release build; all 64 existing
ServiceLib.Tests still pass after the fixes.

Why several of these matter beyond a caught exception: ConfigHandler.
AddBatchServers deletes the existing subscription servers *before* parsing the
new body, so an unhandled parse exception on the import path loses the user's
server list. On the WPF build App_DispatcherUnhandledException swallows it; the
Avalonia (Linux/macOS) build has no such handler.

  1. Utils.TryUri - Uri.IdnHost throws lazily for invalid IDN hosts (incl. the
     invisible U+00AD / U+200B and the U+FFFD from decoding garbage bytes),
     outside the guard, in 10 parsers + AddSubItem. (UriFormatException)
  2. JsonUtils.ParseJson - duplicate JSON keys throw ArgumentException lazily on
     first access, outside the catch, in the V2ray/Singbox/Inner config import
     (no enclosing catch on that path). One-line option fixes all three.
  3. HyRealm.TryParse - an empty or malformed host (e.g. "realm://.?vu/..."
     yields Host=".") is accepted, then ToUri() throws UriFormatException.
     Rejected via Uri.CheckHostName.
  4. ShadowsocksFmt.ResolveSip008 - a SIP008 body of [null] dereferences a null
     element -> NullReferenceException. 6-byte input.
  5. QRCodeUtils.ParseBarcode - a 26-byte GIF declaring 4097x65529 makes the
     decoder allocate ~1 GB and the reader scan a flipped copy too: ~8s and
     ~3.6 GB on the UI thread. Cap dimensions before decoding.

Minimal reproducers and a full write-up per finding are available on request.

Note on disclosure: there is no SECURITY.md in the repo, so these are sent as
normal patches. Items 2, 4 and 5 are denial-of-service / data-loss on import
and may warrant a private channel if you prefer - happy to follow whatever
process you use.

---
_5 commits, one per fix. Found by coverage-guided fuzzing (SharpFuzz + libFuzzer) of the ServiceLib parsers. Each reproduces in a normal Release build; all 64 ServiceLib.Tests pass after the fixes._
