### PR TITLE
修复 Windows 下由于 Wintun GUID 计算错误导致 TUN 无法正常重启的问题

### DIFF
--- a/v2rayN/ServiceLib/Common/WindowsUtils.cs
+++ b/v2rayN/ServiceLib/Common/WindowsUtils.cs
@@ -54,12 +54,12 @@ internal static class WindowsUtils
 
     public static async Task RemoveTunDevice()
     {
-        var tunNameList = new List<string> { "wintunsingbox_tun", "xray_tun" };
+        var tunNameList = new List<string> { "singbox_tun", "xray_tun" };
         foreach (var tunName in tunNameList)
         {
             try
             {
-                var sum = MD5.HashData(Encoding.UTF8.GetBytes(tunName));
+                var sum = MD5.HashData(Encoding.UTF8.GetBytes($"wintun{tunName}"));
                 var guid = new Guid(sum);
                 var pnpUtilPath = @"C:\Windows\System32\pnputil.exe";
                 var arg = $$""" /remove-device  "SWD\Wintun\{{{guid}}}" """;


### PR DESCRIPTION
修复了 `xray_tun` 残留网卡无法被正常卸载，导致 TUN 模式重启失败的问题。

Wintun 的设备 GUID 是通过 `wintun` + `网卡名` 算 MD5 得来的。之前的代码里 `xray_tun` 漏加了 `wintun` 前缀，导致算出的 GUID 不对，找不到老设备。这次统一加上前缀再算就可以了。
