### PR TITLE
添加Sing-box TLS 公钥指纹固定

### DIFF
--- a/v2rayN/ServiceLib/Handler/Builder/NodeValidator.cs
+++ b/v2rayN/ServiceLib/Handler/Builder/NodeValidator.cs
@@ -137,7 +137,8 @@ public class NodeValidator
                 && item.CertSha.IsNullOrEmpty())
                 || (coreType == ECoreType.sing_box
                     && item.GetAllowInsecure()
-                    && !isCertProvided))
+                    && !isCertProvided
+                    && item.CertPubKeySha.IsNullOrEmpty()))
             {
                 if (coreType == ECoreType.Xray)
                 {

--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -274,6 +274,7 @@ public static class ConfigHandler
             item.MuxEnabled = profileItem.MuxEnabled;
             item.Cert = profileItem.Cert;
             item.CertSha = profileItem.CertSha;
+            item.CertPubKeySha = profileItem.CertPubKeySha;
             item.EchConfigList = profileItem.EchConfigList;
             item.VerifyPeerCertByName = profileItem.VerifyPeerCertByName;
             item.Finalmask = profileItem.Finalmask;

--- a/v2rayN/ServiceLib/Models/CoreConfigs/SingboxConfig.cs
+++ b/v2rayN/ServiceLib/Models/CoreConfigs/SingboxConfig.cs
@@ -190,6 +190,7 @@ public class Tls4Sbox
     public string? fragment_fallback_delay { get; set; }
     public bool? record_fragment { get; set; }
     public List<string>? certificate { get; set; }
+    public List<string>? certificate_public_key_sha256 { get; set; }
     public Ech4Sbox? ech { get; set; }
 }
 

--- a/v2rayN/ServiceLib/Models/Entities/ProfileItem.cs
+++ b/v2rayN/ServiceLib/Models/Entities/ProfileItem.cs
@@ -195,6 +195,7 @@ public class ProfileItem
     public bool? MuxEnabled { get; set; }
     public string Cert { get; set; }
     public string CertSha { get; set; }
+    public string CertPubKeySha { get; set; }
     public string EchConfigList { get; set; }
     public string VerifyPeerCertByName { get; set; }
     public string Finalmask { get; set; }

--- a/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
+++ b/v2rayN/ServiceLib/Resx/ResUI.Designer.cs
@@ -2861,7 +2861,16 @@ namespace ServiceLib.Resx {
                 return ResourceManager.GetString("TbCertSha256Tips", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   查找类似 Public key SHA-256 (Base64), sing-box only 的本地化字符串。
+        /// </summary>
+        public static string TbCertPubKeySha256Tips {
+            get {
+                return ResourceManager.GetString("TbCertPubKeySha256Tips", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   查找类似 Clear system proxy 的本地化字符串。
         /// </summary>

--- a/v2rayN/ServiceLib/Resx/ResUI.fr.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.fr.resx
@@ -1617,6 +1617,9 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
   <data name="TbCertSha256Tips" xml:space="preserve">
     <value>Empreinte du certificat (SHA-256)</value>
   </data>
+  <data name="TbCertPubKeySha256Tips" xml:space="preserve">
+    <value>Clé publique SHA-256 (Base64), sing-box uniquement</value>
+  </data>
   <data name="TbServeStale" xml:space="preserve">
     <value>Cache optimiste</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.resx
@@ -1629,6 +1629,9 @@ The "Get Certificate" action may fail if a self-signed certificate is used or if
   <data name="TbCertSha256Tips" xml:space="preserve">
     <value>Certificate fingerprint (SHA-256)</value>
   </data>
+  <data name="TbCertPubKeySha256Tips" xml:space="preserve">
+    <value>Public key SHA-256 (Base64), sing-box only</value>
+  </data>
   <data name="TbServeStale" xml:space="preserve">
     <value>Serve Stale</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1624,7 +1624,7 @@
     <value>证书指纹（SHA-256）</value>
   </data>
   <data name="TbCertPubKeySha256Tips" xml:space="preserve">
-    <value>公钥 SHA-256 (Base64), 仅Sing-box</value>
+    <value>公钥 SHA-256 (Base64), 仅 Sing-box</value>
   </data>
   <data name="TbServeStale" xml:space="preserve">
     <value>乐观缓存</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1623,6 +1623,9 @@
   <data name="TbCertSha256Tips" xml:space="preserve">
     <value>证书指纹（SHA-256）</value>
   </data>
+  <data name="TbCertPubKeySha256Tips" xml:space="preserve">
+    <value>公钥 SHA-256 (Base64), sing-box 可用</value>
+  </data>
   <data name="TbServeStale" xml:space="preserve">
     <value>乐观缓存</value>
   </data>

--- a/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.zh-Hans.resx
@@ -1624,7 +1624,7 @@
     <value>证书指纹（SHA-256）</value>
   </data>
   <data name="TbCertPubKeySha256Tips" xml:space="preserve">
-    <value>公钥 SHA-256 (Base64), sing-box 可用</value>
+    <value>公钥 SHA-256 (Base64), 仅Sing-box</value>
   </data>
   <data name="TbServeStale" xml:space="preserve">
     <value>乐观缓存</value>

--- a/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/Singbox/SingboxOutboundService.cs
@@ -460,6 +460,13 @@ public partial class CoreConfigSingboxService
                     tls.certificate = certs;
                     tls.insecure = false;
                 }
+                else if (!_node.CertPubKeySha.IsNullOrEmpty())
+                {
+                    tls.certificate_public_key_sha256 = _node.CertPubKeySha
+                        .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                        .ToList();
+                    tls.insecure = false;
+                }
             }
             else if (_node.StreamSecurity == Global.StreamSecurityReality)
             {

--- a/v2rayN/ServiceLib/ViewModels/AddServerViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/AddServerViewModel.cs
@@ -26,6 +26,9 @@ public partial class AddServerViewModel : MyReactiveObject, ICloseable
     public partial string CertSha { get; set; }
 
     [Reactive]
+    public partial string CertPubKeySha { get; set; }
+
+    [Reactive]
     public partial string SalamanderPass { get; set; }
 
     [Reactive]
@@ -265,6 +268,9 @@ public partial class AddServerViewModel : MyReactiveObject, ICloseable
         this.WhenAnyValue(x => x.CertSha)
             .Subscribe(_ => UpdateCertTip());
 
+        this.WhenAnyValue(x => x.CertPubKeySha)
+            .Subscribe(_ => UpdateCertTip());
+        
         this.WhenAnyValue(x => x.SelectedSource.Network)
             .Subscribe(_ =>
             {
@@ -292,6 +298,7 @@ public partial class AddServerViewModel : MyReactiveObject, ICloseable
         MuxEnabled = SelectedSource?.MuxEnabled == true;
         Cert = SelectedSource?.Cert ?? string.Empty;
         CertSha = SelectedSource?.CertSha ?? string.Empty;
+        CertPubKeySha = SelectedSource?.CertPubKeySha ?? string.Empty;
 
         var protocolExtra = SelectedSource?.GetProtocolExtra() ?? new();
         var transport = SelectedSource?.GetTransportExtra() ?? new();
@@ -393,6 +400,7 @@ public partial class AddServerViewModel : MyReactiveObject, ICloseable
         SelectedSource.MuxEnabled = MuxEnabled;
         SelectedSource.Cert = Cert.IsNullOrEmpty() ? string.Empty : Cert;
         SelectedSource.CertSha = CertSha.IsNullOrEmpty() ? string.Empty : CertSha;
+        SelectedSource.CertPubKeySha = CertPubKeySha.IsNullOrEmpty() ? string.Empty : CertPubKeySha;
         if (!Global.Networks.Contains(SelectedSource.Network))
         {
             SelectedSource.Network = Global.DefaultNetwork;
@@ -455,7 +463,7 @@ public partial class AddServerViewModel : MyReactiveObject, ICloseable
     private void UpdateCertTip(string? errorMessage = null)
     {
         CertTip = errorMessage.IsNullOrEmpty()
-            ? ((Cert.IsNullOrEmpty() && CertSha.IsNullOrEmpty()) ? ResUI.CertNotSet : ResUI.CertSet)
+            ? ((Cert.IsNullOrEmpty() && CertSha.IsNullOrEmpty() && CertPubKeySha.IsNullOrEmpty()) ? ResUI.CertNotSet : ResUI.CertSet)
             : errorMessage;
     }
 

--- a/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml
+++ b/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml
@@ -1276,6 +1276,17 @@
                                             Width="400"
                                             Margin="{StaticResource Margin4}"
                                             VerticalAlignment="Center"
+                                            Text="{x:Static resx:ResUI.TbCertPubKeySha256Tips}"
+                                            TextWrapping="Wrap" />
+                                        <TextBox
+                                            x:Name="txtCertPubKeySha256"
+                                            Width="400"
+                                            Margin="{StaticResource Margin4}"
+                                            HorizontalAlignment="Left" />
+                                        <TextBlock
+                                            Width="400"
+                                            Margin="{StaticResource Margin4}"
+                                            VerticalAlignment="Center"
                                             Text="{x:Static resx:ResUI.TbFullCertTips}"
                                             TextWrapping="Wrap" />
                                         <TextBox

--- a/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/AddServerWindow.axaml.cs
@@ -175,6 +175,7 @@ public partial class AddServerWindow : WindowBase<AddServerViewModel>
             this.Bind(ViewModel, vm => vm.SelectedSource.Fingerprint, v => v.cmbFingerprint.SelectedValue).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Alpn, v => v.cmbAlpn.SelectedValue).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.CertSha, v => v.txtCertSha256Pinning.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.CertPubKeySha, v => v.txtCertPubKeySha256.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.CertTip, v => v.labCertPinning.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.Cert, v => v.txtCert.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.EchConfigList, v => v.txtEchConfigList.Text).DisposeWith(disposables);

--- a/v2rayN/v2rayN/Views/AddServerWindow.xaml
+++ b/v2rayN/v2rayN/Views/AddServerWindow.xaml
@@ -1606,6 +1606,19 @@
                                     Margin="{StaticResource Margin4}"
                                     VerticalAlignment="Center"
                                     Style="{StaticResource ToolbarTextBlock}"
+                                    Text="{x:Static resx:ResUI.TbCertPubKeySha256Tips}"
+                                    TextWrapping="Wrap" />
+                                <TextBox
+                                    x:Name="txtCertPubKeySha256"
+                                    Width="400"
+                                    Margin="{StaticResource Margin4}"
+                                    HorizontalAlignment="Left"
+                                    Style="{StaticResource DefTextBox}" />
+                                <TextBlock
+                                    Width="400"
+                                    Margin="{StaticResource Margin4}"
+                                    VerticalAlignment="Center"
+                                    Style="{StaticResource ToolbarTextBlock}"
                                     Text="{x:Static resx:ResUI.TbFullCertTips}"
                                     TextWrapping="Wrap" />
                                 <TextBox

--- a/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/AddServerWindow.xaml.cs
@@ -172,6 +172,7 @@ public partial class AddServerWindow
             this.Bind(ViewModel, vm => vm.SelectedSource.Fingerprint, v => v.cmbFingerprint.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.SelectedSource.Alpn, v => v.cmbAlpn.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.CertSha, v => v.txtCertSha256Pinning.Text).DisposeWith(disposables);
+            this.Bind(ViewModel, vm => vm.CertPubKeySha, v => v.txtCertPubKeySha256.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.CertTip, v => v.labCertPinning.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.Cert, v => v.txtCert.Text).DisposeWith(disposables);
             this.Bind(ViewModel, vm => vm.Cert, v => v.txtCert.Text).DisposeWith(disposables);


### PR DESCRIPTION
本 PR 为 sing-box 核心补全了 TLS 公钥指纹固定（certificate_public_key_sha256）支持：在 ProfileItem 及节点编辑 UI 中新增公钥哈希字段，并在生成 sing-box 配置文件时正确渲染该属性。