### PR TITLE
Fix UI

### DIFF
--- a/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
+++ b/v2rayN/v2rayN.Desktop/Views/MainWindow.axaml.cs
@@ -445,6 +445,19 @@ public partial class MainWindow : WindowBase<MainWindowViewModel>
                 break;
         }
 
+        // workaround
+        Task.Run(async () =>
+        {
+            await Task.Delay(5000);
+            Dispatcher.UIThread.Post(() =>
+            {
+                ViewModel?.TabMainSelectedIndex = 0;
+                tabMain.SelectedIndex = 0;
+                tabMain1.SelectedIndex = 0;
+                tabMain2.SelectedIndex = 0;
+            });
+        });
+
         RestoreUI();
     }
 


### PR DESCRIPTION
fix #10058

view 完全未显示

所以为 View 绑定慢于 ViewModel 赋值导致 View 绑定时将 TabMainSelectedIndex 设置为 -1