### PR TITLE
ci: run the test job on pushes to master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,17 @@
 name: Code Test
 
 on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'v2rayN/ServiceLib/**'
+      - 'v2rayN/ServiceLib.UdpTest/**'
+      - 'v2rayN/ServiceLib.Tests/**'
+      - 'v2rayN/Directory.Build.*'
+      - 'v2rayN/Directory.Packages.props'
+      - 'global.json'
+      - '.github/workflows/test.yml'
   pull_request:
     branches:
       - master


### PR DESCRIPTION
`Code Test` currently has only a `pull_request` trigger, so the suite never runs against master itself. Two gaps follow:

- a direct push to master is never tested;
- a merge can break the suite even when the pull request's own check was green: checks run on the PR head, not on the merged result, so two individually green changes that conflict semantically fail only after the merge - and nothing runs there today.

This adds a `push` trigger for master with the same paths filter, keeping `pull_request` as is. The paths list is duplicated because workflow YAML does not support anchors.

On push events `publish-unit-test-result-action` publishes its result as a check run on the commit (with failure annotations); the PR comment mode simply has no pull request to post to.
