### PR TITLE
refactor(fmt): fold GetQueryDecoded into GetQueryValue

### DIFF
--- a/v2rayN/ServiceLib/Handler/Fmt/BaseFmt.cs
+++ b/v2rayN/ServiceLib/Handler/Fmt/BaseFmt.cs
@@ -200,17 +200,17 @@ public class BaseFmt
 
         item.StreamSecurity = GetQueryValue(query, "security");
         item.Sni = GetQueryValue(query, "sni");
-        item.Alpn = GetQueryDecoded(query, "alpn");
-        item.Fingerprint = GetQueryDecoded(query, "fp");
-        item.PublicKey = GetQueryDecoded(query, "pbk");
-        item.ShortId = GetQueryDecoded(query, "sid");
-        item.SpiderX = GetQueryDecoded(query, "spx");
-        item.Mldsa65Verify = GetQueryDecoded(query, "pqv");
-        item.EchConfigList = GetQueryDecoded(query, "ech");
-        item.VerifyPeerCertByName = GetQueryDecoded(query, "vcn");
-        item.CertSha = GetQueryDecoded(query, "pcs");
+        item.Alpn = GetQueryValue(query, "alpn");
+        item.Fingerprint = GetQueryValue(query, "fp");
+        item.PublicKey = GetQueryValue(query, "pbk");
+        item.ShortId = GetQueryValue(query, "sid");
+        item.SpiderX = GetQueryValue(query, "spx");
+        item.Mldsa65Verify = GetQueryValue(query, "pqv");
+        item.EchConfigList = GetQueryValue(query, "ech");
+        item.VerifyPeerCertByName = GetQueryValue(query, "vcn");
+        item.CertSha = GetQueryValue(query, "pcs");
 
-        var finalmaskDecoded = GetQueryDecoded(query, "fm");
+        var finalmaskDecoded = GetQueryValue(query, "fm");
         if (finalmaskDecoded.IsNotEmpty())
         {
             var node = JsonUtils.ParseJson(finalmaskDecoded);
@@ -245,13 +245,13 @@ public class BaseFmt
                 transport = transport with
                 {
                     RawHeaderType = GetQueryValue(query, "headerType", Global.None),
-                    Host = GetQueryDecoded(query, "host"),
-                    Path = GetQueryDecoded(query, "path"),
+                    Host = GetQueryValue(query, "host"),
+                    Path = GetQueryValue(query, "path"),
                 };
                 break;
 
             case nameof(ETransport.kcp):
-                var kcpSeed = GetQueryDecoded(query, "seed");
+                var kcpSeed = GetQueryValue(query, "seed");
                 var kcpMtuStr = GetQueryValue(query, "mtu");
                 var kcpMtu = int.TryParse(kcpMtuStr, out var mtu) ? mtu : 0;
                 transport = transport with
@@ -266,13 +266,13 @@ public class BaseFmt
             case nameof(ETransport.httpupgrade):
                 transport = transport with
                 {
-                    Host = GetQueryDecoded(query, "host"),
-                    Path = GetQueryDecoded(query, "path", "/"),
+                    Host = GetQueryValue(query, "host"),
+                    Path = GetQueryValue(query, "path", "/"),
                 };
                 break;
 
             case nameof(ETransport.xhttp):
-                var xhttpExtra = GetQueryDecoded(query, "extra");
+                var xhttpExtra = GetQueryValue(query, "extra");
                 if (xhttpExtra.IsNotEmpty())
                 {
                     var node = JsonUtils.ParseJson(xhttpExtra);
@@ -289,9 +289,9 @@ public class BaseFmt
 
                 transport = transport with
                 {
-                    Host = GetQueryDecoded(query, "host"),
-                    Path = GetQueryDecoded(query, "path", "/"),
-                    XhttpMode = GetQueryDecoded(query, "mode"),
+                    Host = GetQueryValue(query, "host"),
+                    Path = GetQueryValue(query, "path", "/"),
+                    XhttpMode = GetQueryValue(query, "mode"),
                     XhttpExtra = xhttpExtra,
                 };
                 break;
@@ -299,9 +299,9 @@ public class BaseFmt
             case nameof(ETransport.grpc):
                 transport = transport with
                 {
-                    GrpcAuthority = GetQueryDecoded(query, "authority"),
-                    GrpcServiceName = GetQueryDecoded(query, "serviceName"),
-                    GrpcMode = GetQueryDecoded(query, "mode", Global.GrpcGunMode),
+                    GrpcAuthority = GetQueryValue(query, "authority"),
+                    GrpcServiceName = GetQueryValue(query, "serviceName"),
+                    GrpcMode = GetQueryValue(query, "mode", Global.GrpcGunMode),
                 };
                 break;
 
@@ -337,18 +337,13 @@ public class BaseFmt
         return $"{Global.ProtocolShares[eConfigType]}{url}{query}{remark}";
     }
 
-    protected static string GetQueryValue(NameValueCollection query, string key, string defaultValue = "")
-    {
-        return query[key] ?? defaultValue;
-    }
-
     /// <summary>
     /// Values are already unescaped by <see cref="Utils.ParseQueryString" />, so this must not
     /// unescape them a second time: a value that still holds a valid percent sequence after the
     /// first pass - an obfuscation password of "ob%41fs", say - would decay into "obAfs".
     /// </summary>
-    protected static string GetQueryDecoded(NameValueCollection query, string key, string defaultValue = "")
+    protected static string GetQueryValue(NameValueCollection query, string key, string defaultValue = "")
     {
-        return GetQueryValue(query, key, defaultValue);
+        return query[key] ?? defaultValue;
     }
 }

