### PR TITLE
feat: update node IP and delay info on connect

### DIFF
--- a/v2rayN/ServiceLib/Handler/ConnectionHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConnectionHandler.cs
@@ -12,7 +12,7 @@ public static class ConnectionHandler
         var time = await GetRealPingTimeInfo();
         var ip = time > 0 ? await GetIPInfo() : Global.None;
 
-        return new AvailabilityCheckResult(time, ip ?? Global.None);
+        return new AvailabilityCheckResult(time, ip);
     }
 
     /// <summary>

--- a/v2rayN/ServiceLib/Handler/ConnectionHandler.cs
+++ b/v2rayN/ServiceLib/Handler/ConnectionHandler.cs
@@ -5,14 +5,14 @@ public static class ConnectionHandler
     private static readonly string _tag = "ConnectionHandler";
 
     /// <summary>
-    /// Runs ping and IP checks and returns a formatted result string.
+    /// Runs ping and IP checks.
     /// </summary>
-    public static async Task<string> RunAvailabilityCheck()
+    public static async Task<AvailabilityCheckResult> RunAvailabilityCheck()
     {
         var time = await GetRealPingTimeInfo();
         var ip = time > 0 ? await GetIPInfo() : Global.None;
 
-        return string.Format(ResUI.TestMeOutput, time, ip);
+        return new AvailabilityCheckResult(time, ip ?? Global.None);
     }
 
     /// <summary>

--- a/v2rayN/ServiceLib/Models/Dto/AvailabilityCheckResult.cs
+++ b/v2rayN/ServiceLib/Models/Dto/AvailabilityCheckResult.cs
@@ -1,0 +1,6 @@
+namespace ServiceLib.Models.Dto;
+
+public sealed record AvailabilityCheckResult(int Time, string Ip)
+{
+    public string? GetValidIp() => Ip == Global.None ? null : Ip;
+}

--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -695,19 +695,11 @@ public partial class MainWindowViewModel : MyReactiveObject
                 {
                     return;
                 }
-                var ip = result.GetValidIp();
-                if (ip.IsNotEmpty())
-                {
-                    ProfileExManager.Instance.SetTestIpInfo(profileItem.IndexId, ip);
-                }
-                if (result.Time > 0)
-                {
-                    ProfileExManager.Instance.SetTestDelay(profileItem.IndexId, result.Time);
-                }
+               
                 await ProfilesViewModel.SetSpeedTestResult(new()
                 {
                     IndexId = profileItem.IndexId,
-                    IpInfo = ip,
+                    IpInfo = result.Ip,
                     Delay = result.Time > 0 ? result.Time.ToString() : null
                 });
             });

--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -690,7 +690,26 @@ public partial class MainWindowViewModel : MyReactiveObject
             });
             RxSchedulers.MainThreadScheduler.Schedule(async () =>
             {
-                await StatusBarViewModel.TestServerAvailability();
+                var result = await StatusBarViewModel.TestServerAvailability();
+                if (result == null || profileItem.IndexId.IsNullOrEmpty())
+                {
+                    return;
+                }
+                var ip = result.GetValidIp();
+                if (ip.IsNotEmpty())
+                {
+                    ProfileExManager.Instance.SetTestIpInfo(profileItem.IndexId, ip);
+                }
+                if (result.Time > 0)
+                {
+                    ProfileExManager.Instance.SetTestDelay(profileItem.IndexId, result.Time);
+                }
+                await ProfilesViewModel.SetSpeedTestResult(new()
+                {
+                    IndexId = profileItem.IndexId,
+                    IpInfo = ip,
+                    Delay = result.Time > 0 ? result.Time.ToString() : null
+                });
             });
 
             var showClashUI = AppManager.Instance.IsRunningCore(ECoreType.sing_box);

--- a/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
@@ -324,20 +324,22 @@ public partial class StatusBarViewModel : MyReactiveObject
         SetDefaultServerRequested.Publish(SelectedServer.ID);
     }
 
-    public async Task TestServerAvailability()
+    public async Task<AvailabilityCheckResult?> TestServerAvailability()
     {
         var item = await ConfigHandler.GetDefaultServer(_config);
         if (item == null)
         {
-            return;
+            return null;
         }
 
         await TestServerAvailabilitySub(ResUI.Speedtesting);
 
-        var msg = await Task.Run(ConnectionHandler.RunAvailabilityCheck);
+        var result = await Task.Run(ConnectionHandler.RunAvailabilityCheck);
+        var msg = string.Format(ResUI.TestMeOutput, result.Time, result.Ip);
 
         NoticeManager.Instance.SendMessageEx(msg);
         await TestServerAvailabilitySub(msg);
+        return result;
     }
 
     private async Task TestServerAvailabilitySub(string msg)

--- a/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/StatusBarViewModel.cs
@@ -337,6 +337,16 @@ public partial class StatusBarViewModel : MyReactiveObject
         var result = await Task.Run(ConnectionHandler.RunAvailabilityCheck);
         var msg = string.Format(ResUI.TestMeOutput, result.Time, result.Ip);
 
+        var ip = result.GetValidIp();
+        if (ip.IsNotEmpty())
+        {
+            ProfileExManager.Instance.SetTestIpInfo(item.IndexId, ip);
+        }
+        if (result.Time > 0)
+        {
+            ProfileExManager.Instance.SetTestDelay(item.IndexId, result.Time);
+        }
+
         NoticeManager.Instance.SendMessageEx(msg);
         await TestServerAvailabilitySub(msg);
         return result;


### PR DESCRIPTION
连接节点的时候同时更新节点信息里面延迟和IP地址。
虽然是一个参考值，但是既然有这两个选项，我觉得还是尽量准确一点的好。
如果只有测速的时候才更新，而在连接的时候反而不更新，不就失去参考的意义了。
代码没有修改基本上都是复用，只是简单的修改了几行就行了。
希望能合并进去。