### PR TITLE
Narrow the TUN self-address drop rule to single addresses

### DIFF
--- a/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
+++ b/v2rayN/ServiceLib.Tests/CoreConfig/Singbox/CoreConfigSingboxServiceTests.cs
@@ -57,6 +57,85 @@ public class CoreConfigSingboxServiceTests
     }
 
     [Fact]
+    public void GenerateClientConfigContent_TunEnabled_ShouldKeepEmbeddedTunRules()
+    {
+        // The embedded tun rules reject local-network noise (NetBIOS/mDNS, multicast).
+        // They are deserialized into List<Rule4Sbox>, so a schema mismatch in the
+        // embedded template makes JsonUtils.Deserialize return null and silently
+        // drops every one of them.
+        var config = CoreConfigTestFactory.CreateConfig(ECoreType.sing_box);
+        config.TunModeItem.EnableTun = true;
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+
+        var node = CoreConfigTestFactory.CreateVmessNode(ECoreType.sing_box);
+        var context = CoreConfigTestFactory.CreateContext(config, node, ECoreType.sing_box) with
+        {
+            IsTunEnabled = true,
+        };
+
+        var result = new CoreConfigSingboxService(context).GenerateClientConfigContent();
+
+        result.Success.Should().BeTrue($"ret msg: {result.Msg}");
+        var cfg = JsonUtils.Deserialize<SingboxConfig>(result.Data!.ToString())!;
+
+        cfg.route.rules.Should().Contain(
+            r => r.action == "reject"
+                && r.network != null && r.network.Contains("udp")
+                && r.port != null && r.port.Contains(5353),
+            "the embedded tun rules must reject mDNS/NetBIOS noise");
+        cfg.route.rules.Should().Contain(
+            r => r.action == "reject"
+                && r.ip_cidr != null && r.ip_cidr.Contains("224.0.0.0/3"),
+            "the embedded tun rules must reject multicast traffic");
+    }
+
+    [Fact]
+    public void GenerateClientConfigContent_TunEnabled_ShouldRejectTrafficToTunOwnAddresses()
+    {
+        // Regression test: traffic addressed to the TUN interface's own addresses must
+        // never reach an outbound. auto_route hijacks the default route, so `direct`
+        // writes such a packet straight back into the TUN, which routes it to the
+        // outbound again - an infinite loop that pins a CPU core. Observed in the wild
+        // with WebRTC ICE connectivity checks against the TUN's own fc00::/7 ULA
+        // address, sustaining ~8k packets/s out of the TUN interface.
+        var config = CoreConfigTestFactory.CreateConfig(ECoreType.sing_box);
+        config.TunModeItem.EnableTun = true;
+        config.TunModeItem.EnableIPv6Address = true;
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+
+        var node = CoreConfigTestFactory.CreateVmessNode(ECoreType.sing_box);
+        var context = CoreConfigTestFactory.CreateContext(config, node, ECoreType.sing_box) with
+        {
+            IsTunEnabled = true,
+        };
+
+        var result = new CoreConfigSingboxService(context).GenerateClientConfigContent();
+
+        result.Success.Should().BeTrue($"ret msg: {result.Msg}");
+        var cfg = JsonUtils.Deserialize<SingboxConfig>(result.Data!.ToString())!;
+        var tun = cfg.inbounds.First(i => i.type == "tun");
+        tun.address.Should().NotBeNullOrEmpty();
+
+        foreach (var address in tun.address!)
+        {
+            var self = IPAddress.Parse(address.Split('/').First());
+            var hostBits = self.AddressFamily == AddressFamily.InterNetworkV6 ? 128 : 32;
+            var expected = $"{self}/{hostBits}";
+            cfg.route.rules.Should().Contain(
+                r => r.action == "reject" && r.ip_cidr != null && r.ip_cidr.Contains(expected),
+                $"traffic to the TUN's own address '{address}' must be rejected, not routed");
+        }
+
+        // The match has to stay on the addresses themselves. sing-tun derives the TUN's DNS
+        // entry from the address right after the interface's own, and every prefix offered
+        // here leaves room for it, so a prefix match would drop system name lookups too.
+        var dropRule = cfg.route.rules.First(r =>
+            r.action == "reject" && r.method == "drop" && r.ip_cidr?.Count > 0);
+        dropRule.ip_cidr!.Should().OnlyContain(c =>
+            c.EndsWith("/32", StringComparison.Ordinal) || c.EndsWith("/128", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void GenerateClientConfigContent_BindInterface_ShouldUseDialBindInterface()
     {
         var config = CoreConfigTestFactory.CreateConfig(ECoreType.sing_box);

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxRoutingService.cs
@@ -48,12 +48,18 @@ public partial class CoreConfigSingboxService
                 // packet straight back into the TUN, which hands it to the outbound again -
                 // an infinite loop that pins a CPU core. Drop instead of rejecting so no
                 // ICMP unreachable is generated back towards the same addresses.
+                //
+                // Match each address on its own, not the prefix it carries. On Linux sing-tun
+                // registers Inet4Address[0].Addr().Next() with systemd-resolved as a "~." DNS
+                // upstream, and every prefix offered here is a /30 or /126, so carrying the
+                // prefix through would cover that resolver address too and drop every system
+                // name lookup along with the loop.
                 var tunAddresses = _coreConfig.inbounds.FirstOrDefault(i => i.type == "tun")?.address;
                 if (tunAddresses?.Count > 0)
                 {
                     _coreConfig.route.rules.Add(new()
                     {
-                        ip_cidr = [.. tunAddresses],
+                        ip_cidr = [.. tunAddresses.Select(ToSingleAddressPrefix)],
                         action = "reject",
                         method = "drop",
                     });
@@ -282,6 +288,14 @@ public partial class CoreConfigSingboxService
         {
             Logging.SaveLog(_tag, ex);
         }
+    }
+
+    private static string ToSingleAddressPrefix(string address)
+    {
+        var addr = address.Split('/').First();
+        return IPAddress.TryParse(addr, out var ip)
+            ? $"{addr}/{(ip.AddressFamily == AddressFamily.InterNetworkV6 ? 128 : 32)}"
+            : address;
     }
 
     private List<string> BuildRoutingDirectExe()


### PR DESCRIPTION
Fixes #9934

已在真机运行测试，环境为 Linux + systemd-resolved、sing-box 1.13.12、TUN 默认配置。下方两组验证都是实际运行的结果。

`#9897` 加入的防回环规则把 TUN 入站的 `address` 原样作为 `ip_cidr`，`/30` 或 `/126` 的接口前缀成为匹配范围。

sing-tun 把接口地址加一后的地址作为 TUN 的 DNS 入口，Windows 经 `luid.SetDNS`，Linux 经 systemd-resolved，两者都在 `AutoRoute` 且未禁用 DNS 劫持时执行，取值方式相同。该地址恒落在接口前缀内：取值处的 `HasNextAddress` 判断限定了这一点，而 `Global.TunIPv4Address` 的八个预设全部是 `/30`、IPv6 预设全部是 `/126`，sing-box 的 system stack 又拒绝单地址前缀，因此没有能避开的配置。

结果是系统解析器发往该地址的查询命中 drop，无回应也无 ICMP，直到超时。代理链路本身正常，表现为域名解析全部失败。

按地址逐个匹配保留了 `#9897` 的目的，该 PR 诊断的回环目标是接口地址本身，收窄后仍然命中；DNS 入口地址由 sing-box 处理。

真机验证（Linux）：用生成的配置直接运行 sing-box，两次运行只改这条规则的前缀长度。

```text
ip_cidr ["172.18.0.1/30"]   getent hosts www.google.com -> 空，3/3
ip_cidr ["172.18.0.1/32"]   getent hosts www.google.com -> 正常，3/3
```

两次运行中 `dig` 走公共解析器、按 IP 直连 HTTPS、本地 mixed 端口均正常。

真机端到端：应用本 PR 编译 v2rayN 并实际运行，生成的配置为 `drop ip_cidr: ["172.18.0.1/32"]`，五次采样中 `getent`、`resolvectl query`、HTTP 请求均正常。

一并恢复 `#9897` 的两个回归测试，它们在 `eff58459`（#9817）中被删除，其实现代码与模板修复未受影响。`ShouldRejectTrafficToTunOwnAddresses` 的断言改为匹配单地址形式，并增加对前缀长度的检查，因此同时覆盖两侧：它原本要防的回环，以及需要留给 sing-box 的 DNS 入口地址。

该测试在 `8b4063b4` 上失败，本 PR 上 69 个测试全部通过。

Windows 与 macOS 未测试。

---

*本 PR 的排查、源码定位、补丁与正文由 [Claude Code](https://claude.com/claude-code) 生成。Reviewed by @liuclare*
