### PR TITLE
Fix hy2 fmt

### DIFF
--- a/v2rayN/ServiceLib/Handler/Fmt/Hysteria2Fmt.cs
+++ b/v2rayN/ServiceLib/Handler/Fmt/Hysteria2Fmt.cs
@@ -223,6 +223,11 @@ public class Hysteria2Fmt : BaseFmt
             var sha = item.CertSha;
             dicQuery.Add("pinSHA256", Utils.UrlEncode(sha));
         }
+        else if (!item.Cert.IsNullOrEmpty()
+            && CertPemManager.GetLeafCertSha256Thumbprint(item.Cert) is { Length: > 0 } thumbprint)
+        {
+            dicQuery.Add("pinSHA256", Utils.UrlEncode(thumbprint));
+        }
         if (!item.EchConfigList.IsNullOrEmpty())
         {
             dicQuery.Add("ech", Utils.UrlEncode(item.EchConfigList));

--- a/v2rayN/ServiceLib/Manager/CertPemManager.cs
+++ b/v2rayN/ServiceLib/Manager/CertPemManager.cs
@@ -281,6 +281,37 @@ public class CertPemManager
         }
     }
 
+    public static string GetLeafCertSha256Thumbprint(string pemCertChain, bool includeColon = false)
+    {
+        var certs = ParsePemChain(pemCertChain);
+        if (certs.Count == 0)
+        {
+            return string.Empty;
+        }
+        foreach (var certStr in certs)
+        {
+            try
+            {
+                var cert = X509Certificate2.CreateFromPem(certStr);
+                var extension = cert.Extensions
+                    .OfType<X509BasicConstraintsExtension>()
+                    .FirstOrDefault();
+                var isCa = extension?.CertificateAuthority == true;
+                if (isCa)
+                {
+                    continue;
+                }
+                var thumbprint = cert.GetCertHashString(HashAlgorithmName.SHA256);
+                return includeColon ? string.Join(":", thumbprint.Chunk(2).Select(c => new string(c))) : thumbprint;
+            }
+            catch
+            {
+                // Ignore
+            }
+        }
+        return string.Empty;
+    }
+
     private static readonly Lazy<X509Certificate2Collection> _chromeRootCerts = new(() =>
     {
         var pemText = EmbedUtils.GetEmbedText(Global.ChromeRootCertFileName);


### PR DESCRIPTION
修复 hysteria2 分享链接导出

当固定证书指定为多证书/证书链时，从中提取第一个叶证书赋值 pinSHA256