### PR TITLE
修复 Windows TUN 设备清理

### DIFF
--- a/v2rayN/ServiceLib/Common/WindowsUtils.cs
+++ b/v2rayN/ServiceLib/Common/WindowsUtils.cs
@@ -54,12 +54,12 @@ internal static class WindowsUtils
 
     public static async Task RemoveTunDevice()
     {
-        var tunNameList = new List<string> { "wintunsingbox_tun", "xray_tun" };
+        var tunNameList = new List<string> { "singbox_tun", "xray_tun" };
         foreach (var tunName in tunNameList)
         {
             try
             {
-                var sum = MD5.HashData(Encoding.UTF8.GetBytes(tunName));
+                var sum = MD5.HashData(Encoding.UTF8.GetBytes($"wintun{tunName}"));
                 var guid = new Guid(sum);
                 var pnpUtilPath = @"C:\Windows\System32\pnputil.exe";
                 var arg = $$""" /remove-device  "SWD\Wintun\{{{guid}}}" """;


### PR DESCRIPTION
Windows 下 TUN 重启时，旧的 Wintun 设备没有被正确移除，导致后续可能无法正常启动。这里修正了设备 GUID 的计算。



请在 Windows 上再帮忙测试一下这个修复，如果还有问题麻烦告诉我。