### PR TITLE
fix(fmt): stop share-URI query values from being decoded twice or dropped

### DIFF
--- a/v2rayN/ServiceLib.Tests/Fmt/ShareUriQueryTests.cs
+++ b/v2rayN/ServiceLib.Tests/Fmt/ShareUriQueryTests.cs
@@ -1,0 +1,73 @@
+namespace ServiceLib.Tests.Fmt;
+
+public class ShareUriQueryTests
+{
+    [Test]
+    [Arguments("ob%41fs")]
+    [Arguments("66%ff")]
+    [Arguments("100%")]
+    public async Task GetShareUriAndResolveConfig_QueryValueWithPercent_ShouldSurviveTheRoundTrip(string obfsPassword)
+    {
+        var source = new ProfileItem
+        {
+            ConfigType = EConfigType.Hysteria2,
+            Remarks = "percent demo",
+            Address = "hy2.example",
+            Port = 8443,
+            Password = "pw",
+        };
+        source.SetProtocolExtra(new ProtocolExtraItem { SalamanderPass = obfsPassword, });
+
+        var uri = FmtHandler.GetShareUri(source);
+
+        await uri.Should().NotBeNull();
+
+        var resolved = FmtHandler.ResolveConfig(uri!, out var msg);
+
+        await resolved.Should().NotBeNull().Because($"uri: {uri}, msg: {msg}");
+        await resolved!.GetProtocolExtra().SalamanderPass.Should().BeEqualTo(obfsPassword);
+    }
+
+    // RFC 3986 lists '=' among the sub-delimiters a query value may carry, so only the first one
+    // separates the key from the value. Splitting on every '=' discarded the pair outright.
+    [Test]
+    public async Task ResolveConfig_QueryValueWithUnescapedEquals_ShouldNotBeDropped()
+    {
+        const string shareUri = "hysteria2://pw@hy2.example:8443/?ech=AAj+DQAEAAAAAA==&sni=real.example";
+
+        var resolved = FmtHandler.ResolveConfig(shareUri, out var msg);
+
+        await resolved.Should().NotBeNull().Because($"uri: {shareUri}, msg: {msg}");
+        await resolved!.EchConfigList.Should().BeEqualTo("AAj+DQAEAAAAAA==");
+        await resolved.Sni.Should().BeEqualTo("real.example");
+    }
+
+    // Canonical SIP002 percent-encodes the plugin argument, and that is what this client's own
+    // exporter emits. This covers the non-canonical spelling instead: the options are a ';'
+    // separated list of 'key=value' pairs, so left unescaped the value always carries '='.
+    [Test]
+    public async Task ResolveConfig_NonCanonicalSip002PluginWithLiteralEquals_ShouldConfigureObfs()
+    {
+        const string shareUri =
+            "ss://YWVzLTEyOC1nY206cGFzczEyMw==@1.2.3.4:8388/?plugin=obfs-local;obfs=http;obfs-host=example.com#ss";
+
+        var resolved = FmtHandler.ResolveConfig(shareUri, out var msg);
+
+        await resolved.Should().NotBeNull().Because($"uri: {shareUri}, msg: {msg}");
+        await resolved!.ConfigType.Should().BeEqualTo(EConfigType.Shadowsocks);
+        await resolved.GetTransportExtra().Host.Should().BeEqualTo("example.com");
+        await resolved.GetTransportExtra().RawHeaderType.Should().BeEqualTo(Global.RawHeaderHttp);
+    }
+
+    [Test]
+    public async Task ResolveConfig_EscapedQueryValue_ShouldStillDecodeExactlyOnce()
+    {
+        const string shareUri = "hysteria2://pw@hy2.example:8443/?ech=AAj%2BDQAEAAAAAA%3D%3D&obfs=salamander&obfs-password=a%20b";
+
+        var resolved = FmtHandler.ResolveConfig(shareUri, out var msg);
+
+        await resolved.Should().NotBeNull().Because($"uri: {shareUri}, msg: {msg}");
+        await resolved!.EchConfigList.Should().BeEqualTo("AAj+DQAEAAAAAA==");
+        await resolved.GetProtocolExtra().SalamanderPass.Should().BeEqualTo("a b");
+    }
+}

