### PR TITLE
Fix subscription downloads requiring an Accept header

### DIFF
--- a/v2rayN/ServiceLib/Handler/SubscriptionHandler.cs
+++ b/v2rayN/ServiceLib/Handler/SubscriptionHandler.cs
@@ -82,7 +82,7 @@ public static class SubscriptionHandler
 
     private static DownloadService CreateDownloadHandler(string hashCode, Func<bool, string, Task> updateFunc)
     {
-        var downloadHandle = new DownloadService();
+        var downloadHandle = new DownloadService { AcceptHeader = "*/*" };
         downloadHandle.Error += (sender2, args) =>
         {
             updateFunc?.Invoke(false, $"{hashCode}{args.GetException().Message}");

--- a/v2rayN/ServiceLib/Services/DownloadService.cs
+++ b/v2rayN/ServiceLib/Services/DownloadService.cs
@@ -11,6 +11,8 @@ public class DownloadService
 
     public event ErrorEventHandler? Error;
 
+    public string? AcceptHeader { get; init; }
+
     private static readonly string _tag = "DownloadService";
 
     /// <summary>
@@ -253,6 +255,10 @@ public class DownloadService
                 userAgent = Utils.GetVersion(false);
             }
             client.DefaultRequestHeaders.UserAgent.TryParseAdd(userAgent);
+            if (AcceptHeader.IsNotEmpty())
+            {
+                client.DefaultRequestHeaders.Accept.ParseAdd(AcceptHeader);
+            }
 
             Uri uri = new(url);
             //Authorization Header


### PR DESCRIPTION
Some subscription URLs require an `Accept` header and return HTTP 403 when it is omitted.

Set `Accept: */*` on the HttpClient requests made by the subscription download service. The setting is scoped to the subscription instance, covering main, additional and converted subscription URLs as well as the existing direct-connection retry. User-Agent, authentication and network settings are preserved, and other downloads keep their existing behavior.

Validation:

- Windows x64 WPF Release build and publish completed successfully.
- Local HTTP captures confirmed that subscription requests include the header while ordinary downloads remain unchanged, for both direct and explicit proxy paths; User-Agent and Basic authentication were preserved.
- Live subscription comparisons reproduced HTTP 403 without the header and HTTP 200 with valid content after adding it.

Fixes #9993
