### PR TITLE
Fix regional presets settings

### DIFF
--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -2958,6 +2958,20 @@ public static class ConfigHandler
                 break;
         }
 
+        // Activate a routing that matches the preset's geo data.
+        // The IR rule-sets need geosite "ir" (Chocolate4U only) and geosite:gfw only exists on Loyalsoldier/runetfreedom;
+        // an active routing with categories missing from the new dats would stop the core from starting.
+        // Derived from the effective geo source so the mapping follows whatever the built-in default is.
+        var effectiveGeoUrl = config.ConstItem.GeoSourceUrl.IsNullOrEmpty() ? Global.GeoUrl : config.ConstItem.GeoSourceUrl;
+        var routingPrefix = effectiveGeoUrl.Contains("Chocolate4U", StringComparison.OrdinalIgnoreCase) ? "IR-"
+            : effectiveGeoUrl.Contains("russia", StringComparison.OrdinalIgnoreCase) ? "RU"
+            : "V4-";
+        var presetRouting = (await AppManager.Instance.RoutingItems())?.FirstOrDefault(t => t.Remarks.StartsWith(routingPrefix));
+        if (presetRouting != null)
+        {
+            await SetDefaultRouting(config, presetRouting);
+        }
+
         return true;
     }
 

--- a/v2rayN/ServiceLib/Helper/DownloaderHelper.cs
+++ b/v2rayN/ServiceLib/Helper/DownloaderHelper.cs
@@ -261,7 +261,7 @@ public class DownloaderHelper
             downloader.DownloadFileCompleted += (sender, value) =>
             {
                 var newState = states[index] with { Completed = true };
-                if (value.Error != null)
+                if (value.Error != null && !(request.IgnoreNotFound && IsNotFoundError(value.Error)))
                 {
                     newState = newState with { Error = value.Error };
                 }
@@ -270,6 +270,19 @@ public class DownloaderHelper
             };
             await downloader.DownloadFileTaskAsync(request.FileUrl, request.FilePath, parallelCancellationToken);
         });
+    }
+
+    private static bool IsNotFoundError(Exception? ex)
+    {
+        while (ex != null)
+        {
+            if (ex is HttpRequestException { StatusCode: HttpStatusCode.NotFound })
+            {
+                return true;
+            }
+            ex = ex.InnerException;
+        }
+        return false;
     }
 
     // https://github.com/bezzad/Downloader/blob/a75a6e431acd6cbba6293f7afdcf676544a09174/src/Downloader/SocketClient.cs#L45

--- a/v2rayN/ServiceLib/Models/Dto/FileDownloadState.cs
+++ b/v2rayN/ServiceLib/Models/Dto/FileDownloadState.cs
@@ -18,5 +18,11 @@ public record FileDownloadRequest
     public required string FilePath { get; init; }
     public string? DisplayFileName { get; init; }
 
+    /// <summary>
+    /// Treat HTTP 404 as a successful (skipped) download.
+    /// Used for sing-box rule-set files that may not exist on the selected source.
+    /// </summary>
+    public bool IgnoreNotFound { get; init; }
+
     public string FileName => DisplayFileName ?? Path.GetFileName(FilePath);
 }

--- a/v2rayN/ServiceLib/Services/DownloadService.cs
+++ b/v2rayN/ServiceLib/Services/DownloadService.cs
@@ -87,12 +87,19 @@ public class DownloadService
             {
                 var span = states.Span;
                 var completedCount = 0;
+                var failedCount = 0;
+                FileDownloadState? failedState = null;
                 var downloadingStates = new List<FileDownloadState>();
                 foreach (ref readonly var item in span)
                 {
                     if (item.Completed)
                     {
                         completedCount++;
+                        if (item.IsFailed)
+                        {
+                            failedCount++;
+                            failedState ??= item;
+                        }
                     }
                     else if (item.TotalBytes > 0)
                     {
@@ -104,25 +111,13 @@ public class DownloadService
                 var totalTotalBytes = downloadingStates.Sum(x => x.TotalBytes);
                 var downloadingFileName = string.Join(", ", downloadingStates.Select(x => x.Request.FileName));
                 var allCompleted = completedCount == span.Length;
-                if (allCompleted)
+                if (allCompleted && failedCount > 0 && failedState?.Error != null)
                 {
-                    // check and throw errors if any
-                    FileDownloadState? failedState = null;
-                    foreach (ref readonly var item in span)
-                    {
-                        if (!item.IsFailed)
-                        {
-                            continue;
-                        }
-                        failedState = item;
-                        break;
-                    }
-                    if (failedState?.Error != null)
-                    {
-                        throw failedState.Error;
-                    }
+                    // do not throw here (the downloader swallows it); report and let the caller see Success=false
+                    Logging.SaveLog(_tag, failedState.Error);
+                    Error?.Invoke(this, new ErrorEventArgs(failedState.Error));
                 }
-                UpdateCompleted?.Invoke(this, new UpdateResult(allCompleted, $"{completedCount}/{span.Length} | {Utils.HumanFy((long)totalSpeed / 1024)}/s {Utils.HumanFy(totalDownloadedBytes / 1024)}/{Utils.HumanFy(totalTotalBytes / 1024)} {downloadingFileName}"));
+                UpdateCompleted?.Invoke(this, new UpdateResult(allCompleted && failedCount == 0, $"{completedCount}/{span.Length} | {Utils.HumanFy((long)totalSpeed / 1024)}/s {Utils.HumanFy(totalDownloadedBytes / 1024)}/{Utils.HumanFy(totalTotalBytes / 1024)} {downloadingFileName}"));
             }
         }
         catch (Exception ex)

--- a/v2rayN/ServiceLib/Services/UpdateService.cs
+++ b/v2rayN/ServiceLib/Services/UpdateService.cs
@@ -145,8 +145,15 @@ public class UpdateService(Config config, Func<bool, string, Task> updateFunc)
         requests.AddRange(await GetSrsFileAllRequest());
         // NOTE: srs files are more small, so we reverse the order to ensure a good download experience for the user.
         requests.Reverse();
-        await DownloadGeoFiles(requests);
-        await UpdateFunc(true, string.Format(ResUI.MsgDownloadGeoFileSuccessfully, "geo"));
+        var installed = await DownloadGeoFiles(requests);
+        if (installed)
+        {
+            await UpdateFunc(true, string.Format(ResUI.MsgDownloadGeoFileSuccessfully, "geo"));
+        }
+        else
+        {
+            await UpdateFunc(false, ResUI.OperationFailed);
+        }
     }
 
     #region CheckUpdate private