--- a/v2rayN/ServiceLib/Common/Utils.cs
+++ b/v2rayN/ServiceLib/Common/Utils.cs
@@ -200,7 +200,9 @@ public class Utils
         var parts = query[1..].Split('&', StringSplitOptions.RemoveEmptyEntries);
         foreach (var part in parts)
         {
-            var keyValue = part.Split('=');
+            // Split on the FIRST '=' only: RFC 3986 lists '=' among the sub-delimiters a query
+            // value may carry, so everything after the first one belongs to the value.
+            var keyValue = part.Split('=', 2);
             if (keyValue.Length != 2)
             {
                 continue;

--- a/v2rayN/ServiceLib/Handler/Fmt/BaseFmt.cs
+++ b/v2rayN/ServiceLib/Handler/Fmt/BaseFmt.cs
@@ -342,8 +342,13 @@ public class BaseFmt
         return query[key] ?? defaultValue;
     }
 
+    /// <summary>
+    /// Values are already unescaped by <see cref="Utils.ParseQueryString" />, so this must not
+    /// unescape them a second time: a value that still holds a valid percent sequence after the
+    /// first pass - an obfuscation password of "ob%41fs", say - would decay into "obAfs".
+    /// </summary>
     protected static string GetQueryDecoded(NameValueCollection query, string key, string defaultValue = "")
     {
-        return Utils.UrlDecode(GetQueryValue(query, key, defaultValue));
+        return GetQueryValue(query, key, defaultValue);
     }
 }


### PR DESCRIPTION
Two defects in the same place, both on the import side, both silent.

## The value is unescaped twice

`Utils.ParseQueryString` already unescapes every value, and `BaseFmt.GetQueryDecoded` unescaped it a second time. A value that still holds a valid percent sequence after the first pass decays on the second: an obfuscation password of `ob%41fs` exports as `ob%2541fs` and imports back as `obAfs`.

Only well-formed sequences are affected, which is exactly why this is hard to notice — `100%` and `66%ff` survive untouched, because `Uri.UnescapeDataString` leaves a malformed escape alone. Both are covered as test arguments so the boundary stays pinned.

## A value containing `=` is dropped

The same function split each pair on every `=` and skipped the pair unless exactly two halves came out. RFC 3986 lists `=` among the sub-delimiters a query value may carry, so only the first `=` separates the key from the value — `HttpUtility.ParseQueryString` reads a query string the same way. Splitting on all of them discarded a syntactically valid pair without a word:

- `?ech=AAj+DQAEAAAAAA==` — the whole parameter was dropped and the ECH config silently lost;
- a `plugin` value in the non-canonical SIP002 spelling — those are `;` separated `key=value` lists, so left unescaped they never reached `ShadowsocksFmt` and the obfuscation was silently not configured.

v2rayN percent-encodes both on export, so its own links were never affected. What changes is that the parser now follows the grammar instead of discarding a pair it cannot split in two.

## The change

```diff
-            var keyValue = part.Split('=');
+            var keyValue = part.Split('=', 2);
```

```diff
-        return Utils.UrlDecode(GetQueryValue(query, key, defaultValue));
+        return GetQueryValue(query, key, defaultValue);
```

`ParseQueryString` keeps decoding, because `ConfigHandler.AddSubItem` reads `queryVars["remarks"]` from the collection directly and expects a decoded value.

`GetQueryDecoded` and `GetQueryValue` are equivalent after this. They are left separate to keep the change to two lines; collapsing them touches 36 call sites, so that seemed better as your call than mine.

## One behaviour change worth naming

The collection keeps the first occurrence of a repeated key. For a query that both repeats a key and leaves a bare `=` in the first of them — `?sni=a=b&sni=real.example` — the old code dropped the unsplittable pair and resolved `sni` to `real.example`, while the new code keeps `a=b`. It is the only input class I found where the previous behaviour gave the better result.

## Testing

Windows, .NET SDK 10.0.400.

The tests were written first. On `master` three of them fail:

```
сбой ResolveConfig_QueryValueWithUnescapedEquals_ShouldNotBeDropped
сбой ResolveConfig_NonCanonicalSip002PluginWithLiteralEquals_ShouldConfigureObfs
сбой GetShareUriAndResolveConfig_QueryValueWithPercent_ShouldSurviveTheRoundTrip(ob%41fs)
  total: 75   failed: 3   succeeded: 72
```

With the change:

```
  total: 75   failed: 0   succeeded: 75
```

The 69 pre-existing tests pass unchanged, which is the part that matters for removing a decode from a shared helper: no exporter double-encodes, so nothing relied on the second pass.

`ResolveConfig_EscapedQueryValue_ShouldStillDecodeExactlyOnce` is the control for the opposite direction — a properly escaped `ech` and an `obfs-password` of `a%20b` must still arrive decoded exactly once.
