### PR TITLE
fix(tun): 自动将代理节点 IP/域名追加到 RouteExcludeAddress 防止路由环路 (#9974)

### DIFF
--- a/v2rayN/ServiceLib.Tests/CoreConfig/Context/CoreConfigContextBuilderTests.cs
+++ b/v2rayN/ServiceLib.Tests/CoreConfig/Context/CoreConfigContextBuilderTests.cs
@@ -83,6 +83,96 @@ public class CoreConfigContextBuilderTests
         await groupA.GetProtocolExtra().ChildItems.Should().BeEqualTo(leaf.IndexId);
     }
 
+    [Test]
+    public async Task Build_WhenTunEnabled_ShouldAutoExcludeProxyServerAddress()
+    {
+        var config = CoreConfigTestFactory.CreateConfig();
+        config.TunModeItem.EnableTun = true;
+        config.TunModeItem.RouteExcludeAddress = ["10.0.0.0/8"];
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+
+        var node = CoreConfigTestFactory.CreateVmessNode(ECoreType.Xray, "vmess-node");
+        node.Address = "1.2.3.4";
+        await UpsertProfilesAsync(node);
+
+        var result = await CoreConfigContextBuilder.Build(config, node);
+
+        await result.Success.Should().BeTrue();
+        await result.Context.AppConfig.TunModeItem.RouteExcludeAddress.Should().Contain("10.0.0.0/8");
+        await result.Context.AppConfig.TunModeItem.RouteExcludeAddress.Should().Contain("1.2.3.4/32");
+    }
+
+    [Test]
+    public async Task Build_WhenTunEnabled_ShouldAutoExcludeProxyServerAddress_IPv6WithBrackets()
+    {
+        var config = CoreConfigTestFactory.CreateConfig();
+        config.TunModeItem.EnableTun = true;
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+
+        var node = CoreConfigTestFactory.CreateVmessNode(ECoreType.Xray, "vmess-v6");
+        node.Address = "[2001:db8::1]";
+        await UpsertProfilesAsync(node);
+
+        var result = await CoreConfigContextBuilder.Build(config, node);
+
+        await result.Success.Should().BeTrue();
+        await result.Context.AppConfig.TunModeItem.RouteExcludeAddress.Should().Contain("2001:db8::1/128");
+    }
+
+    [Test]
+    public async Task Build_WhenTunEnabled_ShouldNotExcludeLoopbackAddress()
+    {
+        var config = CoreConfigTestFactory.CreateConfig();
+        config.TunModeItem.EnableTun = true;
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+
+        var node = CoreConfigTestFactory.CreateVmessNode(ECoreType.Xray, "vmess-loopback");
+        node.Address = "127.0.0.1";
+        await UpsertProfilesAsync(node);
+
+        var result = await CoreConfigContextBuilder.Build(config, node);
+
+        await result.Success.Should().BeTrue();
+        await result.Context.AppConfig.TunModeItem.RouteExcludeAddress.Should().NotContain("127.0.0.1/32");
+        await result.Context.AppConfig.TunModeItem.RouteExcludeAddress.Should().NotContain("127.0.0.1");
+    }
+
+    [Test]
+    public async Task Build_WhenTunEnabled_ShouldNotExcludeAnyOrNoneAddress()
+    {
+        var config = CoreConfigTestFactory.CreateConfig();
+        config.TunModeItem.EnableTun = true;
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+
+        var node = CoreConfigTestFactory.CreateVmessNode(ECoreType.Xray, "vmess-any");
+        node.Address = "0.0.0.0";
+        await UpsertProfilesAsync(node);
+
+        var result = await CoreConfigContextBuilder.Build(config, node);
+
+        await result.Success.Should().BeTrue();
+        await result.Context.AppConfig.TunModeItem.RouteExcludeAddress.Should().NotContain("0.0.0.0/32");
+    }
+
+    [Test]
+    public async Task Build_WhenTunEnabled_WithDomainNode_ShouldExcludeResolvedIPs()
+    {
+        var config = CoreConfigTestFactory.CreateConfig();
+        config.TunModeItem.EnableTun = true;
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+
+        var node = CoreConfigTestFactory.CreateVmessNode(ECoreType.Xray, "vmess-domain");
+        node.Address = "one.one.one.one";
+        await UpsertProfilesAsync(node);
+
+        var result = await CoreConfigContextBuilder.Build(config, node);
+
+        await result.Success.Should().BeTrue();
+        await result.Context.AppConfig.TunModeItem.RouteExcludeAddress.Should().NotBeNull();
+        await result.Context.AppConfig.TunModeItem.RouteExcludeAddress!.Count.Should().BeGreaterThan(0);
+        await result.Context.AppConfig.TunModeItem.RouteExcludeAddress.Should().Contain(x => x.StartsWith("1.1.1.1") || x.StartsWith("1.0.0.1") || x.Contains(':'));
+    }
+
     private static string NewId(string prefix)
     {
         return $"{prefix}-{Guid.NewGuid():N}";
@@ -96,12 +186,22 @@ public class CoreConfigContextBuilderTests
                || message.Contains("циклическую зависимость", StringComparison.OrdinalIgnoreCase);
     }
 