--- a/v2rayN/ServiceLib/Handler/Fmt/Hysteria2Fmt.cs
+++ b/v2rayN/ServiceLib/Handler/Fmt/Hysteria2Fmt.cs
@@ -100,7 +100,7 @@ public class Hysteria2Fmt : BaseFmt
 
         var query = Utils.ParseQueryString(url.Query);
         ResolveUriQuery(query, ref item);
-        var authPassword = GetQueryDecoded(query, "auth");
+        var authPassword = GetQueryValue(query, "auth");
         if (authPassword.IsNullOrEmpty())
         {
             return null;
@@ -170,7 +170,7 @@ public class Hysteria2Fmt : BaseFmt
         }
         if (item.CertSha.IsNullOrEmpty())
         {
-            var pinSHA256 = GetQueryDecoded(query, "pinSHA256");
+            var pinSHA256 = GetQueryValue(query, "pinSHA256");
             item.CertSha = pinSHA256;
             if (!pinSHA256.IsNullOrEmpty())
             {
@@ -184,16 +184,16 @@ public class Hysteria2Fmt : BaseFmt
                 item.AllowInsecure = Global.StringTrue;
             }
         }
-        item.EchConfigList = GetQueryDecoded(query, "ech");
+        item.EchConfigList = GetQueryValue(query, "ech");
         item.SetProtocolExtra(item.GetProtocolExtra() with
         {
-            Ports = GetQueryDecoded(query, "mport"),
-            SalamanderPass = GetQueryDecoded(query, "obfs-password"),
+            Ports = GetQueryValue(query, "mport"),
+            SalamanderPass = GetQueryValue(query, "obfs-password"),
             // NOTE: The "PacketSize" parameter is not defined by the official URI Scheme, may remove or rename it in the future.
-            GeckoMinPacketSize = GetQueryDecoded(query, "minPacketSize"),
-            GeckoMaxPacketSize = GetQueryDecoded(query, "maxPacketSize"),
+            GeckoMinPacketSize = GetQueryValue(query, "minPacketSize"),
+            GeckoMaxPacketSize = GetQueryValue(query, "maxPacketSize"),
         });
-        if (GetQueryDecoded(query, "obfs") == "gecko")
+        if (GetQueryValue(query, "obfs") == "gecko")
         {
             // Ensure the "PacketSize" parameters are present for gecko obfs.
             var protocolExtraItem = item.GetProtocolExtra();

--- a/v2rayN/ServiceLib/Handler/Fmt/WireguardFmt.cs
+++ b/v2rayN/ServiceLib/Handler/Fmt/WireguardFmt.cs
@@ -26,12 +26,12 @@ public class WireguardFmt : BaseFmt
 
         item.SetProtocolExtra(item.GetProtocolExtra() with
         {
-            WgPublicKey = GetQueryDecoded(query, "publickey"),
-            WgPresharedKey = GetQueryDecoded(query, "presharedkey"),
-            WgReserved = GetQueryDecoded(query, "reserved"),
-            WgInterfaceAddress = GetQueryDecoded(query, "address"),
-            WgMtu = int.TryParse(GetQueryDecoded(query, "mtu"), out var mtuVal) ? mtuVal : null,
-            WgDns = GetQueryDecoded(query, "dns"),
+            WgPublicKey = GetQueryValue(query, "publickey"),
+            WgPresharedKey = GetQueryValue(query, "presharedkey"),
+            WgReserved = GetQueryValue(query, "reserved"),
+            WgInterfaceAddress = GetQueryValue(query, "address"),
+            WgMtu = int.TryParse(GetQueryValue(query, "mtu"), out var mtuVal) ? mtuVal : null,
+            WgDns = GetQueryValue(query, "dns"),
         });
 
         return item;


### PR DESCRIPTION
Follow-up to #10027, which made `GetQueryDecoded` a verbatim alias of `GetQueryValue`: values arrive from `Utils.ParseQueryString` already unescaped, so the method must not decode anything - its name now promises the opposite of what it is required to do.

This folds the alias away: all 36 call sites use `GetQueryValue`, and the double-unescaping warning comment moves onto the surviving method, so the constraint stays documented at the one place it applies. No behavior change - the alias already delegated verbatim.

Verified locally: `dotnet test ./v2rayN/ServiceLib.Tests -c Release` - 93/93 passed.
