### PR TITLE
Change the default value of `SpeedTestPageSize`

### DIFF
--- a/v2rayN/ServiceLib/Global.cs
+++ b/v2rayN/ServiceLib/Global.cs
@@ -91,7 +91,7 @@ public class Global
     public const string V2RayLocalAsset = "V2RAY_LOCATION_ASSET";
     public const string XrayLocalAsset = "XRAY_LOCATION_ASSET";
     public const string XrayLocalCert = "XRAY_LOCATION_CERT";
-    public const int SpeedTestPageSize = 1000;
+    public const int SpeedTestPageSize = 32;
     public const string LinuxBash = "/bin/bash";
     public const string StringTrue = "true";
     public const string StringFalse = "false";


### PR DESCRIPTION
Most users don't change `SpeedTestPageSize` in "guiNConfig.json", so they use the default value of 1000.

I tested for several Fibre-optic/Mobile internets and 1000 concurrent tests causes NAT/CGNAT stops working or gets throttled.

So most tests fail and show -1.