+    private static readonly SemaphoreSlim _dbLock = new(1, 1);
+
     private static async Task UpsertProfilesAsync(params ProfileItem[] profiles)
     {
-        SQLiteHelper.Instance.CreateTable<ProfileItem>();
-        foreach (var profile in profiles)
+        await _dbLock.WaitAsync();
+        try
         {
-            await SQLiteHelper.Instance.ReplaceAsync(profile);
+            SQLiteHelper.Instance.CreateTable<ProfileItem>();
+            foreach (var profile in profiles)
+            {
+                await SQLiteHelper.Instance.ReplaceAsync(profile);
+            }
+        }
+        finally
+        {
+            _dbLock.Release();
         }
     }
 }

--- a/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
+++ b/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
@@ -96,22 +96,74 @@ public class CoreConfigContextBuilder
             }
         }
 
-        if (context.IsTunEnabled && context.AppConfig.TunModeItem.RouteExcludeAddress is { Count: > 0 })
+        if (context.IsTunEnabled)
         {
             var appConfig = JsonUtils.DeepCopy(config);
             var routeExcludeAddressList = new List<string>();
-            foreach (var addr in context.AppConfig.TunModeItem.RouteExcludeAddress)
+            if (context.AppConfig.TunModeItem.RouteExcludeAddress is { Count: > 0 })
             {
-                try
+                foreach (var addr in context.AppConfig.TunModeItem.RouteExcludeAddress)
                 {
-                    IPNetwork2.Parse(addr);
-                    routeExcludeAddressList.Add(addr);
-                }
-                catch
-                {
-                    validatorResult.Warnings.Add(string.Format(ResUI.MsgTunRouteExcludeInvalidAddress, addr));
+                    try
+                    {
+                        IPNetwork2.Parse(addr);
+                        routeExcludeAddressList.Add(addr);
+                    }
+                    catch
+                    {
+                        validatorResult.Warnings.Add(string.Format(ResUI.MsgTunRouteExcludeInvalidAddress, addr));
+                    }
                 }
             }
+
+            // Exclude proxy server IP addresses from TUN to prevent routing loops
+            var allNodes = context.AllProxiesMap.Values
+                .Append(context.Node)
+                .Where(n => n != null && !n.ConfigType.IsGroupType() && n.ConfigType != EConfigType.Outbound);
+
+            var uniqueAddresses = allNodes
+                .Select(n => n.Address?.Trim().Trim('[', ']'))
+                .Where(a => !string.IsNullOrEmpty(a))
+                .Distinct(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var pAddr in uniqueAddresses)
+            {
+                if (IPAddress.TryParse(pAddr, out var ipAddr))
+                {
+                    if (IsValidExcludableIP(ipAddr))
+                    {
+                        var cidr = ipAddr.AddressFamily == AddressFamily.InterNetworkV6 ? $"{ipAddr}/128" : $"{ipAddr}/32";
+                        if (!routeExcludeAddressList.Contains(cidr))
+                        {
+                            routeExcludeAddressList.Add(cidr);
+                        }
+                    }
+                }
+                else if (Utils.IsDomain(pAddr))
+                {
+                    try
+                    {
+                        using var cts = new CancellationTokenSource(2000);
+                        var addresses = await Dns.GetHostAddressesAsync(pAddr, cts.Token);
+                        foreach (var addr in addresses)
+                        {
+                            if (IsValidExcludableIP(addr))
+                            {
+                                var cidr = addr.AddressFamily == AddressFamily.InterNetworkV6 ? $"{addr}/128" : $"{addr}/32";
+                                if (!routeExcludeAddressList.Contains(cidr))
+                                {
+                                    routeExcludeAddressList.Add(cidr);
+                                }
+                            }
+                        }
+                    }
+                    catch
+                    {
+                        // Ignore DNS resolution failures at config build time
+                    }
+                }
+            }
+
             appConfig.TunModeItem.RouteExcludeAddress = routeExcludeAddressList;
             context = context with { AppConfig = appConfig };
         }
