### PR TITLE
Profile pre-resolver

### DIFF
--- a/v2rayN/Directory.Packages.props
+++ b/v2rayN/Directory.Packages.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
     <PackageVersion Include="AwesomeAssertions" Version="9.5.0" />
     <PackageVersion Include="DialogHost.Avalonia" Version="0.12.3" />
+    <PackageVersion Include="DnsClientX" Version="2.1.0" />
     <PackageVersion Include="IPNetwork2" Version="4.3.0" />
     <PackageVersion Include="ReactiveUI.Avalonia" Version="12.1.1" />
     <PackageVersion Include="CliWrap" Version="3.10.4" />

--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using DnsClientX;
 
 namespace ServiceLib.Handler;
 
@@ -1633,10 +1634,15 @@ public static class ConfigHandler
         }
 
         var subFilter = string.Empty;
+        var preResolver = string.Empty;
         if (isSub && subid.IsNotEmpty())
         {
             subFilter = (await AppManager.Instance.GetSubItem(subid))?.Filter ?? "";
+            preResolver = (await AppManager.Instance.GetSubItem(subid))?.PreResolver ?? "";
         }
+
+        await using var dnsClient = preResolver.IsNullOrEmpty() ? null : new ClientX(preResolver, DnsRequestFormat.DnsOverHttp2);
+        var dnsCache = new Dictionary<string, string>();
 
         var countServers = 0;
         List<ProfileItem> lstAdd = [];
@@ -1672,6 +1678,28 @@ public static class ConfigHandler
             }
             profileItem.Subid = subid;
             profileItem.IsSub = isSub;
+
+            if (dnsClient is not null && profileItem.Address.IsNotEmpty())
+            {
+                if (!dnsCache.TryGetValue(profileItem.Address, out var resolvedAddress))
+                {
+                    var response = await dnsClient.Resolve(profileItem.Address);
+                    foreach (var typedAnswer in response.TypedAnswers!)
+                    {
+                        resolvedAddress = typedAnswer switch
+                        {
+                            ARecord a => a.Address.ToString(),
+                            AAAARecord aaaa => aaaa.Address.ToString(),
+                            _ => string.Empty,
+                        };
+                    }
+                    dnsCache[profileItem.Address] = resolvedAddress;
+                }
+                if (!resolvedAddress.IsNullOrEmpty())
+                {
+                    profileItem.Address = resolvedAddress;
+                }
+            }
 
             var addStatus = profileItem.ConfigType switch
             {

--- a/v2rayN/ServiceLib/Models/Entities/SubItem.cs
+++ b/v2rayN/ServiceLib/Models/Entities/SubItem.cs
@@ -35,4 +35,6 @@ public class SubItem
     public string? Memo { get; set; }
 
     public ECoreType? CustomCoreType { get; set; }
+
+    public string? PreResolver { get; set; }
 }

--- a/v2rayN/ServiceLib/ServiceLib.csproj
+++ b/v2rayN/ServiceLib/ServiceLib.csproj
@@ -5,6 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="DnsClientX" />
 		<PackageReference Include="Downloader" />
 		<PackageReference Include="IPNetwork2" />
 		<PackageReference Include="ReactiveUI">


### PR DESCRIPTION
添加订阅分组`预解析`，更新时解析域名到 IP

同时解决 proxy-server-nameserver, 部分服务商使用私有 DNS 保护解析节点地址