### PR TITLE
chore(deps): update CliWrap and TUnit, drop unused test pins

### DIFF
--- a/v2rayN/Directory.Packages.props
+++ b/v2rayN/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="DialogHost.Avalonia" Version="0.12.3" />
     <PackageVersion Include="IPNetwork2" Version="4.3.0" />
     <PackageVersion Include="ReactiveUI.Avalonia" Version="12.1.1" />
-    <PackageVersion Include="CliWrap" Version="3.10.4" />
+    <PackageVersion Include="CliWrap" Version="3.10.5" />
     <PackageVersion Include="Downloader" Version="5.9.5" />
     <PackageVersion Include="H.NotifyIcon.Wpf" Version="2.4.1" />
     <PackageVersion Include="MaterialDesignThemes" Version="5.3.2" />
@@ -28,8 +28,8 @@
     <PackageVersion Include="sqlite-net-e" Version="1.11.285" />
     <PackageVersion Include="Repobot.SQLite.Unofficial" Version="3.53.4.1" />
     <PackageVersion Include="TaskScheduler" Version="2.12.2" />
-    <PackageVersion Include="TUnit" Version="1.65.0" />
-    <PackageVersion Include="TUnit.Assertions.Should" Version="1.65.0-beta" />
+    <PackageVersion Include="TUnit" Version="1.65.38" />
+    <PackageVersion Include="TUnit.Assertions.Should" Version="1.65.38-beta" />
     <PackageVersion Include="WebDav.Client" Version="2.9.0" />
     <PackageVersion Include="xunit.v3" Version="4.0.0" />
     <PackageVersion Include="YamlDotNet" Version="18.1.0" />

--- a/v2rayN/Directory.Packages.props
+++ b/v2rayN/Directory.Packages.props
@@ -9,7 +9,6 @@
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.1.2" />
     <PackageVersion Include="Avalonia.Desktop" Version="12.1.1" />
     <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
-    <PackageVersion Include="AwesomeAssertions" Version="9.5.0" />
     <PackageVersion Include="DialogHost.Avalonia" Version="0.12.3" />
     <PackageVersion Include="IPNetwork2" Version="4.3.0" />
     <PackageVersion Include="ReactiveUI.Avalonia" Version="12.1.1" />
@@ -31,7 +30,6 @@
     <PackageVersion Include="TUnit" Version="1.65.38" />
     <PackageVersion Include="TUnit.Assertions.Should" Version="1.65.38-beta" />
     <PackageVersion Include="WebDav.Client" Version="2.9.0" />
-    <PackageVersion Include="xunit.v3" Version="4.0.0" />
     <PackageVersion Include="YamlDotNet" Version="18.1.0" />
     <PackageVersion Include="ZXing.Net.Bindings.SkiaSharp" Version="0.16.22" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />


### PR DESCRIPTION
## Summary

Updates NuGet dependencies in `Directory.Packages.props` and removes two entries that no longer pin anything. A single file is changed; no source changes are required.

| Package | From | To |
| --- | --- | --- |
| CliWrap | 3.10.4 | 3.10.5 |
| TUnit | 1.65.0 | 1.65.38 |
| TUnit.Assertions.Should | 1.65.0-beta | 1.65.38-beta |
| AwesomeAssertions | 9.5.0 | removed |
| xunit.v3 | 4.0.0 | removed |

`TUnit.Assertions.Should` is versioned in lockstep with `TUnit` and published with a `-beta` suffix; its `1.65.0-beta` package depends on `TUnit.Assertions 1.65.0-beta`, so it moves together with `TUnit` to keep the whole TUnit stack on a single version (`TUnit.Assertions 1.65.38` after this change).

Since the migration to TUnit (c9e843aa) no project references `AwesomeAssertions` or `xunit.v3` any more, so those two `PackageVersion` entries no longer pin anything - neither package appears in any `project.assets.json`, directly or transitively.

## Testing

Windows, .NET SDK 10.0.400.

- `dotnet restore v2rayN.slnx --force-evaluate`: all projects restored
- `dotnet build v2rayN.slnx -c Release`: 0 errors (1 pre-existing warning in the `GlobalHotKeys` submodule)
- `ServiceLib.Tests` (TUnit): 69/69 passed
- `dotnet publish` for every CI target - `v2rayN` win-x64, `v2rayN.Desktop` win-x64 and linux-x64, `AmazTool` win-x64, all `-p:SelfContained=true` as in `build.yml`: succeeded