### PR TITLE
feat: add native linux wayland support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -402,3 +402,6 @@ FodyWeavers.xsd
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# Local packaging/test artifacts
+dist/

--- a/package-debian-loong.sh
+++ b/package-debian-loong.sh
@@ -597,7 +597,7 @@ package_binary() {
   write_desktop_file "$stage"
   write_maintainer_scripts "$debian_dir"
 
-  extra_depends="libc6 (>= 2.39), fontconfig (>= 2.15.0), desktop-file-utils (>= 0.26), xdg-utils (>= 1.1.3), coreutils (>= 9.4), bash (>= 5.2.21), libfreetype6 (>= 2.13)"
+  extra_depends="libc6 (>= 2.39), fontconfig (>= 2.15.0), desktop-file-utils (>= 0.26), xdg-utils (>= 1.1.3), coreutils (>= 9.4), bash (>= 5.2.21), libfreetype6 (>= 2.13), libwayland-client0, libwayland-cursor0, libwayland-egl1, libxkbcommon0, libegl1, libgbm1, libdrm2, libglib2.0-0"
   
   mkdir -p "$workdir/debian"
   cat > "$workdir/debian/control" <<EOF

--- a/package-debian-riscv.sh
+++ b/package-debian-riscv.sh
@@ -595,7 +595,7 @@ package_binary() {
   write_desktop_file "$stage"
   write_maintainer_scripts "$debian_dir"
 
-  extra_depends="libc6 (>= 2.39), fontconfig (>= 2.15.0), desktop-file-utils (>= 0.26), xdg-utils (>= 1.1.3), coreutils (>= 9.4), bash (>= 5.2.21), libfreetype6 (>= 2.13)"
+  extra_depends="libc6 (>= 2.39), fontconfig (>= 2.15.0), desktop-file-utils (>= 0.26), xdg-utils (>= 1.1.3), coreutils (>= 9.4), bash (>= 5.2.21), libfreetype6 (>= 2.13), libwayland-client0, libwayland-cursor0, libwayland-egl1, libxkbcommon0, libegl1, libgbm1, libdrm2, libglib2.0-0"
   
   mkdir -p "$workdir/debian"
   cat > "$workdir/debian/control" <<EOF

--- a/package-debian.sh
+++ b/package-debian.sh
@@ -609,7 +609,7 @@ package_binary() {
   write_desktop_file "$stage"
   write_maintainer_scripts "$debian_dir"
 
-  extra_depends="libc6 (>= 2.39), fontconfig (>= 2.15.0), desktop-file-utils (>= 0.26), xdg-utils (>= 1.1.3), coreutils (>= 9.4), bash (>= 5.2.21), libfreetype6 (>= 2.13)"
+  extra_depends="libc6 (>= 2.39), fontconfig (>= 2.15.0), desktop-file-utils (>= 0.26), xdg-utils (>= 1.1.3), coreutils (>= 9.4), bash (>= 5.2.21), libfreetype6 (>= 2.13), libwayland-client0, libwayland-cursor0, libwayland-egl1, libxkbcommon0, libegl1, libgbm1, libdrm2, libglib2.0-0"
 
   mkdir -p "$workdir/debian"
   cat > "$workdir/debian/control" <<EOF

--- a/package-rhel-loong.sh
+++ b/package-rhel-loong.sh
@@ -509,7 +509,9 @@ BugURL:         https://github.com/2dust/v2rayN/issues
 ExclusiveArch:  loongarch64
 Source0:        __PKGROOT__.tar.gz
 
-Requires:       cairo, pango, openssl, mesa-libEGL, mesa-libGL
+Requires:       cairo, pango, openssl, mesa-libEGL, mesa-libGL, mesa-libgbm
+Requires:       libwayland-client, libwayland-cursor, libwayland-egl
+Requires:       libxkbcommon, libdrm, glib2
 Requires:       glibc >= 2.39
 Requires:       fontconfig >= 2.15.0
 Requires:       desktop-file-utils >= 0.26

--- a/package-rhel-riscv.sh
+++ b/package-rhel-riscv.sh
@@ -508,7 +508,9 @@ BugURL:         https://github.com/2dust/v2rayN/issues
 ExclusiveArch:  riscv64
 Source0:        __PKGROOT__.tar.gz
 
-Requires:       cairo, pango, openssl, mesa-libEGL, mesa-libGL
+Requires:       cairo, pango, openssl, mesa-libEGL, mesa-libGL, mesa-libgbm
+Requires:       libwayland-client, libwayland-cursor, libwayland-egl
+Requires:       libxkbcommon, libdrm, glib2
 Requires:       glibc >= 2.39
 Requires:       fontconfig >= 2.15.0
 Requires:       desktop-file-utils >= 0.26

--- a/package-rhel.sh
+++ b/package-rhel.sh
@@ -497,7 +497,9 @@ BugURL:         https://github.com/2dust/v2rayN/issues
 ExclusiveArch:  aarch64 x86_64
 Source0:        __PKGROOT__.tar.gz
 
-Requires:       cairo, pango, openssl, mesa-libEGL, mesa-libGL
+Requires:       cairo, pango, openssl, mesa-libEGL, mesa-libGL, mesa-libgbm
+Requires:       libwayland-client, libwayland-cursor, libwayland-egl
+Requires:       libxkbcommon, libdrm, glib2
 Requires:       glibc >= 2.39
 Requires:       fontconfig >= 2.15.0
 Requires:       desktop-file-utils >= 0.26

--- a/v2rayN/Directory.Packages.props
+++ b/v2rayN/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.1.2" />
     <PackageVersion Include="Avalonia.Desktop" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Wayland" Version="12.1.1" />
     <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
     <PackageVersion Include="AwesomeAssertions" Version="9.5.0" />
     <PackageVersion Include="DialogHost.Avalonia" Version="0.12.3" />

--- a/v2rayN/ServiceLib/Models/Configs/ConfigItems.cs
+++ b/v2rayN/ServiceLib/Models/Configs/ConfigItems.cs
@@ -101,6 +101,7 @@ public class UIItem
     public bool AutoHideStartup { get; set; }
     public bool Hide2TrayWhenClose { get; set; }
     public bool MacOSShowInDock { get; set; }
+    public bool EnableLinuxWayland { get; set; }
     public List<ColumnItem> MainColumnItem { get; set; }
     public List<WindowSizeItem> WindowSizeItem { get; set; }
     public bool HideColumnIpInfo { get; set; }

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -4221,18 +4221,12 @@ namespace ServiceLib.Resx {
             }
         }
 
-        /// <summary>
-        ///   查找类似 Enable native Wayland backend (requires restart) 的本地化字符串。
-        /// </summary>
         public static string TbSettingsEnableLinuxWayland {
             get {
                 return ResourceManager.GetString("TbSettingsEnableLinuxWayland", resourceCulture);
             }
         }
 
-        /// <summary>
-        ///   查找类似 Linux only. Disable it if cursor themes, tray, or window behavior are abnormal. 的本地化字符串。
-        /// </summary>
         public static string TbSettingsEnableLinuxWaylandTip {
             get {
                 return ResourceManager.GetString("TbSettingsEnableLinuxWaylandTip", resourceCulture);

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -4220,6 +4220,24 @@ namespace ServiceLib.Resx {
                 return ResourceManager.GetString("TbSettingsEnableDragDropSort", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   查找类似 Enable native Wayland backend (requires restart) 的本地化字符串。
+        /// </summary>
+        public static string TbSettingsEnableLinuxWayland {
+            get {
+                return ResourceManager.GetString("TbSettingsEnableLinuxWayland", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   查找类似 Linux only. Disable it if cursor themes, tray, or window behavior are abnormal. 的本地化字符串。
+        /// </summary>
+        public static string TbSettingsEnableLinuxWaylandTip {
+            get {
+                return ResourceManager.GetString("TbSettingsEnableLinuxWaylandTip", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   查找类似 Enable fragment 的本地化字符串。

--- a/v2rayN/ServiceLib/Resx/ResUI.fa.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fa.resx
@@ -909,6 +909,12 @@
   <data name="TbSettingsEnableDragDropSort" xml:space="preserve">
     <value>فعال کردن مرتب‌سازی سرورها با کشیدن و رها کردن (نیاز به راه‌اندازی مجدد)</value>
   </data>
+  <data name="TbSettingsEnableLinuxWayland" xml:space="preserve">
+    <value>فعال‌سازی بک‌اند بومی Wayland [آزمایشی] (نیاز به راه‌اندازی مجدد)</value>
+  </data>
+  <data name="TbSettingsEnableLinuxWaylandTip" xml:space="preserve">
+    <value>فقط برای لینوکس. اگر تم نشانگر، سینی یا رفتار پنجره غیرعادی بود، این گزینه را غیرفعال کنید.</value>
+  </data>
   <data name="TbAutoRefresh" xml:space="preserve">
     <value>بازخوانی خودکار</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.fr.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fr.resx
@@ -909,6 +909,12 @@
   <data name="TbSettingsEnableDragDropSort" xml:space="preserve">
     <value>Activer le tri par glisser-déposer des configurations (redémarrage requis)</value>
   </data>
+  <data name="TbSettingsEnableLinuxWayland" xml:space="preserve">
+    <value>Activer le backend Wayland natif [expérimental] (redémarrage requis)</value>
+  </data>
+  <data name="TbSettingsEnableLinuxWaylandTip" xml:space="preserve">
+    <value>Linux uniquement. Si le thème du curseur, la zone de notification ou le comportement des fenêtres est anormal, désactivez cette option.</value>
+  </data>
   <data name="TbAutoRefresh" xml:space="preserve">
     <value>Actualisation automatique</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.hu.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.hu.resx
@@ -909,6 +909,12 @@
   <data name="TbSettingsEnableDragDropSort" xml:space="preserve">
     <value>Konfigurációk rendezésének engedélyezése húzással (újraindítást igényel)</value>
   </data>
+  <data name="TbSettingsEnableLinuxWayland" xml:space="preserve">
+    <value>Natív Wayland háttérrendszer engedélyezése [kísérleti] (újraindítást igényel)</value>
+  </data>
+  <data name="TbSettingsEnableLinuxWaylandTip" xml:space="preserve">
+    <value>Csak Linuxon. Ha a kurzortéma, a rendszertálca vagy az ablakok viselkedése rendellenes, kapcsold ki ezt az opciót.</value>
+  </data>
   <data name="TbAutoRefresh" xml:space="preserve">
     <value>Automatikus frissítés</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.id.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.id.resx
@@ -909,6 +909,12 @@
   <data name="TbSettingsEnableDragDropSort" xml:space="preserve">
     <value>Aktifkan pengurutan konfigurasi dengan seret dan lepas (perlu mulai ulang)</value>
   </data>
+  <data name="TbSettingsEnableLinuxWayland" xml:space="preserve">
+    <value>Aktifkan backend Wayland native [eksperimental] (perlu mulai ulang)</value>
+  </data>
+  <data name="TbSettingsEnableLinuxWaylandTip" xml:space="preserve">
+    <value>Hanya untuk Linux. Jika tema kursor, tray, atau perilaku jendela tidak normal, nonaktifkan opsi ini.</value>
+  </data>
   <data name="TbAutoRefresh" xml:space="preserve">
     <value>Muat ulang otomatis</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -910,10 +910,10 @@
     <value>Enable sorting Configurations by drag-n-drop (requires restart)</value>
   </data>
   <data name="TbSettingsEnableLinuxWayland" xml:space="preserve">
-    <value>Enable native Wayland backend (requires restart)</value>
+    <value>Enable native Wayland backend [Experimental] (requires restart)</value>
   </data>
   <data name="TbSettingsEnableLinuxWaylandTip" xml:space="preserve">
-    <value>Linux only. Disable it if cursor themes, tray, or window behavior are abnormal.</value>
+    <value>Linux only. If the cursor theme, tray, or window behavior is abnormal, disable this option.</value>
   </data>
   <data name="TbAutoRefresh" xml:space="preserve">
     <value>Auto refresh</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -909,6 +909,12 @@
   <data name="TbSettingsEnableDragDropSort" xml:space="preserve">
     <value>Enable sorting Configurations by drag-n-drop (requires restart)</value>
   </data>
+  <data name="TbSettingsEnableLinuxWayland" xml:space="preserve">
+    <value>Enable native Wayland backend (requires restart)</value>
+  </data>
+  <data name="TbSettingsEnableLinuxWaylandTip" xml:space="preserve">
+    <value>Linux only. Disable it if cursor themes, tray, or window behavior are abnormal.</value>
+  </data>
   <data name="TbAutoRefresh" xml:space="preserve">
     <value>Auto refresh</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -909,6 +909,12 @@
   <data name="TbSettingsEnableDragDropSort" xml:space="preserve">
     <value>Включить сортировку перетаскиванием сервера (требуется перезапуск)</value>
   </data>
+  <data name="TbSettingsEnableLinuxWayland" xml:space="preserve">
+    <value>Включить нативный бэкенд Wayland [экспериментально] (требуется перезапуск)</value>
+  </data>
+  <data name="TbSettingsEnableLinuxWaylandTip" xml:space="preserve">
+    <value>Только для Linux. Если тема курсора, трей или поведение окон работают некорректно, отключите этот параметр.</value>
+  </data>
   <data name="TbAutoRefresh" xml:space="preserve">
     <value>Автообновление</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -909,6 +909,12 @@
   <data name="TbSettingsEnableDragDropSort" xml:space="preserve">
     <value>启用配置拖放排序 (需重启)</value>
   </data>
+  <data name="TbSettingsEnableLinuxWayland" xml:space="preserve">
+    <value>启用原生 Wayland 后端 [实验性] (需重启)</value>
+  </data>
+  <data name="TbSettingsEnableLinuxWaylandTip" xml:space="preserve">
+    <value>仅 Linux 可用，若光标主题，托盘或窗口行为异常，请关闭此项。</value>
+  </data>
   <data name="TbAutoRefresh" xml:space="preserve">
     <value>自动刷新</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -910,10 +910,10 @@
     <value>啟用拖放排序 (需重啟)</value>
   </data>
   <data name="TbSettingsEnableLinuxWayland" xml:space="preserve">
-    <value>啟用原生 Wayland 後端 (需重啟)</value>
+    <value>啟用原生 Wayland 後端 [實驗性] (需重啟)</value>
   </data>
   <data name="TbSettingsEnableLinuxWaylandTip" xml:space="preserve">
-    <value>僅 Linux 可用。如游標主題、托盤或視窗行為異常，請關閉此項。</value>
+    <value>僅 Linux 可用，若游標主題、托盤或視窗行為異常，請關閉此項。</value>
   </data>
   <data name="TbAutoRefresh" xml:space="preserve">
     <value>自動重新整理</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hant.resx
@@ -909,6 +909,12 @@
   <data name="TbSettingsEnableDragDropSort" xml:space="preserve">
     <value>啟用拖放排序 (需重啟)</value>
   </data>
+  <data name="TbSettingsEnableLinuxWayland" xml:space="preserve">
+    <value>啟用原生 Wayland 後端 (需重啟)</value>
+  </data>
+  <data name="TbSettingsEnableLinuxWaylandTip" xml:space="preserve">
+    <value>僅 Linux 可用。如游標主題、托盤或視窗行為異常，請關閉此項。</value>
+  </data>
   <data name="TbAutoRefresh" xml:space="preserve">
     <value>自動重新整理</value>
   </data>

--- a/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/OptionSettingViewModel.cs
@@ -45,6 +45,7 @@ public partial class OptionSettingViewModel : MyReactiveObject, ICloseable
     [Reactive] public partial bool AutoHideStartup { get; set; }
     [Reactive] public partial bool Hide2TrayWhenClose { get; set; }
     [Reactive] public partial bool MacOSShowInDock { get; set; }
+    [Reactive] public partial bool EnableLinuxWayland { get; set; }
     [Reactive] public partial bool EnableDragDropSort { get; set; }
     [Reactive] public partial bool DoubleClick2Activate { get; set; }
     [Reactive] public partial int AutoUpdateInterval { get; set; }
@@ -175,6 +176,7 @@ public partial class OptionSettingViewModel : MyReactiveObject, ICloseable
         AutoHideStartup = _config.UiItem.AutoHideStartup;
         Hide2TrayWhenClose = _config.UiItem.Hide2TrayWhenClose;
         MacOSShowInDock = _config.UiItem.MacOSShowInDock;
+        EnableLinuxWayland = _config.UiItem.EnableLinuxWayland;
         EnableDragDropSort = _config.UiItem.EnableDragDropSort;
         DoubleClick2Activate = _config.UiItem.DoubleClick2Activate;
         AutoUpdateInterval = _config.GuiItem.AutoUpdateInterval;
@@ -303,6 +305,7 @@ public partial class OptionSettingViewModel : MyReactiveObject, ICloseable
                           || DisplayRealTimeSpeed != _config.GuiItem.DisplayRealTimeSpeed
                         || EnableDragDropSort != _config.UiItem.EnableDragDropSort
                         || EnableHWA != _config.GuiItem.EnableHWA
+                        || EnableLinuxWayland != _config.UiItem.EnableLinuxWayland
                         || CurrentFontFamily != _config.UiItem.CurrentFontFamily;
 
         //Core
@@ -347,6 +350,7 @@ public partial class OptionSettingViewModel : MyReactiveObject, ICloseable
         _config.UiItem.AutoHideStartup = AutoHideStartup;
         _config.UiItem.Hide2TrayWhenClose = Hide2TrayWhenClose;
         _config.UiItem.MacOSShowInDock = MacOSShowInDock;
+        _config.UiItem.EnableLinuxWayland = EnableLinuxWayland;
         _config.GuiItem.AutoUpdateInterval = AutoUpdateInterval;
         _config.UiItem.EnableDragDropSort = EnableDragDropSort;
         _config.UiItem.DoubleClick2Activate = DoubleClick2Activate;

--- a/v2rayN/v2rayN.Desktop/Program.cs
+++ b/v2rayN/v2rayN.Desktop/Program.cs
@@ -67,6 +67,11 @@ internal class Program
            .LogToTrace()
            .UseReactiveUI(_ => { });
 
+        if (OperatingSystem.IsLinux() && !Design.IsDesignMode && AppManager.Instance.Config.UiItem.EnableLinuxWayland)
+        {
+            builder = builder.UseWaylandWithFallback();
+        }
+
         if (OperatingSystem.IsMacOS())
         {
             var showInDock = Design.IsDesignMode || AppManager.Instance.Config.UiItem.MacOSShowInDock;

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml
@@ -596,6 +596,29 @@
                             Grid.Column="0"
                             Margin="{StaticResource Margin4}"
                             VerticalAlignment="Center"
+                            IsVisible="{Binding BlIsLinux}"
+                            Text="{x:Static resx:ResUI.TbSettingsEnableLinuxWayland}" />
+                        <ToggleSwitch
+                            x:Name="togEnableLinuxWayland"
+                            Grid.Row="8"
+                            Grid.Column="1"
+                            Margin="{StaticResource Margin4}"
+                            HorizontalAlignment="Left"
+                            IsVisible="{Binding BlIsLinux}" />
+                        <TextBlock
+                            Grid.Row="8"
+                            Grid.Column="2"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
+                            IsVisible="{Binding BlIsLinux}"
+                            Text="{x:Static resx:ResUI.TbSettingsEnableLinuxWaylandTip}"
+                            TextWrapping="Wrap" />
+
+                        <TextBlock
+                            Grid.Row="8"
+                            Grid.Column="0"
+                            Margin="{StaticResource Margin4}"
+                            VerticalAlignment="Center"
                             IsVisible="{Binding BlIsIsMacOS}"
                             Text="{x:Static resx:ResUI.TbSettingsMacOSShowInDock}" />
                         <ToggleSwitch

--- a/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/OptionSettingWindow.axaml.cs
@@ -99,6 +99,7 @@ public partial class OptionSettingWindow : WindowBase<OptionSettingViewModel>
             this.Bind(ViewModel, vm => vm.AutoHideStartup, v => v.togAutoHideStartup.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.Hide2TrayWhenClose, v => v.togHide2TrayWhenClose.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.MacOSShowInDock, v => v.togMacOSShowInDock.IsChecked).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.EnableLinuxWayland, v => v.togEnableLinuxWayland.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.EnableDragDropSort, v => v.togEnableDragDropSort.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.DoubleClick2Activate, v => v.togDoubleClick2Activate.IsChecked).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.AutoUpdateInterval, v => v.txtautoUpdateInterval.Text).DisposeWith(disposables);

--- a/v2rayN/v2rayN.Desktop/v2rayN.Desktop.csproj
+++ b/v2rayN/v2rayN.Desktop/v2rayN.Desktop.csproj
@@ -16,6 +16,7 @@
 			<TreatAsUsed>true</TreatAsUsed>
 		</PackageReference>
 		<PackageReference Include="Avalonia.Desktop" />
+		<PackageReference Include="Avalonia.Wayland" />
 		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" />
 		<PackageReference Include="DialogHost.Avalonia" />
 		<PackageReference Include="ReactiveUI.Avalonia" />


### PR DESCRIPTION
avalonia新版本添加了对linux wayland的原生实验性支持,这个提交增加了wayland设置开关选项,一并补齐了linux的依赖项
默认还是x11
<img width="1265" height="799" alt="image" src="https://github.com/user-attachments/assets/20061194-4a61-4582-9722-c615f380fa8a" />
