### PR TITLE
Fix subscription import error when using endpoints that can output only gzip

### DIFF
--- a/v2rayN/ServiceLib/Services/DownloadService.cs
+++ b/v2rayN/ServiceLib/Services/DownloadService.cs
@@ -236,6 +236,7 @@ public class DownloadService
             {
                 Proxy = webProxy,
                 UseProxy = webProxy != null,
+                AutomaticDecompression = DecompressionMethods.All,
                 ConnectTimeout = TimeSpan.FromSeconds(connectTimeout)
             };
             var certificateChainPolicy = CertPemManager.Instance.BuildCertificateChainPolicy();


### PR DESCRIPTION
Some subscription endpoints can output only gzip compressed data instead of plain base64 (like Durev VPN). And because of that received string cannot be imported as subscription.

Tested with "Durev VPN" subscriptions

before:
```
2026.09.07 05:20:30 Subscription update started
2026.09.07 05:20:30 durev->Started getting subscriptions
2026.09.07 05:20:32 durev->Got subscription content successfully
2026.09.07 05:20:32 durev->Start parsing and processing subscription content
2026.09.07 05:20:32 durev->Failed to import subscription content
2026.09.07 05:20:32 -------------------------------------------------------
2026.09.07 05:20:32 Subscription update ended
```
after:
```
2026.09.07 05:34:28 Subscription update started
2026.09.07 05:34:28 durev->Started getting subscriptions
2026.09.07 05:34:30 durev->Got subscription content successfully
2026.09.07 05:34:30 durev->Start parsing and processing subscription content
2026.09.07 05:34:30 durev->Subscription update ended
2026.09.07 05:34:30 -------------------------------------------------------
2026.09.07 05:34:30 Subscription update ended
```