### PR TITLE
主窗口打开时将键盘焦点设置到服务器列表

### DIFF
--- a/v2rayN/v2rayN/Views/ProfilesView.xaml.cs
+++ b/v2rayN/v2rayN/Views/ProfilesView.xaml.cs
@@ -1,3 +1,4 @@
+using System.Collections.Specialized;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
@@ -11,10 +12,12 @@ public partial class ProfilesView
 {
     private static Config _config;
     private static readonly string _tag = "ProfilesView";
+    private bool _initialFocusSet;
 
     public ProfilesView()
     {
         InitializeComponent();
+        IsVisibleChanged += ProfilesView_IsVisibleChanged;
         lstGroup.MaxHeight = Math.Floor(SystemParameters.WorkArea.Height * 0.20 / 40) * 40;
 
         _config = AppManager.Instance.Config;
@@ -155,6 +158,97 @@ public partial class ProfilesView
     }
 
     #region Event
+
+    private void ProfilesView_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        // Wait until the view is actually visible; a collapsed control cannot take keyboard focus.
+        if (_initialFocusSet || e.NewValue is not true)
+        {
+            return;
+        }
+        _initialFocusSet = true;
+
+        // Keyboard focus can only be established once the window is active; on the very
+        // first activation WPF has no previously focused element to restore, so set it then.
+        if (Window.GetWindow(this) is { IsActive: false } window)
+        {
+            EventHandler? activatedHandler = null;
+            activatedHandler = (_, _) =>
+            {
+                window.Activated -= activatedHandler;
+                FocusProfilesList();
+            };
+            window.Activated += activatedHandler;
+        }
+        else
+        {
+            FocusProfilesList();
+        }
+
+        if (lstProfiles.Items.Count > 0)
+        {
+            return;
+        }
+
+        // The profile items arrive asynchronously; move focus from the empty grid to the
+        // first row once items land, unless the user has already moved focus elsewhere.
+        NotifyCollectionChangedEventHandler? handler = null;
+        handler = (_, _) =>
+        {
+            if (lstProfiles.Items.Count == 0)
+            {
+                return;
+            }
+            ((INotifyCollectionChanged)lstProfiles.Items).CollectionChanged -= handler;
+            Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
+            {
+                if (Keyboard.FocusedElement is null or Window || ReferenceEquals(Keyboard.FocusedElement, lstProfiles))
+                {
+                    FocusProfilesList();
+                }
+            }));
+        };
+        ((INotifyCollectionChanged)lstProfiles.Items).CollectionChanged += handler;
+    }
+
+    public void FocusProfilesList()
+    {
+        if (!TryFocusProfilesList())
+        {
+            Dispatcher.BeginInvoke(DispatcherPriority.Loaded, new Action(() => TryFocusProfilesList()));
+        }
+    }
+
+    private bool TryFocusProfilesList()
+    {
+        if (lstProfiles.Items.Count == 0)
+        {
+            return lstProfiles.Focus();
+        }
+
+        if (lstProfiles.SelectedIndex < 0)
+        {
+            lstProfiles.SelectedIndex = 0;
+        }
+        lstProfiles.ScrollIntoView(lstProfiles.SelectedItem, null);
+        lstProfiles.UpdateLayout();
+
+        // DataGrid keyboard navigation is cell-based; focus the current cell so the
+        // arrow keys work immediately, instead of the grid or row container.
+        var column = lstProfiles.Columns
+            .Where(c => c.Visibility == Visibility.Visible)
+            .OrderBy(c => c.DisplayIndex)
+            .FirstOrDefault();
+        if (column != null)
+        {
+            lstProfiles.CurrentCell = new DataGridCellInfo(lstProfiles.SelectedItem, column);
+            if (column.GetCellContent(lstProfiles.SelectedItem) is { Parent: DataGridCell cell })
+            {
+                return cell.Focus();
+            }
+        }
+        return lstProfiles.Focus();
+    }
 
     public async Task ShareServer(string url)
     {


### PR DESCRIPTION
## 说明

只修改 `ProfilesView.xaml.cs` 一个文件。

主窗口打开时没有任何控件获得键盘焦点，所以用户按下的前几个按键不会有任何反应，必须先按 Tab 才能开始操作。这个 PR 在 ProfilesView 显示出来时把键盘焦点放到服务器列表上（必要时等待窗口激活）：

- 列表有数据时，聚焦到当前选中行的单元格，这样方向键和回车可以直接使用；
- 列表为空时，聚焦到表格本身；
- 如果配置是异步加载的，等数据到达后再把焦点移到第一行，但用户已经把焦点移到别处时不会打断。

## 原因

Windows 上的常见做法是窗口打开时把焦点放在主要内容上，本项目的对话框其实已经是这样做的（例如 AddServerWindow 里的 `txtRemarks.Focus()`），只有主窗口没有。改动之后，用快捷键唤出窗口的用户可以直接用方向键和回车切换服务器，不需要先按 Tab。

对鼠标用户没有任何视觉或行为上的变化。

## 测试

在 Windows 10 上手动测试，三种 `MainGirdOrientation` 布局（Horizontal、Vertical、Tab）都验证过，包括列表为空和有服务器两种情况，以及冷启动和 Alt+Tab 切换。