### PR TITLE
fix: preserve Mihomo Reality short-id as YAML string

### DIFF
--- a/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigClashService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/CoreConfigClashService.cs
@@ -1,3 +1,6 @@
+using YamlDotNet.Core;
+using YamlDotNet.RepresentationModel;
+
 namespace ServiceLib.Services.CoreConfig;
 
 /// <summary>
@@ -127,7 +130,27 @@ public class CoreConfigClashService(Config config, bool isTunEnabled)
                 Logging.SaveLog($"{_tag}-Mixin", ex);
             }
 
+            // Mihomo parses plain values such as 815458e4 as floats, so quote REALITY short IDs.
+            var originalRealityShortIds = new List<(Dictionary<object, object> RealityOptions, string ShortId)>();
+            if (fileContent.GetValueOrDefault("proxies") is List<object> proxies)
+            {
+                foreach (var proxy in proxies.OfType<Dictionary<object, object>>())
+                {
+                    if (proxy.GetValueOrDefault("reality-opts") is Dictionary<object, object> realityOptions
+                        && realityOptions.GetValueOrDefault("short-id") is string shortId
+                        && !shortId.StartsWith(tagYamlStr2, StringComparison.Ordinal))
+                    {
+                        originalRealityShortIds.Add((realityOptions, shortId));
+                        realityOptions["short-id"] = new YamlScalarNode(shortId) { Style = ScalarStyle.DoubleQuoted };
+                    }
+                }
+            }
+
             var txtFileNew = YamlUtils.ToYaml(fileContent).Replace(tagYamlStr2, tagYamlStr3);
+            foreach (var (realityOptions, shortId) in originalRealityShortIds)
+            {
+                realityOptions["short-id"] = shortId;
+            }
             await File.WriteAllTextAsync(fileName, txtFileNew);
             //check again
             if (!File.Exists(fileName))


### PR DESCRIPTION
v2rayN 重新生成 Mihomo 自定义 YAML 配置时，可能会去掉 REALITY `short-id` 的引号。例如：

```yaml
reality-opts:
  short-id: "815458e4"
```

可能被输出为：

```yaml
reality-opts:
  short-id: 815458e4
```

Mihomo 会将未加引号的 `815458e4` 解析为浮点数，随后因无法将转换后的值作为十六进制 short ID 解码而报告 `invalid REALITY short ID`。

在生成 Mihomo 自定义配置时，将 `proxies[].reality-opts.short-id` 明确序列化为带双引号的 YAML 字符串。无论用户输入是否带引号，最终都会生成：

```yaml
reality-opts:
  short-id: "815458e4"
```

该处理仅作用于 Mihomo 自定义配置的最终生成阶段，不修改用户原始 YAML，也不会改变其他字段或 `YamlUtils.ToYaml` 的全局序列化行为。现有 `!<str>` 兼容逻辑保持不变。

本地验证结果：

- `ServiceLib` 构建成功，0 个警告、0 个错误。
- 验证带引号和不带引号的 `815458e4` 均生成带双引号的字符串，值未发生变化。
- 验证普通端口、布尔值和其他数字字段未受影响。
- 验证现有 `!<str>` 处理仍能生成有效的 `!!str` 标量。
- 生成的配置通过 Mihomo v1.19.29 的 `mihomo -t -f` 检查。