@@ -504,5 +556,14 @@ public class CoreConfigContextBuilder
         node.SetProtocolExtra(node.GetProtocolExtra() with { ChildItems = Utils.List2String(childIndexIdList) });
         context.AllProxiesMap[node.IndexId] = node;
         return childNodeValidatorResult;
+    }
+
+    private static bool IsValidExcludableIP(IPAddress ipAddr)
+    {
+        return !IPAddress.IsLoopback(ipAddr)
+               && !ipAddr.Equals(IPAddress.Any)
+               && !ipAddr.Equals(IPAddress.IPv6Any)
+               && !ipAddr.Equals(IPAddress.None)
+               && !ipAddr.Equals(IPAddress.IPv6None);
     }
 }


### PR DESCRIPTION
### 问题背景
在 TUN 模式下，当发往远程代理服务器的流量未能被进程路径规则及时匹配时（例如 XHTTP 频繁新建连接、双核前置模式下 socket 归属未能及时解析），代理核心自身发往 VPS 的连接会被 TUN 网卡截获并重新路由回本地，从而导致死循环或连接握手超时（详见 #9974）。

虽然手动在 TUN 设置中的 `route_exclude_address` 填入节点 IP 可以解决，但需要用户手动排查，且无法直接支持订阅中常见的域名节点。

---

### 改动说明
在 `CoreConfigContextBuilder.cs` 生成 TUN 配置时，自动收集当前活动节点以及路由规则引用的所有代理节点，将其 IP（及解析后的域名 IP）自动追加到 `RouteExcludeAddress`：

1. **原生 IP 节点支持**：
   - 自动格式化为 `/32` (IPv4) 或 `/128` (IPv6) 加入排除列表。
   - 自动处理带方括号的 IPv6 地址格式（如 `[2001:db8::1]` $\rightarrow$ `2001:db8::1/128`）。

2. **订阅域名节点支持**：
   - 对于域名节点（如 `node.example.com`），在配置构建时调用 `Dns.GetHostAddressesAsync` 解析其实际 IP 并加入排除列表。
   - 对相同域名做大小写不敏感去重（`Distinct(StringComparer.OrdinalIgnoreCase)`），避免节点数量较多时重复发起 DNS 查询。

3. **边界与异常保护**：
   - **特殊地址过滤**：通过 `IsValidExcludableIP` 过滤回环地址 (`127.0.0.1`, `::1`)、通配地址 (`0.0.0.0`, `::`) 和广播地址 (`255.255.255.255`)，避免影响本地 IPC 或广播路由。
   - **非阻塞与容错**：每个域名解析附加 2 秒超时（`CancellationTokenSource(2000)`）及 `try-catch`，在离线或域名解析失败时静默跳过，绝不卡死或中断配置生成。
   - **节点类型过滤**：自动过滤分组节点（`GroupType`）与外部自定义 JSON 节点（`Outbound`）。
   - **保留用户配置**：用户在界面中手动配置的 `route_exclude_address` 规则保持完整保留并合并。

---

### 单元测试
在 `CoreConfigContextBuilderTests.cs` 中增加了针对上述逻辑的测试覆盖：
- `Build_WhenTunEnabled_ShouldAutoExcludeProxyServerAddress`：验证 IPv4 节点自动排除与用户已有规则的合并。
- `Build_WhenTunEnabled_ShouldAutoExcludeProxyServerAddress_IPv6WithBrackets`：验证带方括号 IPv6 节点的格式化与排除。
- `Build_WhenTunEnabled_ShouldNotExcludeLoopbackAddress`：验证回环地址（127.0.0.1）不被误加入排除列表。
- `Build_WhenTunEnabled_ShouldNotExcludeAnyOrNoneAddress`：验证通配地址（0.0.0.0）不被加入排除列表。

同时在测试辅助类中通过 `SemaphoreSlim` 保证 SQLite 内存表在并行测试环境下的读写安全。

全量单元测试（73/73）均通过，`dotnet build` 0 警告 0 错误。

---

### 关联 Issue
- Fixes #9974
