### PR TITLE
Set initial keyboard focus to the profiles list and tray menu

### DIFF
--- a/v2rayN/v2rayN/Views/MainWindow.xaml.cs
+++ b/v2rayN/v2rayN/Views/MainWindow.xaml.cs
@@ -306,13 +306,31 @@ public partial class MainWindow
                 WindowState = WindowState.Normal;
             }
             this?.Activate();
-            this?.Focus();
+            if (GetProfilesView() is { } profilesView)
+            {
+                profilesView.FocusProfilesList();
+            }
+            else
+            {
+                this?.Focus();
+            }
         }
         else
         {
             this?.Hide();
         }
         AppManager.Instance.ShowInTaskbar = bl;
+    }
+
+    private ProfilesView? GetProfilesView()
+    {
+        return _config.UiItem.MainGirdOrientation switch
+        {
+            EGirdOrientation.Horizontal => tabProfiles.Content as ProfilesView,
+            EGirdOrientation.Vertical => tabProfiles1.Content as ProfilesView,
+            EGirdOrientation.Tab when tabMain2.SelectedItem == tabProfiles2 => tabProfiles2.Content as ProfilesView,
+            _ => null,
+        };
     }
 
     protected override void OnLoaded(object? sender, RoutedEventArgs e)

--- a/v2rayN/v2rayN/Views/ProfilesView.xaml.cs
+++ b/v2rayN/v2rayN/Views/ProfilesView.xaml.cs
@@ -1,3 +1,4 @@
+using System.Collections.Specialized;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
@@ -11,10 +12,12 @@ public partial class ProfilesView
 {
     private static Config _config;
     private static readonly string _tag = "ProfilesView";
+    private bool _initialFocusSet;
 
     public ProfilesView()
     {
         InitializeComponent();
+        IsVisibleChanged += ProfilesView_IsVisibleChanged;
         lstGroup.MaxHeight = Math.Floor(SystemParameters.WorkArea.Height * 0.20 / 40) * 40;
 
         _config = AppManager.Instance.Config;
@@ -155,6 +158,97 @@ public partial class ProfilesView
     }
 
     #region Event
+
+    private void ProfilesView_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        // Wait until the view is actually visible; a collapsed control cannot take keyboard focus.
+        if (_initialFocusSet || e.NewValue is not true)
+        {
+            return;
+        }
+        _initialFocusSet = true;
+
+        // Keyboard focus can only be established once the window is active; on the very
+        // first activation WPF has no previously focused element to restore, so set it then.
+        if (Window.GetWindow(this) is { IsActive: false } window)
+        {
+            EventHandler? activatedHandler = null;
+            activatedHandler = (_, _) =>
+            {
+                window.Activated -= activatedHandler;
+                FocusProfilesList();
+            };
+            window.Activated += activatedHandler;
+        }
+        else
+        {
+            FocusProfilesList();
+        }
+
+        if (lstProfiles.Items.Count > 0)
+        {
+            return;
+        }
+
+        // The profile items arrive asynchronously; move focus from the empty grid to the
+        // first row once items land, unless the user has already moved focus elsewhere.
+        NotifyCollectionChangedEventHandler? handler = null;
+        handler = (_, _) =>
+        {
+            if (lstProfiles.Items.Count == 0)
+            {
+                return;
+            }
+            ((INotifyCollectionChanged)lstProfiles.Items).CollectionChanged -= handler;
+            Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
+            {
+                if (Keyboard.FocusedElement is null or Window || ReferenceEquals(Keyboard.FocusedElement, lstProfiles))
+                {
+                    FocusProfilesList();
+                }
+            }));
+        };
+        ((INotifyCollectionChanged)lstProfiles.Items).CollectionChanged += handler;
+    }
+
+    public void FocusProfilesList()
+    {
+        if (!TryFocusProfilesList())
+        {
+            Dispatcher.BeginInvoke(DispatcherPriority.Loaded, new Action(() => TryFocusProfilesList()));
+        }
+    }
+
+    private bool TryFocusProfilesList()
+    {
+        if (lstProfiles.Items.Count == 0)
+        {
+            return lstProfiles.Focus();
+        }
+
+        if (lstProfiles.SelectedIndex < 0)
+        {
+            lstProfiles.SelectedIndex = 0;
+        }
+        lstProfiles.ScrollIntoView(lstProfiles.SelectedItem, null);
+        lstProfiles.UpdateLayout();
+
+        // DataGrid keyboard navigation is cell-based; focus the current cell so the
+        // arrow keys work immediately, instead of the grid or row container.
+        var column = lstProfiles.Columns
+            .Where(c => c.Visibility == Visibility.Visible)
+            .OrderBy(c => c.DisplayIndex)
+            .FirstOrDefault();
+        if (column != null)
+        {
+            lstProfiles.CurrentCell = new DataGridCellInfo(lstProfiles.SelectedItem, column);
+            if (column.GetCellContent(lstProfiles.SelectedItem) is { Parent: DataGridCell cell })
+            {
+                return cell.Focus();
+            }
+        }
+        return lstProfiles.Focus();
+    }
 
     public async Task ShareServer(string url)
     {

--- a/v2rayN/v2rayN/Views/StatusBarView.xaml.cs
+++ b/v2rayN/v2rayN/Views/StatusBarView.xaml.cs
@@ -1,3 +1,4 @@
+using System.Windows.Controls;
 using v2rayN.Manager;
 
 namespace v2rayN.Views;
@@ -14,6 +15,11 @@ public partial class StatusBarView
         menuExit.Click += menuExit_Click;
         txtRunningServerDisplay.PreviewMouseDown += txtRunningInfoDisplay_MouseDoubleClick;
         txtRunningInfoDisplay.PreviewMouseDown += txtRunningInfoDisplay_MouseDoubleClick;
+
+        if (tbNotify.ContextMenu is { } trayMenu)
+        {
+            trayMenu.Opened += TrayMenu_Opened;
+        }
 
         this.WhenActivated(disposables =>
         {
@@ -77,6 +83,29 @@ public partial class StatusBarView
         });
 
         _ = RefreshIcon();
+    }
+
+    // Give the tray menu's first item keyboard focus on open, like native tray menus do;
+    // the popup otherwise opens with focus left on the window.
+    private void TrayMenu_Opened(object sender, RoutedEventArgs e)
+    {
+        if (sender is not ContextMenu menu)
+        {
+            return;
+        }
+        var timer = new DispatcherTimer(DispatcherPriority.Input) { Interval = TimeSpan.FromMilliseconds(150) };
+        timer.Tick += (_, _) =>
+        {
+            timer.Stop();
+            if (!menu.IsOpen)
+            {
+                return;
+            }
+            menu.Items.OfType<MenuItem>()
+                .FirstOrDefault(mi => mi.IsEnabled && mi.Visibility == Visibility.Visible)?
+                .Focus();
+        };
+        timer.Start();
     }
 
     private async Task RefreshIcon()


