### PR TITLE
fix(hysteria2): default the port to 443 when the share URI omits it

### DIFF
--- a/v2rayN/ServiceLib.Tests/Fmt/Hysteria2FmtTests.cs
+++ b/v2rayN/ServiceLib.Tests/Fmt/Hysteria2FmtTests.cs
@@ -1,0 +1,54 @@
+namespace ServiceLib.Tests.Fmt;
+
+public class Hysteria2FmtTests
+{
+    // "The hostname and optional port of the server. If the port is omitted, it defaults to 443."
+    // -- https://v2.hysteria.network/docs/developers/URI-Scheme/
+    // A ':' with no digits after it is an omitted port too, per RFC 3986 'port = *DIGIT'.
+    [Test]
+    [Arguments("hysteria2://password@hy2.example/")]
+    [Arguments("hysteria2://password@hy2.example")]
+    [Arguments("hysteria2://password@hy2.example:/")]
+    [Arguments("hy2://password@hy2.example/?sni=real.example")]
+    public async Task ResolveConfig_WithoutPort_ShouldDefaultTo443(string shareUri)
+    {
+        var resolved = FmtHandler.ResolveConfig(shareUri, out var msg);
+
+        await resolved.Should().NotBeNull().Because($"uri: {shareUri}, msg: {msg}");
+        await resolved!.ConfigType.Should().BeEqualTo(EConfigType.Hysteria2);
+        await resolved.Address.Should().BeEqualTo("hy2.example");
+        await resolved.Port.Should().BeEqualTo(443);
+    }
+
+    [Test]
+    public async Task ResolveConfig_WithoutPort_ShouldProduceAValidProfile()
+    {
+        // Uri.Port is -1 for an unregistered scheme with no port, and ProfileItem.IsValid rejects
+        // any port outside 1..65535 - so the default is what keeps such a link usable at all.
+        var resolved = FmtHandler.ResolveConfig("hysteria2://password@hy2.example/", out _);
+
+        await resolved.Should().NotBeNull();
+        await resolved!.IsValid().Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ResolveConfig_WithExplicitPort_ShouldKeepIt()
+    {
+        var resolved = FmtHandler.ResolveConfig("hysteria2://password@hy2.example:8443/", out _);
+
+        await resolved.Should().NotBeNull();
+        await resolved!.Port.Should().BeEqualTo(8443);
+    }
+
+    [Test]
+    public async Task ResolveConfig_WithExplicitZeroPort_ShouldNotApplyTheDefault()
+    {
+        // Uri.Port is 0 here, not -1: the port is present, it is just not a usable one. Treating
+        // it as "omitted" would silently move the endpoint to :443, so it stays invalid instead.
+        var resolved = FmtHandler.ResolveConfig("hysteria2://password@hy2.example:0/", out _);
+
+        await resolved.Should().NotBeNull();
+        await resolved!.Port.Should().BeEqualTo(0);
+        await resolved.IsValid().Should().BeFalse();
+    }
+}

--- a/v2rayN/ServiceLib/Handler/Fmt/Hysteria2Fmt.cs
+++ b/v2rayN/ServiceLib/Handler/Fmt/Hysteria2Fmt.cs
@@ -17,7 +17,11 @@ public class Hysteria2Fmt : BaseFmt
         }
 
         item.Address = url.IdnHost;
-        item.Port = url.Port;
+        // The URI scheme makes the port optional and defaults it to 443. Uri.Port answers -1 for
+        // an unregistered scheme carrying no port, which ProfileItem.IsValid then rejects.
+        // Only -1 means "omitted": an explicit ":0" has to stay 0 and be rejected the way it
+        // always was, instead of being quietly redirected to a server the link never named.
+        item.Port = url.Port == -1 ? 443 : url.Port;
         item.Remarks = url.GetComponents(UriComponents.Fragment, UriFormat.Unescaped);
         item.Password = Utils.UrlDecode(url.UserInfo);
 


### PR DESCRIPTION
The [URI scheme](https://v2.hysteria.network/docs/developers/URI-Scheme/) makes the port optional: "The hostname and optional port of the server. If the port is omitted, it defaults to 443."

`Hysteria2Fmt.Resolve` assigns `url.Port` straight through, and `System.Uri` answers `-1` for an unregistered scheme that carries no port. So `hysteria2://password@hy2.example/` imports as a profile with `Port = -1`, and `ProfileItem.IsValid` rejects anything outside 1..65535 — the link produces a profile that can never be used, without saying why.

```diff
-        item.Port = url.Port;
+        item.Port = url.Port == -1 ? 443 : url.Port;
```

`-1` is the only value that means "the port was omitted", and a `:` with no digits after it maps to `-1` as well. An explicit `:0` parses as `0`, so it keeps the fate it has today — rejected by `IsValid` — rather than being redirected to a server the link never named.

`Hysteria2Fmt.ResolveRealm` takes its port from `HyRealm.RendezvousPort` instead of the URI, so it is unaffected.

## Testing

Windows, .NET SDK 10.0.400.

The tests were written first and fail on `master`:

```
сбой ResolveConfig_WithoutPort_ShouldDefaultTo443(hysteria2://password@hy2.example/)
сбой ResolveConfig_WithoutPort_ShouldDefaultTo443(hysteria2://password@hy2.example)
сбой ResolveConfig_WithoutPort_ShouldDefaultTo443(hysteria2://password@hy2.example:/)
сбой ResolveConfig_WithoutPort_ShouldDefaultTo443(hy2://password@hy2.example/?sni=real.example)
сбой ResolveConfig_WithoutPort_ShouldProduceAValidProfile
  total: 76   failed: 5   succeeded: 71
```

and pass with the change:

```
  total: 76   failed: 0   succeeded: 76
```

Two of them are controls rather than regression guards. `ResolveConfig_WithExplicitPort_ShouldKeepIt` passes before and after, so the default cannot override a port that was given. `ResolveConfig_WithExplicitZeroPort_ShouldNotApplyTheDefault` also passes before and after — it pins the boundary of the default itself, since a condition like `url.Port > 0` would have quietly turned `:0` into `:443`.
