### PR TITLE
Always route IPv6 into Xray TUN regardless of EnableIPv6Address

### DIFF
--- a/v2rayN/ServiceLib.Tests/CoreConfig/CoreConfigTestFactory.cs
+++ b/v2rayN/ServiceLib.Tests/CoreConfig/CoreConfigTestFactory.cs
@@ -251,4 +251,12 @@ internal static class CoreConfigTestFactory
         config.TunModeItem.RouteExcludeAddress = ["10.0.0.1/32", "192.168.1.0/24", "fc00::/7"];
         return config;
     }
+
+    public static Config CreateConfigWithTun(ECoreType coreType, bool enableIPv6Address)
+    {
+        var config = CreateConfig(coreType);
+        config.TunModeItem.EnableTun = true;
+        config.TunModeItem.EnableIPv6Address = enableIPv6Address;
+        return config;
+    }
 }

--- a/v2rayN/ServiceLib.Tests/CoreConfig/V2ray/CoreConfigV2rayServiceTests.cs
+++ b/v2rayN/ServiceLib.Tests/CoreConfig/V2ray/CoreConfigV2rayServiceTests.cs
@@ -570,6 +570,51 @@ public class CoreConfigV2rayServiceTests
         directOutbound!.streamSettings.sockopt!.domainStrategy.Should().Be("UseIPv4");
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void GenerateClientConfigContent_Tun_ShouldRouteIPv6IntoTunnel(bool enableIPv6Address)
+    {
+        var config = CoreConfigTestFactory.CreateConfigWithTun(ECoreType.Xray, enableIPv6Address);
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+
+        var node = CoreConfigTestFactory.CreateVmessNode(ECoreType.Xray, "n-main", "main");
+        var context = CoreConfigTestFactory.CreateContext(config, node, ECoreType.Xray);
+
+        var result = new CoreConfigV2rayService(context).GenerateClientConfigContent();
+
+        result.Success.Should().BeTrue();
+        var cfg = JsonUtils.Deserialize<V2rayConfig>(result.Data!.ToString())!;
+        var tunInbound = cfg.inbounds.FirstOrDefault(i => i.protocol == "tun");
+
+        tunInbound.Should().NotBeNull();
+        tunInbound!.settings.autoSystemRoutingTable.Should().Contain("0.0.0.0/0");
+        tunInbound.settings.autoSystemRoutingTable.Should().Contain("::/0");
+
+        // EnableIPv6Address governs the interface address only, never the routing table.
+        tunInbound.settings.gateway.Should().HaveCount(enableIPv6Address ? 2 : 1);
+    }
+
+    [Fact]
+    public void GenerateClientConfigContent_TunRouteExcludeAddress_ShouldIncludeIPv6Ranges()
+    {
+        var config = CoreConfigTestFactory.CreateConfigWithTunRouteExcludeAddress(ECoreType.Xray);
+        config.TunModeItem.EnableIPv6Address = false;
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+
+        var node = CoreConfigTestFactory.CreateVmessNode(ECoreType.Xray, "n-main", "main");
+        var context = CoreConfigTestFactory.CreateContext(config, node, ECoreType.Xray);
+
+        var result = new CoreConfigV2rayService(context).GenerateClientConfigContent();
+
+        result.Success.Should().BeTrue();
+        var cfg = JsonUtils.Deserialize<V2rayConfig>(result.Data!.ToString())!;
+        var tunInbound = cfg.inbounds.FirstOrDefault(i => i.protocol == "tun");
+
+        tunInbound.Should().NotBeNull();
+        tunInbound!.settings.autoSystemRoutingTable.Should().Contain(x => x.Contains(':'));
+    }
+
     [Fact]
     public void GenerateClientConfigContent_TunRouteExcludeAddress()
     {

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayInboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayInboundService.cs
@@ -67,12 +67,14 @@ public partial class CoreConfigV2rayService
 
                 var address = _config.TunModeItem.IPv4Address.NullIfEmpty() ?? Global.TunIPv4Address.First();
                 tunInbound.settings.gateway = [address];
-                tunInbound.settings.autoSystemRoutingTable = ["0.0.0.0/0"];
+                // Route both families into the tunnel regardless of EnableIPv6Address. That option only
+                // controls whether the interface gets an IPv6 address; leaving ::/0 out of the routing
+                // table makes IPv6 follow the system default route and bypass the tunnel entirely.
+                tunInbound.settings.autoSystemRoutingTable = ["0.0.0.0/0", "::/0"];
                 if (_config.TunModeItem.EnableIPv6Address == true)
                 {
                     var address6 = _config.TunModeItem.IPv6Address.NullIfEmpty() ?? Global.TunIPv6Address.First();
                     tunInbound.settings.gateway.Add(address6);
-                    tunInbound.settings.autoSystemRoutingTable.Add("::/0");
                 }
 
                 var bindInterface = _config.CoreBasicItem.BindInterface?.TrimEx();
@@ -118,15 +120,8 @@ public partial class CoreConfigV2rayService
                     includeList = IPNetwork2.Supernet(includeList.ToArray()).ToList();
                     includeListV6 = IPNetwork2.Supernet(includeListV6.ToArray()).ToList();
 
-                    if (_config.TunModeItem.EnableIPv6Address)
-                    {
-                        tunInbound.settings.autoSystemRoutingTable = includeList.Select(x => x.ToString())
-                            .Concat(includeListV6.Select(x => x.ToString())).ToList();
-                    }
-                    else
-                    {
-                        tunInbound.settings.autoSystemRoutingTable = includeList.Select(x => x.ToString()).ToList();
-                    }
+                    tunInbound.settings.autoSystemRoutingTable = includeList.Select(x => x.ToString())
+                        .Concat(includeListV6.Select(x => x.ToString())).ToList();
                 }
 
                 _coreConfig.inbounds.Add(tunInbound);


