### PR TITLE
Skip the TUN IPv6 route when the host has no global IPv6 address

### DIFF
--- a/v2rayN/ServiceLib.Tests/CoreConfig/CoreConfigTestFactory.cs
+++ b/v2rayN/ServiceLib.Tests/CoreConfig/CoreConfigTestFactory.cs
@@ -205,7 +205,8 @@ internal static class CoreConfigTestFactory
         return node;
     }
 
-    public static CoreConfigContext CreateContext(Config config, ProfileItem node, ECoreType runCoreType)
+    public static CoreConfigContext CreateContext(Config config, ProfileItem node, ECoreType runCoreType,
+        bool hasGlobalIPv6Address = true)
     {
         return new CoreConfigContext
         {
@@ -226,6 +227,7 @@ internal static class CoreConfigTestFactory
             FullConfigTemplate = null,
             IsTunEnabled = config.TunModeItem.EnableTun,
             ProtectDomainList = [],
+            HasGlobalIPv6Address = hasGlobalIPv6Address,
         };
     }
 

--- a/v2rayN/ServiceLib.Tests/CoreConfig/V2ray/CoreConfigV2rayServiceTests.cs
+++ b/v2rayN/ServiceLib.Tests/CoreConfig/V2ray/CoreConfigV2rayServiceTests.cs
@@ -589,6 +589,53 @@ public class CoreConfigV2rayServiceTests
     }
 
     [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task GenerateClientConfigContent_Tun_ShouldSkipIPv6RouteWithoutGlobalIPv6(bool enableIPv6Address)
+    {
+        // A host without a global IPv6 address has no IPv6 traffic that could bypass the tunnel,
+        // while ::/0 would pull IPv6 attempts into a tunnel they cannot leave.
+        var config = CoreConfigTestFactory.CreateConfigWithTun(ECoreType.Xray, enableIPv6Address);
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+
+        var node = CoreConfigTestFactory.CreateVmessNode(ECoreType.Xray, "n-main", "main");
+        var context = CoreConfigTestFactory.CreateContext(config, node, ECoreType.Xray, hasGlobalIPv6Address: false);
+
+        var result = new CoreConfigV2rayService(context).GenerateClientConfigContent();
+
+        await result.Success.Should().BeTrue();
+        var cfg = JsonUtils.Deserialize<V2rayConfig>(result.Data!.ToString())!;
+        var tunInbound = cfg.inbounds.FirstOrDefault(i => i.protocol == "tun");
+
+        await tunInbound.Should().NotBeNull();
+        await tunInbound!.settings.autoSystemRoutingTable.Should().Contain("0.0.0.0/0");
+        var ipv6Routes = tunInbound.settings.autoSystemRoutingTable!.Where(x => x.Contains(':')).ToList();
+        await ipv6Routes.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task GenerateClientConfigContent_TunRouteExcludeAddress_ShouldSkipIPv6RangesWithoutGlobalIPv6()
+    {
+        var config = CoreConfigTestFactory.CreateConfigWithTunRouteExcludeAddress(ECoreType.Xray);
+        config.TunModeItem.EnableIPv6Address = false;
+        CoreConfigTestFactory.BindAppManagerConfig(config);
+
+        var node = CoreConfigTestFactory.CreateVmessNode(ECoreType.Xray, "n-main", "main");
+        var context = CoreConfigTestFactory.CreateContext(config, node, ECoreType.Xray, hasGlobalIPv6Address: false);
+
+        var result = new CoreConfigV2rayService(context).GenerateClientConfigContent();
+
+        await result.Success.Should().BeTrue();
+        var cfg = JsonUtils.Deserialize<V2rayConfig>(result.Data!.ToString())!;
+        var tunInbound = cfg.inbounds.FirstOrDefault(i => i.protocol == "tun");
+
+        await tunInbound.Should().NotBeNull();
+        await tunInbound!.settings.autoSystemRoutingTable.Should().NotBeEmpty();
+        var ipv6Routes = tunInbound.settings.autoSystemRoutingTable!.Where(x => x.Contains(':')).ToList();
+        await ipv6Routes.Should().BeEmpty();
+    }
+
+    [Test]
     public async Task GenerateClientConfigContent_TunRouteExcludeAddress_ShouldIncludeIPv6Ranges()
     {
         var config = CoreConfigTestFactory.CreateConfigWithTunRouteExcludeAddress(ECoreType.Xray);

--- a/v2rayN/ServiceLib/Common/Utils.cs
+++ b/v2rayN/ServiceLib/Common/Utils.cs
@@ -815,6 +815,40 @@ public class Utils
             .Any(ni => ni.Name.Equals(inInterfaceName, StringComparison.OrdinalIgnoreCase));
     }
 
+    /// <summary>
+    /// Whether the host holds a globally routable IPv6 address, that is one inside 2000::/3.
+    /// Link-local and unique local addresses are excluded: they never reach the IPv6 internet,
+    /// so a host holding only those has no IPv6 traffic that could bypass the tunnel, and no
+    /// IPv6 path that traffic sent into the tunnel could come back out of.
+    /// </summary>
+    public static bool HasGlobalIPv6Address()
+    {
+        try
+        {
+            return NetworkInterface.GetAllNetworkInterfaces()
+                .Where(ni => ni.OperationalStatus == OperationalStatus.Up
+                             && ni.NetworkInterfaceType != NetworkInterfaceType.Loopback)
+                .SelectMany(ni => ni.GetIPProperties().UnicastAddresses)
+                .Any(ua => IsGlobalUnicastIPv6(ua.Address));
+        }
+        catch
+        {
+            return true;
+        }
+    }
+
+    private static bool IsGlobalUnicastIPv6(IPAddress address)
+    {
+        if (address.AddressFamily != AddressFamily.InterNetworkV6)
+        {
+            return false;
+        }
+
+        // 2000::/3 is the only range currently assigned for global unicast, which leaves out
+        // ::1, fe80::/10, fc00::/7 and ff00::/8 in a single test.
+        return (address.GetAddressBytes()[0] & 0xE0) == 0x20;
+    }
+
     #endregion Speed Test
 
     #region Miscellaneous

--- a/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
+++ b/v2rayN/ServiceLib/Handler/Builder/CoreConfigContextBuilder.cs
@@ -49,6 +49,7 @@ public class CoreConfigContextBuilder
             RoutingItem = await ConfigHandler.GetDefaultRouting(config),
             IsWindows = Utils.IsWindows(),
             IsMacOS = Utils.IsMacOS(),
+            HasGlobalIPv6Address = Utils.HasGlobalIPv6Address(),
             ProtectCoreTypeList = config.TunModeItem.EnableTun ? [ECoreType.Xray, ECoreType.sing_box] : []
         };
         var validatorResult = NodeValidatorResult.Empty();

--- a/v2rayN/ServiceLib/Models/CoreConfigs/CoreConfigContext.cs
+++ b/v2rayN/ServiceLib/Models/CoreConfigs/CoreConfigContext.cs
@@ -25,6 +25,10 @@ public record CoreConfigContext
     public bool IsWindows { get; init; }
     public bool IsMacOS { get; init; }
 
+    // Defaults to true so that a context built without this flag keeps routing IPv6 into the
+    // tunnel; only a positive detection of the host having no global IPv6 address turns it off.
+    public bool HasGlobalIPv6Address { get; init; } = true;
+
     // Generation Context
     public Dictionary<object, string> CustomOutboundMap { get; init; } = new();
 }

