### PR TITLE
Set tun "route only" to true

### DIFF
--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayInboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayInboundService.cs
@@ -83,7 +83,8 @@ public partial class CoreConfigV2rayService
                     tunInbound.settings.autoOutboundsInterface = bindInterface;
                 }
                 tunInbound.sniffing = inbound.sniffing;
-                tunInbound.sniffing.routeOnly = inbound.sniffing.routeOnly;
+                // tunInbound.sniffing.routeOnly = inbound.sniffing.routeOnly;
+                tunInbound.sniffing.routeOnly = true;
 
                 if (_config.TunModeItem.RouteExcludeAddress is { Count: > 0 })
                 {


### PR DESCRIPTION
tun 上设置 sniff_override_destination 弊大于利

sniff_override_destination 唯二的好处是解决 DNS 污染和 L3/L4 传递域名
弊是会使电脑上所有 fake sni 服务失效，包括 reality, ech, tor 等等

~~话说当年不是也认同 `Set tun "route only" to true` 吗？~~
https://github.com/2dust/v2rayN/commit/620422350f312ea7a7c2897b4806316aeea0192a#diff-04071cc924733260a0af8914d9ba0365ff2d1b1f41e24a6e78c059f5235090d0R195