### PR TITLE
fix(update): 升级完成后删除安装包，并将主程序排除出 UpgradeCore

### DIFF
--- a/v2rayN/AmazTool/UpgradeApp.cs
+++ b/v2rayN/AmazTool/UpgradeApp.cs
@@ -40,6 +40,7 @@ internal class UpgradeApp
 
         Console.WriteLine(Resx.Resource.StartUnzipping);
         StringBuilder sb = new();
+        var extracted = false;
         try
         {
             var thisAppOldFile = $"{Utils.GetExePath()}.tmp";
@@ -88,6 +89,7 @@ internal class UpgradeApp
                     sb.Append(ex.StackTrace);
                 }
             }
+            extracted = true;
         }
         catch (Exception ex)
         {
@@ -98,6 +100,18 @@ internal class UpgradeApp
         {
             Console.WriteLine(Resx.Resource.FailedUpgrade + sb.ToString());
             //return;
+        }
+        else if (extracted)
+        {
+            // Extraction succeeded and no other step in the flow removes the package
+            try
+            {
+                File.Delete(fileName);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
         }
 
         Console.WriteLine(Resx.Resource.Restartv2rayN);

--- a/v2rayN/ServiceLib/ViewModels/CheckUpdateViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/CheckUpdateViewModel.cs
@@ -340,7 +340,7 @@ public partial class CheckUpdateViewModel : MyReactiveObject
     {
         foreach (var item in _lstUpdated)
         {
-            if (item.FileName.IsNullOrEmpty() || item.IsGeoFile)
+            if (item.FileName.IsNullOrEmpty() || item.IsGeoFile || item.CoreType == _v2rayN)
             {
                 continue;
             }


### PR DESCRIPTION
每次 v2rayN 自升级，`guiTemps` 里都会留下一个约 130 MB 的安装包，没有任何环节删除它。

### 为什么没被删

升级结束后，`UpgradeCore` 会遍历本轮更新的每一项，把下载包解压到位再删除（`CheckUpdateViewModel.cs:390`，这是流程中唯一移除下载包的地方）。主程序也在这个列表里，但它在 `:349` 的 `File.Exists` 处被跳过了。

原因是主程序那一项存的不是真实路径，而是百分号编码后的字符串：

```
D:\...\guiTemps\7674d985-...  →  D%3A%5C...%5CguiTemps%5C7674d985-...
```

编码本身是必要的 —— 这个字符串要作为命令行参数传给 AmazTool，由 `AmazTool/Program.cs:42` 解码（`UpdateService.cs:21` 编码）。内核包不经过 AmazTool，存的是原始路径（`UpdateService.cs:65`），所以能被正常删除。

于是主程序的安装包两头落空：`UpgradeCore` 找不到它，AmazTool 解压完也不删。

`guiTemps` 有兜底清理（`TaskManager.cs:61`，每小时删除超过一个月的文件），所以占用有界，稳态约 260 MB。但那是给中断、崩溃留下的孤儿文件准备的；正常走完流程的都是用完即删 —— 内核包在 `CheckUpdateViewModel.cs:390`，备份临时目录在 `BackupAndRestoreViewModel.cs:171`。安装包是唯一漏网的。

### 顺带：主程序本就不该进 UpgradeCore

那个循环是内核包逻辑，解压到 `Utils.GetBinPath("", coreTypeStr)`，对主程序会解到 `bin/v2rayn/`。`:343` 的过滤只排除空文件名和 geo 文件，没有排除主程序；它现在被挡住，靠的是上面那个路径编码，而不是一个明确的条件。

### 改动

1. `UpgradeCore` 显式排除主程序 —— 行为不变，只是不再依赖路径编码这个无关细节。
2. AmazTool 解压成功后删除安装包。

删除不能放在 `UpgradeCore`：它执行在 `UpgradeN` 之前（`:277` / `:282`），会删掉 AmazTool 的输入。

删除条件要求解压未抛异常**且**无条目级失败 —— `ZipFile.OpenRead` 抛出时 `sb` 不会被写入，仅判断 `sb.Length` 不足以代表成功，故用单独的完成标志，避免误删可重试的下载。

### 验证

AmazTool 用三种包各跑一次：

| 场景 | 包内容 | 结果 |
|---|---|---|
| 正常 | 两个可解条目 | 产物齐全，安装包已删除 |
| 单条目失败 | 含非法路径 `bad<dir/file.txt` | 合法条目解出，安装包保留 |
| 整包损坏 | `PK\x03\x04` + 4096 随机字节 | 安装包保留 |

第三种是必须区分的一种：异常自 `ZipFile.OpenRead` → `ReadEndOfCentralDirectory` 抛出，落在进入条目循环之前，`sb` 为空；若把删除挂在 `if (sb.Length > 0)` 的 `else` 上，这一路会删掉一个仍可重试的下载。

`File.Delete` 未报文件占用：`using var archive` 在 try 作用域结束时已释放句柄，删除发生在其后。

`dotnet build v2rayN.sln -c Release` 成功，0 错误；`dotnet test ./v2rayN/ServiceLib.Tests -c Release` 93/93 通过。环境 .NET SDK 10.0.400 / Windows 11 x64。
