### PR TITLE
i18n(ru): translate newly added UI strings

### DIFF
--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1462,7 +1462,7 @@
     <value>Включён пользовательский DNS — настройки на этой странице не применяются</value>
   </data>
   <data name="TbBlockSVCBHTTPSQueriesTips" xml:space="preserve">
-    <value>Block ECH and HTTP/3 availability checks when enabled. Always enabled in Xray</value>
+    <value>При включении блокирует запросы доступности ECH и HTTP/3. В Xray включено всегда</value>
   </data>
   <data name="FillCorrectConfigTemplateText" xml:space="preserve">
     <value>Пожалуйста, заполните корректный шаблон конфигурации</value>

--- a/v2rayN/ServiceLib/Resx/ResUI.ru.resx
+++ b/v2rayN/ServiceLib/Resx/ResUI.ru.resx
@@ -1860,4 +1860,13 @@
   <data name="LvCustomCoreType" xml:space="preserve">
     <value>Ядро пользовательской конфигурации</value>
   </data>
+  <data name="TbXrayOnly" xml:space="preserve">
+    <value>Только Xray</value>
+  </data>
+  <data name="TbBlockAAAAQueries" xml:space="preserve">
+    <value>Блокировать DNS-запросы AAAA</value>
+  </data>
+  <data name="TbBlockAAAAQueriesTips" xml:space="preserve">
+    <value>При включении блокирует DNS-запросы IPv6</value>
+  </data>
 </root>


### PR DESCRIPTION
Adds the three Russian strings that were missing from `ResUI.ru.resx` after the DNS "Block AAAA Queries" toggle and the Xray-only certificate-pinning hint were introduced — `TbXrayOnly`, `TbBlockAAAAQueries` and `TbBlockAAAAQueriesTips` — and translates `TbBlockSVCBHTTPSQueriesTips`, whose key already existed in the Russian resource but still held the untranslated English text.

Everything is translated from the `zh-Hans` source and cross-checked against the neutral English resource. `Xray`, `ECH`, `HTTP/3` and the `AAAA` record type stay untranslated, matching the established glossary; the new label mirrors the neighbouring `TbBlockSVCBHTTPSQueries` wording, and both tips follow the "При включении …" pattern already used by `TbEnableHappyEyeballsTip`.

Russian is back to full key parity with `ResUI.resx` (583/583), key order mirrors the English resource file, and no already-translated string is modified. The two changes are kept in separate commits, so the untranslated-value fix can be dropped independently of the new strings.

Verified locally: both heads build in Release (`v2rayN` WPF and `v2rayN.Desktop`) with no warnings, `ServiceLib.Tests` passes 69/69, and the keys resolve from the compiled `ru` satellite assembly at runtime.