### PR DESCRIPTION
## What

Three small keyboard-focus fixes, with no visual or behavioral change for mouse users:

1. **Main window startup**: keyboard focus now lands on the profiles list (the selected server's cell) when the window opens, instead of the bare window. Arrow keys and Enter work immediately. Works in all three layout orientations, and handles the profile items arriving asynchronously (focus is not stolen if the user has already moved it).
2. **Restore from tray/hotkey**: `ShowHideWindow` used to park focus on the window element itself (`this.Focus()`); it now focuses the profiles list of the active layout, falling back to the old behavior when the list isn't visible (e.g. Tab layout on another tab).
3. **Tray context menu**: the first enabled item receives focus when the menu opens, like native tray menus, so keyboard navigation works right away instead of requiring an initial Tab press.

## Why

Standard Windows behavior is to focus the primary content when a window opens — the app's own dialogs already do this (e.g. `txtRemarks.Focus()` in AddServerWindow), but the main window never did. Users who open v2rayN with a hotkey to switch servers can now do it entirely from the keyboard: hotkey → arrows → Enter.

## Testing

Verified manually on Windows 10 in all three `MainGirdOrientation` layouts (Horizontal, Vertical, Tab), with an empty profile list and with servers present, on cold start, restore from tray, and Alt+Tab switches.