### PR TITLE
Add uot and congestion_control URL parameters to NaiveFmt

### DIFF
--- a/v2rayN/ServiceLib/Handler/Fmt/NaiveFmt.cs
+++ b/v2rayN/ServiceLib/Handler/Fmt/NaiveFmt.cs
@@ -42,6 +42,11 @@ public class NaiveFmt : BaseFmt
         var query = Utils.ParseQueryString(parsedUrl.Query);
         ResolveUriQuery(query, ref item);
         var insecureConcurrency = int.TryParse(GetQueryValue(query, "insecure-concurrency"), out var ic) ? ic : 0;
+        protocolExtra = protocolExtra with
+        {
+            Uot = GetQueryValue(query, "uot") == "1" ? true : null,
+            CongestionControl = GetQueryValue(query, "congestion_control"),
+        };
         if (insecureConcurrency > 0)
         {
             protocolExtra = protocolExtra with
@@ -69,6 +74,14 @@ public class NaiveFmt : BaseFmt
         var dicQuery = new Dictionary<string, string>();
         ToUriQuery(item, Global.None, ref dicQuery);
         var protocolExtra = item.GetProtocolExtra();
+        if (protocolExtra.Uot == true)
+        {
+            dicQuery.Add("uot", "1");
+        }
+        if (!protocolExtra.CongestionControl.IsNullOrEmpty())
+        {
+            dicQuery.Add("congestion_control", protocolExtra.CongestionControl);
+        }
         if (protocolExtra.InsecureConcurrency > 0)
         {
             dicQuery.Add("insecure-concurrency", protocolExtra?.InsecureConcurrency.ToString());


### PR DESCRIPTION
## Summary

v2rayN's `ProtocolExtraItem` model already supports `Uot` (UDP over TCP) and `CongestionControl` for naive proxy nodes, but `NaiveFmt` did not parse or generate these parameters from share link URLs. Users always had to manually toggle UDP over TCP and congestion control in the UI after importing naive nodes.

## Changes

**Resolve** (parsing share link → config):
- Read `uot=1` → `protocolExtra.Uot = true`
- Read `congestion_control=bbr` → `protocolExtra.CongestionControl = "bbr"`

**ToUri** (generating share link from config):
- Write `protocolExtra.Uot == true` → `uot=1`
- Write `protocolExtra.CongestionControl` → `congestion_control=bbr`

## Pattern reference

This matches the exact pattern already used by `TuicFmt.cs` for `congestion_control`:

https://github.com/2dust/v2rayN/blob/master/v2rayN/ServiceLib/Handler/Fmt/TuicFmt.cs#L36

## Example share links

```
naive+https://user:pass@host:443?security=tls&sni=example.com&uot=1&congestion_control=bbr&padding=1&fp=chrome&pcs=abc123#naive-h2
naive+quic://user:pass@host:443?security=tls&sni=example.com&uot=1&congestion_control=bbr&padding=1&fp=chrome&pcs=abc123#naive-h3
```