### PR TITLE
Perf hy2 fmt

### DIFF
--- a/v2rayN/ServiceLib/Handler/Fmt/Hysteria2Fmt.cs
+++ b/v2rayN/ServiceLib/Handler/Fmt/Hysteria2Fmt.cs
@@ -169,6 +169,14 @@ public class Hysteria2Fmt : BaseFmt
         if (item.CertSha.IsNullOrEmpty())
         {
             item.CertSha = GetQueryDecoded(query, "pinSHA256");
+            // NOTE:
+            // To accommodate Xray changes,
+            // some providers issue self-signed cert links with `insecure = false` and a certificate fingerprint,
+            // breaking interoperability between Xray, official Hysteria 2 client, and sing-box.
+            // Since this won't compromise the overall security model,
+            // `insecure = true` is automatically set when a fingerprint is detected,
+            // and the value is restored when generating configurations.
+            item.AllowInsecure = Global.StringTrue;
         }
         item.SetProtocolExtra(item.GetProtocolExtra() with
         {


### PR DESCRIPTION
经用户反馈，部分机场对 xray 客户端发放 `/?insecure=false&sni=www.bing.com&pinSHA256=1d...` 自签证书节点分享链接。而这破坏了官方 hysteria2 和 sing-box 的可用性。

鉴于 R 佬所说，已固定证书则 insecure 不会明显影响整体安全模型，所以如果检测到 pinSHA256 不为空则自动设置 insecure 为 true