### PR DESCRIPTION
## 问题

`EnableIPv6Address` 的语义是"TUN 接口是否分配 IPv6 地址",但它同时决定了 `::/0` 是否加入 `autoSystemRoutingTable`。该项默认为 `false`,此时 IPv6 在路由表中没有指向 TUN 的条目,按系统默认路由从物理网卡出去,隧道未生效,支持 IPv6 的网站可看到本机真实 IPv6 地址。

内置模板 `Sample/SampleTunInbound` 中该字段本身包含双栈,生成时被整个覆盖。#9843 只在 `EnableIPv6Address == true` 分支内补回了 `::/0`,`false` 分支未覆盖。

sing-box 路径不受影响,因为它另有 `strict_route` 下发 `from all unreachable`,IPv6 被判为不可达而非放行。

详细分析、复现方法与对照实验见 #9929。

## 改动

`V2rayInboundService.cs` 两处:

1. `autoSystemRoutingTable` 无条件包含 `0.0.0.0/0` 与 `::/0`,`EnableIPv6Address` 只保留控制 `gateway` 接口地址的职责。
2. `RouteExcludeAddress` 分支中存在同样的条件判断,去掉 if/else,始终合并 v4 与 v6 的 include 列表。只修第一处的话,配置了排除地址的用户仍会泄露。

修改后 IPv6 始终进入隧道。默认 `RouteOnly=false` 下嗅探会还原域名交给出站,仅支持 IPv4 的出口可用 IPv4 完成请求;若目标为 IPv6 字面地址且出口无 IPv6 则连接失败,但不泄露。

## 测试

已验证:编译通过,无新增警告;运行时生成的配置在 `EnableIPv6Address=false` 下为

```text
gateway                = ["172.18.0.1/30"]        // 接口未分配 IPv6 地址
autoSystemRoutingTable = ["0.0.0.0/0", "::/0"]    // IPv6 归隧道管
```

修改前此处为 `["0.0.0.0/0"]`。

未验证:运行时行为。测试环境中 `xray_tun` 未能建立(Xray 创建 TUN 需 root,便携部署下 sudo 流程未走通),未观察到路由表变化。此外,Windows 与 macOS 是否接受为无 IPv6 地址的接口添加 `::/0` 未测试;Linux 上可行,TUN 设备有内核分配的 link-local 地址。

Fixes #9929

---

*本 PR 的排查、源码定位、补丁与正文均由 [Claude Code](https://claude.com/claude-code) 生成。Reviewed by @liuclare*