@@ -533,8 +540,9 @@ public class UpdateService(Config config, Func<bool, string, Task> updateFunc)
         };
     }
 
-    private async Task DownloadGeoFiles(List<FileDownloadRequest> requests)
+    private async Task<bool> DownloadGeoFiles(List<FileDownloadRequest> requests)
     {
+        var installed = false;
         var tmpFilePathDict = new Dictionary<string, string>();
         var tmpFileRequests = new List<FileDownloadRequest>();
         foreach (var request in requests)
@@ -552,6 +560,7 @@ public class UpdateService(Config config, Func<bool, string, Task> updateFunc)
         {
             if (args.Success)
             {
+                installed = true;
                 //_ = UpdateFunc(false, string.Format(ResUI.MsgDownloadGeoFileSuccessfully, fileName));
 
                 foreach (var request in requests)
@@ -589,6 +598,7 @@ public class UpdateService(Config config, Func<bool, string, Task> updateFunc)
         };
 
         await downloadHandle.DownloadSmallFilesAsync(tmpFileRequests, true, TimeSpan.FromSeconds(_timeout));
+        return installed;
     }
 
     #endregion Geo private

--- a/v2rayN/ServiceLib/Services/UpdateService.cs
+++ b/v2rayN/ServiceLib/Services/UpdateService.cs
@@ -441,13 +441,6 @@ public class UpdateService(Config config, Func<bool, string, Task> updateFunc)
         // Append default items
         geoSiteFiles.AddRange(["google", "cn", "geolocation-cn", "category-ads-all"]);
 
-        // The Iran (Chocolate4U) rule-set source does not provide geosite-gfw.srs (referenced by the built-in blacklist routing).
-        // A single 404 aborts the whole batch and nothing (including geosite.dat/geoip.dat) gets installed, so skip it.
-        if (_config.ConstItem.SrsSourceUrl == Global.SingboxRulesetSources[2])
-        {
-            geoSiteFiles.RemoveAll(f => f == "gfw");
-        }
-
         // Download files
         var path = Utils.GetBinPath("srss");
         if (!Directory.Exists(path))
@@ -535,6 +528,8 @@ public class UpdateService(Config config, Func<bool, string, Task> updateFunc)
             FileUrl = url,
             FilePath = targetPath,
             DisplayFileName = fileName,
+            // Not every source provides every rule-set; a missing one must not fail the whole geo update
+            IgnoreNotFound = true,
         };
     }
 

--- a/v2rayN/ServiceLib/Services/UpdateService.cs
+++ b/v2rayN/ServiceLib/Services/UpdateService.cs
@@ -441,6 +441,13 @@ public class UpdateService(Config config, Func<bool, string, Task> updateFunc)
         // Append default items
         geoSiteFiles.AddRange(["google", "cn", "geolocation-cn", "category-ads-all"]);
 
+        // The Iran (Chocolate4U) rule-set source does not provide geosite-gfw.srs (referenced by the built-in blacklist routing).
+        // A single 404 aborts the whole batch and nothing (including geosite.dat/geoip.dat) gets installed, so skip it.
+        if (_config.ConstItem.SrsSourceUrl == Global.SingboxRulesetSources[2])
+        {
+            geoSiteFiles.RemoveAll(f => f == "gfw");
+        }
+
         // Download files
         var path = Utils.GetBinPath("srss");
         if (!Directory.Exists(path))


### PR DESCRIPTION
When you select Iran in regional presets settings, the Chocolate4U geoip/geosite should be downloaded and replaced the default geiop/geosite, but this does not happen, **the reason is that Chocolate4U lacks "geosite-gfw.srs" file.**

downloaded files are copied to the bin folder when they are **all** successfully downloaded, **but the absence of "geosite-gfw.srs" means that practically nothing happens and no files are copied into the bin folder.**
///
Also, since after selecting Iran in Regional presets settings, a custom DNS settings with "geosite:ir" is set automatically, users encounter this error:
`infra/conf: failed to build nameserver > common/geodata: illegal domain rule: geosite:ir > common/geodata: failed to check code IR from geosite.dat > EOF`

because "geosite:ir" only exists in Chocolate4U list, but it was not replaced with default Loyalsoldier list.