### PR TITLE
Fix window position not restored after reopening

### DIFF
--- a/v2rayN/ServiceLib/Handler/ConfigHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConfigHandler.cs
@@ -2976,7 +2976,7 @@ public static class ConfigHandler
         return sizeItem;
     }
 
-    public static int SaveWindowSizeItem(Config config, string typeName, double width, double height)
+    public static int SaveWindowSizeItem(Config config, string typeName, double width, double height, double? left = null, double? top = null)
     {
         var sizeItem = config?.UiItem?.WindowSizeItem?.FirstOrDefault(t => t.TypeName == typeName);
         if (sizeItem == null)
@@ -2987,6 +2987,14 @@ public static class ConfigHandler
 
         sizeItem.Width = (int)width;
         sizeItem.Height = (int)height;
+        if (left != null)
+        {
+            sizeItem.Left = (int)left;
+        }
+        if (top != null)
+        {
+            sizeItem.Top = (int)top;
+        }
 
         return 0;
     }

--- a/v2rayN/ServiceLib/Models/Configs/ConfigItems.cs
+++ b/v2rayN/ServiceLib/Models/Configs/ConfigItems.cs
@@ -268,6 +268,8 @@ public class WindowSizeItem
     public string TypeName { get; set; }
     public int Width { get; set; }
     public int Height { get; set; }
+    public int? Left { get; set; }
+    public int? Top { get; set; }
 }
 
 [Serializable]

--- a/v2rayN/v2rayN.Desktop/Base/WindowBase.cs
+++ b/v2rayN/v2rayN.Desktop/Base/WindowBase.cs
@@ -39,15 +39,28 @@ public class WindowBase<TViewModel> : ReactiveWindow<TViewModel> where TViewMode
             Width = width;
             Height = height;
 
-            var frameDiff = (FrameSize ?? ClientSize) - ClientSize;
-            var totalWidth = (width + frameDiff.Width) * scaling;
-            var totalHeight = (height + frameDiff.Height) * scaling;
+            if (sizeItem.Left != null && sizeItem.Top != null &&
+                IsOnScreen(new PixelPoint(sizeItem.Left.Value, sizeItem.Top.Value)))
+            {
+                Position = new PixelPoint(sizeItem.Left.Value, sizeItem.Top.Value);
+            }
+            else
+            {
+                var frameDiff = (FrameSize ?? ClientSize) - ClientSize;
+                var totalWidth = (width + frameDiff.Width) * scaling;
+                var totalHeight = (height + frameDiff.Height) * scaling;
 
-            var x = workingArea.X + ((workingArea.Width - totalWidth) / 2);
-            var y = workingArea.Y + ((workingArea.Height - totalHeight) / 2);
-            Position = new PixelPoint((int)x, (int)y);
+                var x = workingArea.X + ((workingArea.Width - totalWidth) / 2);
+                var y = workingArea.Y + ((workingArea.Height - totalHeight) / 2);
+                Position = new PixelPoint((int)x, (int)y);
+            }
         }
         catch { }
+    }
+
+    private bool IsOnScreen(PixelPoint position)
+    {
+        return Screens.All.Any(s => s.Bounds.Contains(position));
     }
 
     protected override void OnClosed(EventArgs e)
@@ -55,7 +68,10 @@ public class WindowBase<TViewModel> : ReactiveWindow<TViewModel> where TViewMode
         base.OnClosed(e);
         try
         {
-            ConfigHandler.SaveWindowSizeItem(AppManager.Instance.Config, GetType().Name, Width, Height);
+            if (WindowState == WindowState.Normal)
+            {
+                ConfigHandler.SaveWindowSizeItem(AppManager.Instance.Config, GetType().Name, Width, Height, Position.X, Position.Y);
+            }
         }
         catch { }
     }

--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
@@ -388,7 +388,10 @@ public partial class MainWindow : WindowBase<MainWindowViewModel>
 
     private void StorageUI()
     {
-        ConfigHandler.SaveWindowSizeItem(_config, GetType().Name, Width, Height);
+        if (WindowState == WindowState.Normal)
+        {
+            ConfigHandler.SaveWindowSizeItem(_config, GetType().Name, Width, Height, Position.X, Position.Y);
+        }
 
         if (_config.UiItem.MainGirdOrientation == EGirdOrientation.Horizontal)
         {

--- a/v2rayN/v2rayN/Base/WindowBase.cs
+++ b/v2rayN/v2rayN/Base/WindowBase.cs
@@ -20,10 +20,26 @@ public class WindowBase<TViewModel> : ReactiveWindow<TViewModel> where TViewMode
             Width = Math.Min(sizeItem.Width, SystemParameters.WorkArea.Width);
             Height = Math.Min(sizeItem.Height, SystemParameters.WorkArea.Height);
 
-            Left = SystemParameters.WorkArea.Left + ((SystemParameters.WorkArea.Width - Width) / 2);
-            Top = SystemParameters.WorkArea.Top + ((SystemParameters.WorkArea.Height - Height) / 2);
+            if (sizeItem.Left != null && sizeItem.Top != null && IsOnScreen(sizeItem.Left.Value, sizeItem.Top.Value))
+            {
+                Left = sizeItem.Left.Value;
+                Top = sizeItem.Top.Value;
+            }
+            else
+            {
+                Left = SystemParameters.WorkArea.Left + ((SystemParameters.WorkArea.Width - Width) / 2);
+                Top = SystemParameters.WorkArea.Top + ((SystemParameters.WorkArea.Height - Height) / 2);
+            }
         }
         catch { }
+    }
+
+    private static bool IsOnScreen(double left, double top)
+    {
+        return left >= SystemParameters.VirtualScreenLeft
+            && top >= SystemParameters.VirtualScreenTop
+            && left < SystemParameters.VirtualScreenLeft + SystemParameters.VirtualScreenWidth
+            && top < SystemParameters.VirtualScreenTop + SystemParameters.VirtualScreenHeight;
     }
 
     protected override void OnClosed(EventArgs e)
@@ -32,7 +48,10 @@ public class WindowBase<TViewModel> : ReactiveWindow<TViewModel> where TViewMode
 
         try
         {
-            ConfigHandler.SaveWindowSizeItem(AppManager.Instance.Config, GetType().Name, Width, Height);
+            if (WindowState == WindowState.Normal)
+            {
+                ConfigHandler.SaveWindowSizeItem(AppManager.Instance.Config, GetType().Name, Width, Height, Left, Top);
+            }
         }
         catch { }
     }

--- a/v2rayN/v2rayN/Views/MainWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml.cs
@@ -344,7 +344,10 @@ public partial class MainWindow
 
     private void StorageUI()
     {
-        ConfigHandler.SaveWindowSizeItem(_config, GetType().Name, Width, Height);
+        if (WindowState == WindowState.Normal)
+        {
+            ConfigHandler.SaveWindowSizeItem(_config, GetType().Name, Width, Height, Left, Top);
+        }
 
         if (_config.UiItem.MainGirdOrientation == EGirdOrientation.Horizontal)
         {


### PR DESCRIPTION
Only Width/Height were persisted for window geometry; the window position was always recalculated to be centered on screen at startup, so the app appeared to reset its layout after restarting even though the user had moved it elsewhere. Also guard against saving bogus geometry while minimized/maximized, and fall back to centering when the saved position is no longer on any connected screen (e.g. a monitor was disconnected).