### PR TITLE
chore(deps): update xunit.v3 and NLog, and drop the VSTest packages xunit replaces

### DIFF
--- a/.github/workflows/build-windows-x86.yml
+++ b/.github/workflows/build-windows-x86.yml
@@ -51,10 +51,11 @@ jobs:
           echo "After:"
           dotnet --list-sdks 2>$null; $LASTEXITCODE=0
 
-      - name: Setup .NET 10.0.1xx
-        uses: actions/setup-dotnet@v6.0.0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 10.0.1xx
+          dotnet-version: '10.x'
+          dotnet-quality: 'ga'
 
       - name: Publish ${{ matrix.flavor }} win-x86
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,9 +69,10 @@ jobs:
         dotnet --list-sdks 2>$null; $LASTEXITCODE=0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v6.0.0
+      uses: actions/setup-dotnet@v6
       with:
-        dotnet-version: '10.0.1xx'
+        dotnet-version: '10.x'
+        dotnet-quality: 'ga'
 
     - name: Build v2rayN
       shell: bash
@@ -89,7 +90,7 @@ jobs:
         find ${{ matrix.arch }} -type f -name '*.pdb' -delete
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v7.0.1
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ matrix.arch }}
         path: ${{ matrix.arch }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,11 @@ jobs:
         fetch-depth: '0'
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v6.0.0
+      uses: actions/setup-dotnet@v6
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.x'
+        dotnet-quality: 'ga'
 
     - name: Test Code
       working-directory: ./v2rayN
-      run: dotnet test ./ServiceLib.Tests
+      run: dotnet run --project ./ServiceLib.Tests -c Release

--- a/v2rayN/Directory.Packages.props
+++ b/v2rayN/Directory.Packages.props
@@ -24,7 +24,7 @@
     <PackageVersion Include="Semi.Avalonia" Version="12.1.0.1" />
     <PackageVersion Include="Semi.Avalonia.AvaloniaEdit" Version="12.0.0" />
     <PackageVersion Include="Semi.Avalonia.DataGrid" Version="12.1.0.1" />
-    <PackageVersion Include="NLog" Version="6.1.4" />
+    <PackageVersion Include="NLog" Version="6.2.0" />
     <PackageVersion Include="sqlite-net-e" Version="1.11.285" />
     <PackageVersion Include="Repobot.SQLite.Unofficial" Version="3.53.4.1" />
     <PackageVersion Include="TaskScheduler" Version="2.12.2" />

--- a/v2rayN/Directory.Packages.props
+++ b/v2rayN/Directory.Packages.props
@@ -15,7 +15,6 @@
     <PackageVersion Include="ReactiveUI.Avalonia" Version="12.1.1" />
     <PackageVersion Include="CliWrap" Version="3.10.4" />
     <PackageVersion Include="Downloader" Version="5.9.5" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="H.NotifyIcon.Wpf" Version="2.4.1" />
     <PackageVersion Include="MaterialDesignThemes" Version="5.3.2" />
     <PackageVersion Include="QRCoder" Version="1.8.0" />
@@ -30,8 +29,7 @@
     <PackageVersion Include="Repobot.SQLite.Unofficial" Version="3.53.4.1" />
     <PackageVersion Include="TaskScheduler" Version="2.12.2" />
     <PackageVersion Include="WebDav.Client" Version="2.9.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.v3" Version="4.0.0" />
     <PackageVersion Include="YamlDotNet" Version="18.1.0" />
     <PackageVersion Include="ZXing.Net.Bindings.SkiaSharp" Version="0.16.22" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />

--- a/v2rayN/ServiceLib.Tests/ServiceLib.Tests.csproj
+++ b/v2rayN/ServiceLib.Tests/ServiceLib.Tests.csproj
@@ -8,11 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="xunit.v3" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Updates the outdated packages and, along the way, removes the two the xunit update makes redundant.

| Package | From | To |
| --- | --- | --- |
| xunit.v3 | 3.2.2 | 4.0.0 |
| NLog | 6.1.4 | 6.2.0 |
| Microsoft.NET.Test.Sdk | 18.8.1 | *removed* |
| xunit.runner.visualstudio | 3.1.5 | *removed* |

## Why the test packages go away instead of being updated

xunit.v3 4.0.0 moves from Microsoft.Testing.Platform v1 to v2, and MTP v2 drops the VSTest bridge on the .NET 10 SDK. Anything routed through VSTest now stops before a single test runs:

    error : Testing with VSTest target is no longer supported by Microsoft.Testing.Platform
            on .NET 10 SDK and later.

There are two ways out. One is to opt back into a bridge through a new `global.json`. The other is to stop needing the bridge at all — which is what this PR does, because `ServiceLib.Tests` is already an `Exe` carrying xunit's own in-process runner. With `Microsoft.NET.Test.Sdk` and `xunit.runner.visualstudio` gone, the test project simply runs itself:

```
dotnet run --project ./ServiceLib.Tests -c Release
```

No adapter, no test SDK, no new file in the repository root, and two fewer dependencies to keep updated.

The trade-off worth stating: IDE test discovery now goes through Microsoft Testing Platform rather than the VSTest adapter. Visual Studio, VS Code and Rider all support it, and xunit's own project template takes this same route for `net10.0`.

No source or test changes are required. Every 4.0.0 breaking change is in the extensibility and runner APIs, and the suite uses only `[Fact]`, `[Theory]` and `[InlineData]`.

## Versions that keep themselves current

`test.yml` asked for the `8.0.x` SDK while every project targets `net10.0`, which an 8.0 SDK cannot build (`error NETSDK1045`). It was only ever green because nothing in it reached a compiler.

All three `setup-dotnet` steps now request `10.x` with `dotnet-quality: 'ga'`. A new .NET 10 patch or feature band is picked up on its own, while previews and release candidates stay out — `10.x` alone would include them, [per the action's documentation](https://github.com/actions/setup-dotnet#supported-version-syntax).

`setup-dotnet` and one `upload-artifact` step were the only actions pinned to an exact patch; they now track their major tag like the other seven, so patches arrive without a PR.

## Testing

All commands run on this branch:

- `dotnet build v2rayN.sln -c Release` — 0 errors, 0 warnings
- `dotnet run --project ./ServiceLib.Tests -c Release` — **69 passed, 0 failed**, exit code 0
- with a deliberately failing test added — exit code 1, so CI still turns red
- `ServiceLib.Tests/obj/project.assets.json` — 0 references to either removed package

NLog was verified past compilation, since no test covers it: a temporary probe ran `Logging.Setup()` and both `SaveLog` overloads, then read the file the `FileTarget` produced —

```
2026-08-17 07:12:56.4928-INFO nlog 6.2.0 probe: plain message
2026-08-17 07:12:56.5149-DEBUG nlog 6.2.0 probe: exception path,probe
```

— confirming the target, the layout and both logging paths still behave. The probe was removed before committing.
