### PR TITLE
Fix tray server selection being cleared after refresh (#9927)

### DIFF
--- a/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
@@ -297,15 +297,9 @@ public partial class StatusBarViewModel : MyReactiveObject
             return;
         }
 
-        var models = new List<ComboItem>();
-        BlServers = true;
-        foreach (var it in lstModel)
-        {
-            var name = it.GetSummary();
+        var models = lstModel.Select(it => new ComboItem { ID = it.IndexId, Text = it.GetSummary() }).ToList();
 
-            var item = new ComboItem() { ID = it.IndexId, Text = name };
-            models.Add(item);
-        }
+        BlServers = true;
         Servers.Clear();
         Servers.AddRange(models);
 

--- a/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
@@ -305,13 +305,12 @@ public partial class StatusBarViewModel : MyReactiveObject
 
             var item = new ComboItem() { ID = it.IndexId, Text = name };
             models.Add(item);
-            if (_config.IndexId == it.IndexId)
-            {
-                SelectedServer = item;
-            }
         }
         Servers.Clear();
         Servers.AddRange(models);
+
+        // Update the ItemsSource before SelectedItem so a collection reset does not clear the tray selection.
+        SelectedServer = models.FirstOrDefault(it => it.ID == _config.IndexId) ?? new();
     }
 
     private void ServerSelectedChanged(bool c)


### PR DESCRIPTION
 Summary
- Keep the tray server ComboBox synchronized with the active server after refreshing profiles.
- Fix the empty tray server selection that may appear after switching to a Custom or other server.

Root cause
`SelectedServer` was assigned before the refreshed item was added to `Servers`. The following collection reset caused the WPF ComboBox to clear its selection.

Fix
Refresh the `Servers` collection first, then select the item matching `_config.IndexId`.

 Testing
- `ServiceLib.Tests`: 64 tests passed.
- Windows WPF project built successfully with 0 warnings and 0 errors.
- Verified that the selected server remains visible after the ComboBox collection is refreshed.

Fixes #9927