### PR TITLE
fix: avoid Linux fontconfig crash on CJK text (#10112)

### DIFF
--- a/v2rayN/v2rayN.Desktop/Common/LinuxFontconfig.cs
+++ b/v2rayN/v2rayN.Desktop/Common/LinuxFontconfig.cs
@@ -1,5 +1,3 @@
-using System.Text;
-
 namespace v2rayN.Desktop.Common;
 
 /// <summary>
@@ -67,7 +65,8 @@ public static class LinuxFontconfig
             Directory.CreateDirectory(targetDir);
             var configFile = Path.Combine(targetDir, ConfigFileName);
 
-            if (!File.Exists(configFile))
+            if (!File.Exists(configFile)
+                || File.ReadAllText(configFile) != ConfigContent)
             {
                 File.WriteAllText(configFile, ConfigContent, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
             }

--- a/v2rayN/v2rayN.Desktop/Common/LinuxFontconfig.cs
+++ b/v2rayN/v2rayN.Desktop/Common/LinuxFontconfig.cs
@@ -1,0 +1,82 @@
+using System.Text;
+
+namespace v2rayN.Desktop.Common;
+
+/// <summary>
+/// Linux workaround for https://github.com/2dust/v2rayN/issues/10112
+///
+/// v2rayN deterministically crashes (SIGSEGV inside libfontconfig) on some Linux setups
+/// (Deepin 25 + fontconfig 2.17.1 reproduced; likely any distro rule set that routes CJK text
+/// through styled match/prepare paths such as synthetic oblique/embolden). The bundled
+/// "Noto Sans SC" default font covers most text, but glyph fallback for characters/emoji not
+/// present in the bundle still goes through the system fontconfig, where the crash occurs.
+///
+/// Experiment matrix on the reporter's machine (v2rayN 7.24.9, Deepin 25, fontconfig 2.17.1):
+///   system fontconfig (all distro rules) + CJK fonts     -> crash ~13-14 s after startup
+///   same font dirs, no rules                             -> stable
+///   minimal rules + Noto Sans CJK SC as default family   -> stable (>3 min, then hours)
+///
+/// This helper writes a minimal fontconfig profile (all standard font dirs, no distro rule
+/// files, CJK generic families pinned to Noto CJK which ships with real Bold/Italic faces so
+/// synthetic styles are not needed) and points FONTCONFIG_FILE at it. It only activates on
+/// Linux and only when the user did not already set FONTCONFIG_FILE.
+/// </summary>
+public static class LinuxFontconfig
+{
+    private const string ConfigFileName = "fonts.conf";
+
+    private const string ConfigContent = """
+        <?xml version="1.0"?>
+        <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+        <fontconfig>
+          <dir>/usr/share/fonts</dir>
+          <dir>/usr/local/share/fonts</dir>
+          <dir prefix="xdg">fonts</dir>
+          <cachedir>/var/cache/fontconfig</cachedir>
+          <cachedir prefix="xdg">fontconfig</cachedir>
+          <alias><family>sans-serif</family><prefer><family>Noto Sans CJK SC</family></prefer></alias>
+          <alias><family>system-ui</family><prefer><family>Noto Sans CJK SC</family></prefer></alias>
+          <alias><family>serif</family><prefer><family>Noto Serif CJK SC</family></prefer></alias>
+          <alias><family>monospace</family><prefer><family>Noto Sans Mono</family></prefer></alias>
+        </fontconfig>
+        """;
+
+    /// <summary>
+    /// Set FONTCONFIG_FILE to a safe, minimal fontconfig profile. Best effort: any failure is
+    /// swallowed so the app still starts with the system fontconfig.
+    /// Must run before Avalonia creates its FontManager (i.e. before BuildAvaloniaApp).
+    /// </summary>
+    public static void ApplyIfNeeded()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        // User/distro override wins.
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("FONTCONFIG_FILE")))
+        {
+            return;
+        }
+
+        try
+        {
+            var dataDir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "v2rayN");
+            var targetDir = Path.Combine(dataDir, "guiTemps");
+            Directory.CreateDirectory(targetDir);
+            var configFile = Path.Combine(targetDir, ConfigFileName);
+
+            if (!File.Exists(configFile))
+            {
+                File.WriteAllText(configFile, ConfigContent, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            }
+
+            Environment.SetEnvironmentVariable("FONTCONFIG_FILE", configFile);
+        }
+        catch
+        {
+            // Best effort only; fall back to the system fontconfig.
+        }
+    }
+}

--- a/v2rayN/v2rayN.Desktop/Program.cs
+++ b/v2rayN/v2rayN.Desktop/Program.cs
@@ -45,6 +45,12 @@ internal class Program
             }
         }
 
+        // https://github.com/2dust/v2rayN/issues/10112
+        // Linux: deterministic SIGSEGV when the system fontconfig (distro rule sets) is used
+        // to render CJK fallback text. Adopt a safe fontconfig profile before Avalonia starts,
+        // unless the user already exported FONTCONFIG_FILE.
+        LinuxFontconfig.ApplyIfNeeded();
+
         if (!AppManager.Instance.InitApp())
         {
             return false;


### PR DESCRIPTION
## 目的

修复 [#10112](https://github.com/2dust/v2rayN/issues/10112):Linux 下启动约 13–14 秒后确定性 SIGSEGV(崩溃位于 libfontconfig 内部,由 CJK 回退文本走系统 fontconfig 规则触发)。

## 改动

1. **`v2rayN.Desktop/Common/LinuxFontconfig.cs`(新增)**
   - 仅 Linux 生效;若用户已设置 `FONTCONFIG_FILE` 则完全跳过(尊重用户/发行版自定义)
   - 在 Avalonia 创建 FontManager **之前**(`Program.OnStartup` 中)将 `FONTCONFIG_FILE` 指向一份最小安全 fontconfig 配置:
     - 保留全部标准字体目录(`/usr/share/fonts`、`/usr/local/share/fonts`、XDG fonts)
     - **不含发行版规则文件**(如 90-synthetic.conf 等,实测与 CJK 文本组合即触发 fontconfig 崩溃)
     - 通用字体族绑定 Noto CJK(自带真 Bold/Italic,无需合成)
   - 配置写入 `<dataDir>/guiTemps/fonts.conf`(存在则不覆盖),任何异常静默回退系统 fontconfig
2. **`v2rayN.Desktop/Program.cs`**:在 `OnStartup()` 单实例检查后调用 `LinuxFontconfig.ApplyIfNeeded()`

## 验证(复现机:Deepin 25, fontconfig 2.17.1-5)

| 用例 | 结果 |
|---|---|
| 基线:系统 fontconfig + CJK 字体 | 每次 ~13–14 s 段错误(6+ 次复现,core dump 定位 libfontconfig) |
| 本 PR 产物配置端到端运行 | **95 s 存活 ✓**(另有跨夜 10 h 稳定记录) |
| 配置产物与代码常量 | 字节级一致(651B) |
| `fc-match`/`fc-list` 配置校验 | 别名命中 Noto CJK、558 字体可枚举 ✓ |
| 用户已设 `FONTCONFIG_FILE` | 跳过(代码守卫) |

## 说明

- 这是**防御性缓解**:崩溃点在 libfontconfig(fontconfig 2.17.1 与部分发行版规则集的内部缺陷),非 v2rayN 逻辑错误;上游 fontconfig 修复后此改动影响趋近于零
- 若维护者倾向更小侵入方案(例如仅当字体缺失/仅 Deepin 系发行版启用),可反馈调整