### PR TITLE
ci: fix the test job, which cannot run any test on the .NET 10 SDK

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Test Code
       working-directory: ./v2rayN
-      run: dotnet test ./ServiceLib.Tests -c Release --no-build --results-directory ./TestResults -- --report-trx
+      run: dotnet run --project ./ServiceLib.Tests -c Release -- --report-trx --results-directory ./TestResults
 
     - name: Comment PR with results
       if: always()


### PR DESCRIPTION
## Problem

The `Code Test` job runs no test at all on the .NET 10 SDK, and it does so silently. On a clean checkout the `Test Code` step finishes in about two seconds with no output and exits 0, so the job is green while nothing has been tested, and the reporting step that follows logs:

```
WARNING - Could not find any files for ./v2rayN/TestResults/*.trx
INFO - Finished reading 0 files in 0 seconds
```

That is the current state of every recent run of this workflow, for example [run 32499008620](https://github.com/2dust/v2rayN/actions/runs/32499008620) on PR #10004: `Test Code` starts at 15:42:10.678, the next step starts at 15:42:13.034, and between them the log contains not a single line of output.

The cause is the VSTest mode of `dotnet test`. It can only host a Microsoft.Testing.Platform application through the `Microsoft.Testing.Platform.MSBuild` bridge, and MTP 2 removes that bridge on the .NET 10 SDK, while TUnit 1.65.0 resolves MTP 2.3.3. Once the project is restored, which is what happens on a developer machine, the same command stops being silent and fails outright:

```
error : Testing with VSTest target is no longer supported by Microsoft.Testing.Platform
on .NET 10 SDK and later. If you use dotnet test, you should opt-in to the new dotnet test
experience. For more information, see https://aka.ms/dotnet-test-mtp-error
```

On the runner it never gets that far, because `--no-build` is passed by a job that has no build step: nothing is restored, the MTP targets that ship with the package are never imported, and the VSTest target finds no test assembly to run.

The job is also rarely triggered - its `paths` filter covers only `CoreConfig/**`, `Fmt/**` and the workflow file itself - which is why this has stayed unnoticed since c9e843aa.

## Fix

Run the test project directly, the way the workflow did before c9e843aa. It needs no bridge, no MSBuild property and no opt-in file, and it keeps the TRX report the reporting step consumes: `--report-trx` and `--results-directory` are native Microsoft.Testing.Platform options, so `./v2rayN/TestResults/*.trx` is still produced.

The alternative is the new MTP mode of `dotnet test`, opted into by a `test.runner` section in `global.json`. I verified that it works as well (69/69, same TRX path), but it adds a root-level file and changes the invocation to `dotnet test --project`. The one-line change is the smaller fix; happy to switch to the `global.json` variant if you would rather keep `dotnet test` working for contributors.

## Testing

This PR touches `.github/workflows/test.yml`, so the job runs here and the fix is exercised on the runner. Its own run reports:

```
In process file artifacts produced:
  - /home/runner/work/v2rayN/v2rayN/v2rayN/TestResults/ServiceLib.Tests_net10.0_x64.trx
Test run summary: Passed! - .../ServiceLib.Tests/bin/Release/net10.0/ServiceLib.Tests.dll
  total: 69   failed: 0   succeeded: 69   skipped: 0
```

and the reporting step now reads it: `Detected 1 TRX file (91.7 KiB)`, against `0 files` on master today.

Locally, Windows with SDK 10.0.400 - the same SDK version the runner resolves:

| Command | Result |
| --- | --- |
| current, clean checkout | exit 0, no output, no TRX, no test executed - reproduces the runner exactly |
| current, restored project | exit 1 with the error quoted above |
| new, clean checkout | exit 0, 69/69 passed, TRX at `./v2rayN/TestResults/ServiceLib.Tests_net10.0_x64.trx` |
| new, with a deliberately failing test added | exit 2, so the job goes red, and the TRX records `outcome="Failed"` with the failing test and its assertion message |

The last row matters: the current command is green precisely because it never runs anything, so the red path of the replacement was verified explicitly rather than assumed.