--- a/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayInboundService.cs
+++ b/v2rayN/ServiceLib/Services/CoreConfig/V2ray/V2rayInboundService.cs
@@ -70,7 +70,11 @@ public partial class CoreConfigV2rayService
                 // Route both families into the tunnel regardless of EnableIPv6Address. That option only
                 // controls whether the interface gets an IPv6 address; leaving ::/0 out of the routing
                 // table makes IPv6 follow the system default route and bypass the tunnel entirely.
-                tunInbound.settings.autoSystemRoutingTable = ["0.0.0.0/0", "::/0"];
+                // A host without a global IPv6 address is the exception: it has nothing to leak,
+                // and IPv6 sent into the tunnel would have no way back out.
+                tunInbound.settings.autoSystemRoutingTable = context.HasGlobalIPv6Address
+                    ? ["0.0.0.0/0", "::/0"]
+                    : ["0.0.0.0/0"];
                 if (_config.TunModeItem.EnableIPv6Address == true)
                 {
                     var address6 = _config.TunModeItem.IPv6Address.NullIfEmpty() ?? Global.TunIPv6Address.First();
@@ -95,7 +99,9 @@ public partial class CoreConfigV2rayService
                         .Where(x => x != null).ToList();
 
                     var includeList = new List<IPNetwork2> { wholeInternet };
-                    var includeListV6 = new List<IPNetwork2> { wholeInternetV6 };
+                    var includeListV6 = context.HasGlobalIPv6Address
+                        ? new List<IPNetwork2> { wholeInternetV6 }
+                        : new List<IPNetwork2>();
 
                     foreach (var exclude in excludeList)
                     {


### PR DESCRIPTION
#9930 让 Xray TUN 入站无条件把 `::/0` 写进 `autoSystemRoutingTable`，目的是不让 IPv6 绕过隧道。这个做法只在主机确实持有全局 IPv6 地址时有意义，其余情况下有害。

## IPv6 被禁用时核心起不来

TUN 设备创建时从 `net.ipv6.conf.default.disable_ipv6` 继承该值，为 1 时拿不到任何 IPv6 地址，内核以 EACCES 拒绝指向它的 IPv6 路由。`setSystemRoutes` 一条失败即回滚并返回错误，整个入站起不来：

```
Failed to start: app/proxyman/inbound: failed to start proxy > proxy/tun:
failed to add system route ::/0 > permission denied
```

用 Xray 26.7.28 在 network namespace 内复现：

| disable_ipv6 | autoSystemRoutingTable | 结果 |
|---|---|---|
| 1 | `["0.0.0.0/0", "::/0"]` | 启动失败，错误串同上 |
| 1 | `["0.0.0.0/0"]` | 启动成功，IPv4 默认路由指向 TUN |
| 0 | `["0.0.0.0/0", "::/0"]` | 启动成功，两个地址族的默认路由都指向 TUN |

## IPv6 可用但没有出口时流量断掉

路由加得上，主机因此获得一条 IPv6 默认路由。TUN 会在拨号之前先在本地完成 TCP 握手，这一点记在 `proxy/tun/README.md` 的 LIMITATION 一节。于是 IPv6 目的地看起来可达并被应用选用，失败推迟到出站发生。相关报告见 #10051。

这两类主机都没有会绕过隧道的 IPv6 流量，`::/0` 对它们没有收益。

## 改动

在构建配置上下文时检测一次全局 IPv6 地址，没有就不写 `::/0`。link-local 与 unique local 不计入，它们到不了 IPv6 互联网。判据是地址落在 `2000::/3`，一次位测试同时排除 `::1`、`fe80::/10`、`fc00::/7`、`ff00::/8`。

沿用仓库已有的 `IsWindows` / `IsMacOS` 模式：环境事实由 `CoreConfigContextBuilder` 采集进 `CoreConfigContext`，生成器只读上下文。`autoSystemRoutingTable` 的两处写入点都做了门控。

## 真机对照

同一台机器、同一个 VLESS 节点、同一个 Xray 26.7.28、同一套 DNS 设置，唯一变量是本改动。

| | 7.24.7 | 应用本 PR |
|---|---|---|
| `autoSystemRoutingTable` | `['0.0.0.0/0', '::/0']` | `['0.0.0.0/0']` |
| IPv6 默认路由 | `default dev xray_tun metric 1` | 不出现 |
| IPv6 握手 | 成功 0ms，源为 link-local | ENETUNREACH |
| 已建立 IPv6 连接数 | 9 | 0 |
| curl google / youtube / baidu | 三项均 TLS unexpected eof | 三项均 HTTP 200 |
| 无头 Chrome 加载三站 | 未测 | 三项均成功 |
| 出口 IP | 代理服务器地址 | 同左 |
| IPv4 隧道 | `default dev xray_tun` | 不变 |

测试主机的解析器由校园网提供，对 `www.google.com` 返回 `104.244.42.197`，对 `youtube.com` 返回 `127.0.0.1`。为排除这一干扰，两组测试都手工把 systemd-resolved 的 `~.` 指向了 TUN 设备。Linux 上 Xray 按设计不配置系统 DNS（见 `proxy/tun/README.md`），这一步是测试环境的需要，与本改动无关。

## 测试

新增三个用例，覆盖默认分支与 `RouteExcludeAddress` 分支。在未应用本改动的生成器上三个用例失败，应用后 96/96 通过。

## 未覆盖

主机持有全局 IPv6 而代理出口没有 IPv6 时，`::/0` 仍会写入，走代理的 IPv6 请求会失败。这一类需要客户端知道出口的 IPv6 能力，本改动不处理。

## 未验证

Windows 与 macOS 上 `NetworkInterface` 对解绑 IPv6 的适配器如何报告。判据在生成配置时求值一次，运行中开关 IPv6 需重启核心才生效。

---

*🤖 本 PR 的分析、测试与正文由 [Claude Code](https://claude.com/claude-code) 生成。*
