### PR TITLE
fix: reduce GUI churn and skip needless core restarts on subscription updates

### DIFF
--- a/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MainWindowViewModel.cs
@@ -364,19 +364,14 @@ public partial class MainWindowViewModel : MyReactiveObject
             var indexIdOld = _config.IndexId;
             await RefreshServersDispatcherAsync();
 
-            // If indexId changed or subIndexId is empty, directly reload.
-            if (indexIdOld != _config.IndexId || _config.SubIndexId.IsNullOrEmpty())
+            // Reload only when the active node actually changed (index switched, node updated
+            // or removed); otherwise every scheduled subscription update needlessly restarts
+            // the core, killing all connections and failing in-flight delay tests.
+            var curNode = await AppManager.Instance.GetProfileItem(_config.IndexId);
+            var curNodeJson = curNode is null ? null : JsonUtils.Serialize(curNode);
+            if (indexIdOld != _config.IndexId || curNodeJson != _lastLoadedNodeJson)
             {
                 await Reload();
-            }
-            else
-            {
-                // The activity config belongs to the current group.
-                var profile = await AppManager.Instance.GetProfileItem(_config.IndexId);
-                if (profile != null && profile.Subid == _config.SubIndexId)
-                {
-                    await Reload();
-                }
             }
 
             if (_config.UiItem.EnableAutoAdjustMainLvColWidth)
@@ -650,6 +645,7 @@ public partial class MainWindowViewModel : MyReactiveObject
 
     private bool _hasNextReloadJob = false;
     private readonly SemaphoreSlim _reloadSemaphore = new(1, 1);
+    private string? _lastLoadedNodeJson;
 
     public async Task Reload()
     {
@@ -688,6 +684,7 @@ public partial class MainWindowViewModel : MyReactiveObject
                 await SysProxyHandler.UpdateSysProxy(_config, false);
                 await Task.Delay(1000);
             });
+            _lastLoadedNodeJson = JsonUtils.Serialize(profileItem);
             RxSchedulers.MainThreadScheduler.Schedule(async () =>
             {
                 var result = await StatusBarViewModel.TestServerAvailability();

--- a/v2rayN/ServiceLib/ViewModels/MsgViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/MsgViewModel.cs
@@ -7,6 +7,7 @@ public partial class MsgViewModel : MyReactiveObject
     private readonly ConcurrentQueue<string> _queueMsg = new();
     private volatile bool _lastMsgFilterNotAvailable;
     private int _showLock = 0; // 0 = unlocked, 1 = locked
+    private long _lastDispatchFailTicks;
     public int NumMaxMsg { get; } = 500;
 
     [Reactive]
@@ -36,6 +37,8 @@ public partial class MsgViewModel : MyReactiveObject
 
     public void FlushQueueMsg()
     {
+        // View activation means the interaction handler is now registered.
+        _lastDispatchFailTicks = 0;
         _ = AppendQueueMsg(string.Empty);
     }
 
@@ -70,12 +73,22 @@ public partial class MsgViewModel : MyReactiveObject
 
             if (sb.Length > 0)
             {
+                // When the UI handler is not yet registered (window closed to tray, view not
+                // activated), back off instead of throwing UnhandledInteractionException in a
+                // tight 500ms loop. Buffered lines are kept and flushed on activation.
+                if (Environment.TickCount64 - _lastDispatchFailTicks < 30_000)
+                {
+                    _queueMsg.Enqueue(sb.ToString());
+                    return;
+                }
                 try
                 {
                     await DispatcherShowMsgInteraction.Handle(sb.ToString());
+                    _lastDispatchFailTicks = 0;
                 }
                 catch
                 {
+                    _lastDispatchFailTicks = Environment.TickCount64;
                     _queueMsg.Enqueue(sb.ToString());
                 }
             }

--- a/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
+++ b/v2rayN/ServiceLib/ViewModels/ProfilesViewModel.cs
@@ -362,7 +362,8 @@ public partial class ProfilesViewModel : MyReactiveObject
     public async Task RefreshServersBiz()
     {
         var lstModel = await GetProfileItemsEx(_config.SubIndexId, _serverFilter);
-        _lstProfile = JsonUtils.Deserialize<List<ProfileItem>>(JsonUtils.Serialize(lstModel)) ?? [];
+        // MoveServer only consumes IndexId; avoid a full JSON deep copy of every profile on each refresh.
+        _lstProfile = lstModel?.Select(t => new ProfileItem { IndexId = t.IndexId }).ToList() ?? [];
 
         ProfileItems.ReplaceRange(lstModel ?? []);
         if (lstModel?.Count > 0)


### PR DESCRIPTION
## Problem

Three related sources of avoidable overhead observed on 7.24.9 (Windows x64 / Avalonia):

1. **Message-view exception storm.**
   `MsgViewModel.AppendQueueMsg` re-enqueues the whole batch and retries every 500 ms while `DispatcherShowMsgInteraction` has no registered handler (window hidden to tray, or view not yet activated). Every attempt throws `UnhandledInteractionException` and writes a full stack trace to the log file — guiLogs repeatedly show `Failed to find a registration for an Interaction` at startup (`MsgViewModel.cs` / `StatusBarViewModel.cs`), and the loop keeps running the whole time the window is hidden, burning CPU and churning memory exactly while the core is flapping.

2. **Core restart on every successful subscription update.**
   `MainWindowViewModel.UpdateTaskHandler` calls `Reload()` whenever the updated group contains the active node. With per-subscription auto-update intervals (e.g. 20–45 min) the core process is killed and cold-started on *every* update: all connections drop, in-flight delay tests report -1 ms, and each start re-parses ~26 MB of geoip/geosite data (short full-core CPU spike on every restart). Process monitoring confirms a fresh core PID after each successful scheduled update.

3. **Full JSON deep copy on every list refresh.**
   `ProfilesViewModel.RefreshServersBiz` round-trips the entire profile list through `JsonUtils.Serialize/Deserialize` on every refresh just to obtain `List<ProfileItem>` for `MoveServer`, which only consumes `IndexId`.

## Changes

- **fix(msg)**: 30 s backoff for the unhandled-interaction retry loop (`_lastDispatchFailTicks`); while backing off the batch is kept in the bounded queue instead of being re-dispatched, and `FlushQueueMsg` (view activation = handler registered) resets the flag so buffered lines flush immediately.
- **fix(main)**: snapshot the loaded node on every successful `Reload`; on subscription updates, reload only when the active `IndexId` changed or the active node's data actually changed / was removed. A provider rotating server IPs still triggers a reload exactly as before — only the no-op case is skipped.
- **perf(profiles)**: project `IndexId` (list is already sorted) instead of the JSON round-trip; ordering and `MoveServer` behavior are unchanged.

## Verification

- `dotnet build ServiceLib -c Release` clean (net10.0, 0 warnings / 0 errors).
- Patch 2 correlates with live monitoring: previously every successful scheduled update produced a new core PID; after the change a restart requires an actual node change (update/switch/removal).
- Patch 1 removes the `Failed to find a registration for an Interaction` spam while the window is hidden; GUI commit size stays flat over a 90-minute watch.
